### PR TITLE
fix: restore syntax highlighting text color in code blocks

### DIFF
--- a/assets/enhancements.css
+++ b/assets/enhancements.css
@@ -10,7 +10,6 @@ pre code {
   background: transparent !important;
   padding: 0 !important;
   border-radius: 0 !important;
-  color: inherit !important;
   font-size: inherit !important;
 }
 


### PR DESCRIPTION
Fixes #3 

The global `pre code` reset in `assets/enhancements.css` included `color: inherit !important`, which forced highlight.js's base text color to inherit the near-black body color. On the dark code-block background this made plain/untagged tokens (identifiers, keywords, and `#` lines in `language-http` blocks) invisible until manually selected. Colored tokens (strings/numbers/comments) were unaffected because their color lives on inner spans.

  Removing that one line lets the atom-one-dark theme's base color apply again, restoring readable code across all chapters. The remaining background/padding/border resets are kept.

Introduced in f9ac000.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed code blocks so their text displays with the correct color against dark backgrounds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->