### PR TITLE
Add dark mode theme assets to HTML notes

### DIFF
--- a/1.HTTP-AND-CORS/html_notes/notes.html
+++ b/1.HTTP-AND-CORS/html_notes/notes.html
@@ -789,7 +789,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 
 <body>

--- a/1.HTTP-AND-CORS/html_notes/notes.html
+++ b/1.HTTP-AND-CORS/html_notes/notes.html
@@ -787,7 +787,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 
 <body>

--- a/10.Task queues and background job/html_notes/notes.html
+++ b/10.Task queues and background job/html_notes/notes.html
@@ -441,7 +441,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/10.Task queues and background job/html_notes/notes.html
+++ b/10.Task queues and background job/html_notes/notes.html
@@ -443,7 +443,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/11.Full text search using Elasticsearch for blazingly fast search/html_notes/notes.html
+++ b/11.Full text search using Elasticsearch for blazingly fast search/html_notes/notes.html
@@ -311,7 +311,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/11.Full text search using Elasticsearch for blazingly fast search/html_notes/notes.html
+++ b/11.Full text search using Elasticsearch for blazingly fast search/html_notes/notes.html
@@ -309,7 +309,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/12. Error Handling and Building Fault Tolerant Systems/html_notes/notes.html
+++ b/12. Error Handling and Building Fault Tolerant Systems/html_notes/notes.html
@@ -159,7 +159,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/12. Error Handling and Building Fault Tolerant Systems/html_notes/notes.html
+++ b/12. Error Handling and Building Fault Tolerant Systems/html_notes/notes.html
@@ -157,7 +157,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/13.gRPC-and-Inter-Service-Communication-for-Microservices/html_notes/notes.html
+++ b/13.gRPC-and-Inter-Service-Communication-for-Microservices/html_notes/notes.html
@@ -787,7 +787,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 
 <body>

--- a/13.gRPC-and-Inter-Service-Communication-for-Microservices/html_notes/notes.html
+++ b/13.gRPC-and-Inter-Service-Communication-for-Microservices/html_notes/notes.html
@@ -785,7 +785,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 
 <body>

--- a/14.Production-grade Configuration Management/html_notes/notes.html
+++ b/14.Production-grade Configuration Management/html_notes/notes.html
@@ -423,7 +423,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/14.Production-grade Configuration Management/html_notes/notes.html
+++ b/14.Production-grade Configuration Management/html_notes/notes.html
@@ -425,7 +425,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/15.Logging, Monitoring and Observability/html_notes/notes.html
+++ b/15.Logging, Monitoring and Observability/html_notes/notes.html
@@ -446,7 +446,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/15.Logging, Monitoring and Observability/html_notes/notes.html
+++ b/15.Logging, Monitoring and Observability/html_notes/notes.html
@@ -444,7 +444,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/16.Graceful Shutdown/html_notes/notes.html
+++ b/16.Graceful Shutdown/html_notes/notes.html
@@ -423,7 +423,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/16.Graceful Shutdown/html_notes/notes.html
+++ b/16.Graceful Shutdown/html_notes/notes.html
@@ -425,7 +425,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/17.Backend Security - Everything You Need to Know/html_notes/notes.html
+++ b/17.Backend Security - Everything You Need to Know/html_notes/notes.html
@@ -536,7 +536,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 
 <body>

--- a/17.Backend Security - Everything You Need to Know/html_notes/notes.html
+++ b/17.Backend Security - Everything You Need to Know/html_notes/notes.html
@@ -534,7 +534,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 
 <body>

--- a/18. Backend Scaling and Performance Engineering-part-1/html_notes/notes.html
+++ b/18. Backend Scaling and Performance Engineering-part-1/html_notes/notes.html
@@ -422,7 +422,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/18. Backend Scaling and Performance Engineering-part-1/html_notes/notes.html
+++ b/18. Backend Scaling and Performance Engineering-part-1/html_notes/notes.html
@@ -424,7 +424,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/19.Backend Scaling and Performance Engineering - Part-2/html_notes/notes.html
+++ b/19.Backend Scaling and Performance Engineering - Part-2/html_notes/notes.html
@@ -127,7 +127,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/19.Backend Scaling and Performance Engineering - Part-2/html_notes/notes.html
+++ b/19.Backend Scaling and Performance Engineering - Part-2/html_notes/notes.html
@@ -125,7 +125,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/2.Routing-in-backend/html_notes/notes.html
+++ b/2.Routing-in-backend/html_notes/notes.html
@@ -156,7 +156,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/2.Routing-in-backend/html_notes/notes.html
+++ b/2.Routing-in-backend/html_notes/notes.html
@@ -158,7 +158,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/20.Concurrency & Parallelism - IO Bound vs CPU Bound/html_notes/notes.html
+++ b/20.Concurrency & Parallelism - IO Bound vs CPU Bound/html_notes/notes.html
@@ -356,7 +356,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/20.Concurrency & Parallelism - IO Bound vs CPU Bound/html_notes/notes.html
+++ b/20.Concurrency & Parallelism - IO Bound vs CPU Bound/html_notes/notes.html
@@ -354,7 +354,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/21.Containerization-and-Deployment-Docker-Kubernetes-and-CICD/html_notes/notes.html
+++ b/21.Containerization-and-Deployment-Docker-Kubernetes-and-CICD/html_notes/notes.html
@@ -786,7 +786,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 
 <body>

--- a/21.Containerization-and-Deployment-Docker-Kubernetes-and-CICD/html_notes/notes.html
+++ b/21.Containerization-and-Deployment-Docker-Kubernetes-and-CICD/html_notes/notes.html
@@ -788,7 +788,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 
 <body>

--- a/22.Automated-Testing-Unit-Integration-and-E2E/html_notes/notes.html
+++ b/22.Automated-Testing-Unit-Integration-and-E2E/html_notes/notes.html
@@ -787,7 +787,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 
 <body>

--- a/22.Automated-Testing-Unit-Integration-and-E2E/html_notes/notes.html
+++ b/22.Automated-Testing-Unit-Integration-and-E2E/html_notes/notes.html
@@ -785,7 +785,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 
 <body>

--- a/23.Message-Brokers-and-Event-Streaming-with-Kafka/html_notes/notes.html
+++ b/23.Message-Brokers-and-Event-Streaming-with-Kafka/html_notes/notes.html
@@ -787,7 +787,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 
 <body>

--- a/23.Message-Brokers-and-Event-Streaming-with-Kafka/html_notes/notes.html
+++ b/23.Message-Brokers-and-Event-Streaming-with-Kafka/html_notes/notes.html
@@ -785,7 +785,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 
 <body>

--- a/24.Web-Sockets-And-Real-time-Communication-with-WebSockets/html_notes/notes.html
+++ b/24.Web-Sockets-And-Real-time-Communication-with-WebSockets/html_notes/notes.html
@@ -787,7 +787,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 
 <body>

--- a/24.Web-Sockets-And-Real-time-Communication-with-WebSockets/html_notes/notes.html
+++ b/24.Web-Sockets-And-Real-time-Communication-with-WebSockets/html_notes/notes.html
@@ -785,7 +785,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 
 <body>

--- a/3.Serialization-and-Deserialization-or-backend-engineers/html_notes/notes.html
+++ b/3.Serialization-and-Deserialization-or-backend-engineers/html_notes/notes.html
@@ -137,7 +137,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/3.Serialization-and-Deserialization-or-backend-engineers/html_notes/notes.html
+++ b/3.Serialization-and-Deserialization-or-backend-engineers/html_notes/notes.html
@@ -135,7 +135,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/4.Authentication and authorization for backend engineers/html_notes/notes.html
+++ b/4.Authentication and authorization for backend engineers/html_notes/notes.html
@@ -149,7 +149,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/4.Authentication and authorization for backend engineers/html_notes/notes.html
+++ b/4.Authentication and authorization for backend engineers/html_notes/notes.html
@@ -151,7 +151,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/5. Validations and transformations for backend engineers/html_notes/notes.html
+++ b/5. Validations and transformations for backend engineers/html_notes/notes.html
@@ -124,7 +124,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/5. Validations and transformations for backend engineers/html_notes/notes.html
+++ b/5. Validations and transformations for backend engineers/html_notes/notes.html
@@ -126,7 +126,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/6.controllers-services-repositories-middlewares-and-request-context/html_notes/notes.html
+++ b/6.controllers-services-repositories-middlewares-and-request-context/html_notes/notes.html
@@ -155,7 +155,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/6.controllers-services-repositories-middlewares-and-request-context/html_notes/notes.html
+++ b/6.controllers-services-repositories-middlewares-and-request-context/html_notes/notes.html
@@ -153,7 +153,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/7.API-DESIGN-RestAPI/html_notes/notes.html
+++ b/7.API-DESIGN-RestAPI/html_notes/notes.html
@@ -238,7 +238,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/7.API-DESIGN-RestAPI/html_notes/notes.html
+++ b/7.API-DESIGN-RestAPI/html_notes/notes.html
@@ -236,7 +236,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/8.Database-with-backend/html_notes/notes.html
+++ b/8.Database-with-backend/html_notes/notes.html
@@ -139,7 +139,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/8.Database-with-backend/html_notes/notes.html
+++ b/8.Database-with-backend/html_notes/notes.html
@@ -141,7 +141,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/9.Caching, the secret behind it all/html_notes/notes.html
+++ b/9.Caching, the secret behind it all/html_notes/notes.html
@@ -423,7 +423,9 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/copy-button.css">
   <link rel="stylesheet" href="../../assets/enhancements.css">
   <link rel="stylesheet" href="../../assets/shell.css">
+  <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="../../assets/theme.js"></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/9.Caching, the secret behind it all/html_notes/notes.html
+++ b/9.Caching, the secret behind it all/html_notes/notes.html
@@ -425,7 +425,7 @@ body{padding-bottom:80px;}
   <link rel="stylesheet" href="../../assets/shell.css">
   <link rel="stylesheet" href="../../assets/theme.css">
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
-<script src="../../assets/theme.js"></script>
+<script src="../../assets/theme.js" defer></script>
 </head>
 <body>
 <button class="bfp-toc-toggle" id="bfpTocToggle" aria-controls="bfpToc" aria-expanded="false"><svg width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true"><line x1="2" y1="4" x2="14" y2="4"/><line x1="2" y1="8" x2="14" y2="8"/><line x1="2" y1="12" x2="14" y2="12"/></svg>Contents</button>

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -1,0 +1,328 @@
+/* Dark mode uses Underhood's warm charcoal / amber CRT palette.
+   The light theme remains the incumbent default; all changes below are
+   scoped to the explicit dark theme. */
+:root[data-theme='dark'] {
+  color-scheme: dark;
+  --paper: #17120e;
+  --paper-2: #1b1511;
+  --paper-3: #201914;
+  --node: #251d17;
+  --ink: #f2e8dc;
+  --ink-soft: #b8a898;
+  --ink-faint: #998570;
+  --accent: #f0a03c;
+  --accent-2: #ffc46b;
+  --green: #8fce87;
+  --danger: #ff7a6b;
+  --blue: #8fb9d0;
+  --gold: #ffc46b;
+  --line: #3d332b;
+  --line-strong: #51443a;
+  --code-bg: #100c09;
+  --code-bar: #1a1410;
+  --code-ink: #f2e8dc;
+  --code-faint: #a89781;
+  --shadow: 0 8px 24px rgba(24, 15, 8, .6);
+  --bfp-paper: #17120e;
+  --bfp-paper-2: #1b1511;
+  --bfp-paper-3: #201914;
+  --bfp-node: #251d17;
+  --bfp-ink: #f2e8dc;
+  --bfp-ink-soft: #b8a898;
+  --bfp-ink-faint: #998570;
+  --bfp-accent: #f0a03c;
+  --bfp-accent-2: #ffc46b;
+  --bfp-line: #3d332b;
+  --bfp-line-strong: #51443a;
+  --bfp-code-bg: #100c09;
+  --bfp-code-bar: #1a1410;
+  --bfp-code-line: #3d332b;
+  --bfp-code-ink: #f2e8dc;
+  --bfp-code-faint: #a89781;
+}
+
+:root[data-theme='dark'] body {
+  background: var(--paper);
+  background-image: radial-gradient(circle at 18% 12%, rgba(240, 160, 60, .045), transparent 45%), radial-gradient(circle at 82% 78%, rgba(143, 206, 135, .035), transparent 42%);
+}
+
+:root[data-theme='dark'] body::before {
+  opacity: .22;
+  mix-blend-mode: screen;
+}
+
+:root[data-theme='dark'] .chapter-card,
+:root[data-theme='dark'] .community-card,
+:root[data-theme='dark'] .stat,
+:root[data-theme='dark'] .tag {
+  background: var(--node);
+  border-color: var(--line);
+  color: var(--ink);
+}
+
+:root[data-theme='dark'] .chapter-card:hover,
+:root[data-theme='dark'] .search-trigger:hover {
+  background: #2b2119;
+  border-color: var(--accent);
+}
+
+:root[data-theme='dark'] .card-num,
+:root[data-theme='dark'] .progress-pill {
+  background: rgba(240, 160, 60, .12);
+}
+
+:root[data-theme='dark'] .progress-pill { color: var(--green); border-color: var(--green); }
+:root[data-theme='dark'] .btn-author { background: rgba(242, 232, 220, .06); color: var(--ink); border-color: var(--line-strong); }
+:root[data-theme='dark'] .btn-author:hover { background: rgba(242, 232, 220, .1); }
+:root[data-theme='dark'] .ch-done-btn { border-color: var(--line-strong); }
+:root[data-theme='dark'] .ch-done-btn:hover { border-color: var(--green); background: rgba(143, 206, 135, .1); }
+:root[data-theme='dark'] .ch-done-btn.done { border-color: var(--green); background: var(--green); }
+:root[data-theme='dark'] .search-trigger { background: var(--node); border-color: var(--line-strong); color: var(--ink-soft); }
+:root[data-theme='dark'] .search-modal { background: #201914; border-color: var(--line-strong); }
+:root[data-theme='dark'] .search-input-wrap { background: #1a1410; border-color: var(--line); }
+:root[data-theme='dark'] .search-result { color: var(--ink); }
+:root[data-theme='dark'] .search-result:hover,
+:root[data-theme='dark'] .search-result.active { background: rgba(240, 160, 60, .1); }
+:root[data-theme='dark'] .search-overlay { background: rgba(16, 12, 9, .72); }
+
+/* Shared chapter shell surfaces and controls. */
+:root[data-theme='dark'] .bfp-shell,
+:root[data-theme='dark'] .bfp-content { background: var(--bfp-paper); color: var(--bfp-ink); }
+:root[data-theme='dark'] .bfp-toc { background: linear-gradient(180deg, var(--bfp-paper-2), var(--bfp-paper)); border-color: var(--bfp-line); }
+:root[data-theme='dark'] .bfp-toc-link { color: var(--bfp-ink-soft); }
+:root[data-theme='dark'] .bfp-toc-link:hover { color: var(--bfp-ink); background: rgba(240, 160, 60, .1); }
+:root[data-theme='dark'] .bfp-toc-link.is-active { color: var(--bfp-accent); background: rgba(240, 160, 60, .08); }
+:root[data-theme='dark'] .bfp-toc-toggle { background: rgba(32, 25, 20, .94); color: var(--bfp-ink-soft); border-color: var(--bfp-line-strong); }
+:root[data-theme='dark'] .bfp-toc-scrim { background: rgba(16, 12, 9, .62); }
+:root[data-theme='dark'] .bfp-content a { color: var(--bfp-accent); }
+:root[data-theme='dark'] .chapter-nav {
+  background: #201914;
+  border-top-color: #3d332b;
+  box-shadow: 0 -8px 32px -16px rgba(20, 13, 7, .6);
+  color: #f2e8dc;
+}
+:root[data-theme='dark'] .chapter-nav .nav-chapter-link,
+:root[data-theme='dark'] .chapter-nav .nav-indicator { color: #b8a898; }
+:root[data-theme='dark'] .chapter-nav .nav-indicator {
+  background: #17120e;
+  border-color: #51443a;
+  color: #f2e8dc;
+}
+:root[data-theme='dark'] .chapter-nav .nav-indicator:hover {
+  background: #f0a03c;
+  border-color: #f0a03c;
+  color: #1a1208;
+}
+:root[data-theme='dark'] .chapter-nav .nav-arrow,
+:root[data-theme='dark'] .chapter-nav .nav-sep { color: #f0a03c; }
+:root[data-theme='dark'] .viz,
+:root[data-theme='dark'] figure {
+  background: linear-gradient(180deg, #201914, #17120e);
+  border-color: #3d332b;
+  color: #f2e8dc;
+}
+:root[data-theme='dark'] .viz-title { color: #f2e8dc; }
+:root[data-theme='dark'] .viz-note,
+:root[data-theme='dark'] figcaption { color: #b8a898; }
+:root[data-theme='dark'] .viz svg rect[fill='#e0e9dd'],
+:root[data-theme='dark'] .viz svg rect[fill='#dee5ee'],
+:root[data-theme='dark'] .viz svg rect[fill='#f0e5c9'],
+:root[data-theme='dark'] .viz svg rect[fill='#e6ddcc'],
+:root[data-theme='dark'] .viz svg rect[fill='#f6f0e6'],
+:root[data-theme='dark'] .viz svg rect[fill='#ece3d4'],
+:root[data-theme='dark'] .viz svg rect[fill='#f3ede2'] {
+  fill: #251d17;
+  stroke: #3d332b;
+}
+:root[data-theme='dark'] .viz svg rect[fill='#f7e9e2'] {
+  fill: #2c1a14;
+  stroke: #b8402e;
+}
+:root[data-theme='dark'] .viz svg rect[fill='#eccdc2'] {
+  fill: #2c1a14;
+  stroke: #b8402e;
+}
+:root[data-theme='dark'] .viz svg text[fill='#3f6f4e'] { fill: #8fce87; }
+:root[data-theme='dark'] .viz svg text[fill='#37607f'],
+:root[data-theme='dark'] .viz svg text[fill='#5b5347'],
+:root[data-theme='dark'] .viz svg text[fill='#211e1a'],
+:root[data-theme='dark'] .viz svg text[fill='#8d8475'],
+:root[data-theme='dark'] .viz svg text[fill='#7d756a'] { fill: #f2e8dc; }
+:root[data-theme='dark'] .viz svg text[fill='#8f2f20'] { fill: #ffc46b; }
+:root[data-theme='dark'] figure svg rect[fill^='rgba'] {
+  fill: #251d17;
+  stroke: #3d332b;
+}
+:root[data-theme='dark'] .fig-frame {
+  background: #201914 !important;
+  border-color: #3d332b;
+  box-shadow: none;
+}
+:root[data-theme='dark'] .diagram {
+  background: #201914 !important;
+  border-color: #3d332b;
+  box-shadow: none;
+}
+:root[data-theme='dark'] .flow,
+:root[data-theme='dark'] .fig-wrap,
+:root[data-theme='dark'] .diagram-wrap,
+:root[data-theme='dark'] .demo,
+:root[data-theme='dark'] .ref-box,
+:root[data-theme='dark'] .code-panel,
+:root[data-theme='dark'] .tbl-wrap,
+:root[data-theme='dark'] .table-wrap {
+  background: #201914 !important;
+  border-color: #3d332b;
+  color: #f2e8dc;
+}
+:root[data-theme='dark'] figure > div {
+  background: #201914 !important;
+  border-color: #3d332b;
+  color: #f2e8dc;
+}
+:root[data-theme='dark'] .flow .step .b,
+:root[data-theme='dark'] .section-num,
+:root[data-theme='dark'] .section-badge,
+:root[data-theme='dark'] .sec-num {
+  color: #f2e8dc;
+}
+:root[data-theme='dark'] .ec-logic,
+:root[data-theme='dark'] .ec-config,
+:root[data-theme='dark'] .s400 {
+  background: #2c1a14 !important;
+  color: #f2e8dc;
+  border-color: #b8402e;
+}
+:root[data-theme='dark'] .ec-db,
+:root[data-theme='dark'] .ec-input {
+  background: #1c2830 !important;
+  color: #f2e8dc;
+  border-color: #8fb9d0;
+}
+:root[data-theme='dark'] .ec-ext {
+  background: #1c2a20 !important;
+  color: #f2e8dc;
+  border-color: #8fce87;
+}
+:root[data-theme='dark'] .ec-db .ec-title,
+:root[data-theme='dark'] .ec-input .ec-title { color: #8fb9d0; }
+:root[data-theme='dark'] .ec-ext .ec-title { color: #8fce87; }
+:root[data-theme='dark'] .diagram-box,
+:root[data-theme='dark'] .compare-card {
+  background: #201914 !important;
+  border-color: #3d332b;
+  color: #f2e8dc;
+}
+:root[data-theme='dark'] .card-grid .card {
+  background: #251d17 !important;
+  border-color: #3d332b;
+  color: #f2e8dc;
+}
+:root[data-theme='dark'] .card-grid .card-title {
+  color: #f2e8dc;
+}
+:root[data-theme='dark'] figure svg rect[fill='#fff'],
+:root[data-theme='dark'] figure svg rect[fill='#f3ede2'],
+:root[data-theme='dark'] figure svg rect[fill='#e0e9dd'] {
+  fill: #251d17;
+  stroke: #3d332b;
+}
+:root[data-theme='dark'] figure svg rect[fill='#f7d9d1'],
+:root[data-theme='dark'] figure svg rect[fill='#f4ded6'] {
+  fill: #2c1a14;
+  stroke: #b8402e;
+}
+:root[data-theme='dark'] figure svg rect[fill='var(--ink)'] {
+  fill: #251d17;
+  stroke: #3d332b;
+}
+:root[data-theme='dark'] figure svg text[fill='#fff'] {
+  fill: #f2e8dc;
+}
+:root[data-theme='dark'] ol.steps > li::before {
+  background: #251d17;
+  color: #f2e8dc;
+  border: 1px solid #3d332b;
+}
+:root[data-theme='dark'] figure svg rect[stroke='#d8cfbe'] {
+  stroke: #51443a;
+}
+:root[data-theme='dark'] figure svg text[fill='#3f6f4e'] { fill: #8fce87; }
+:root[data-theme='dark'] figure svg text[fill='#37607f'],
+:root[data-theme='dark'] figure svg text[fill='#5b5347'],
+:root[data-theme='dark'] figure svg text[fill='#211e1a'],
+:root[data-theme='dark'] figure svg text[fill='#8d8475'],
+:root[data-theme='dark'] figure svg text[fill='#7d756a'] { fill: #f2e8dc; }
+:root[data-theme='dark'] figure svg text[fill='#7a4135'],
+:root[data-theme='dark'] figure svg text[fill='#9a8f78'],
+:root[data-theme='dark'] figure svg text[fill='#a06054'],
+:root[data-theme='dark'] figure svg text[fill='#d9a99c'] { fill: #b8a898; }
+:root[data-theme='dark'] figure svg text[fill='#8f2f20'] { fill: #ffc46b; }
+:root[data-theme='dark'] .tag,
+:root[data-theme='dark'] .meta span,
+:root[data-theme='dark'] .note,
+:root[data-theme='dark'] table,
+:root[data-theme='dark'] th,
+:root[data-theme='dark'] td,
+:root[data-theme='dark'] blockquote,
+:root[data-theme='dark'] .callout,
+:root[data-theme='dark'] .tip,
+:root[data-theme='dark'] .warning,
+:root[data-theme='dark'] .formula {
+  border-color: var(--line);
+}
+
+:root[data-theme='dark'] table,
+:root[data-theme='dark'] th,
+:root[data-theme='dark'] td,
+:root[data-theme='dark'] blockquote,
+:root[data-theme='dark'] .note,
+:root[data-theme='dark'] .callout,
+:root[data-theme='dark'] .tip,
+:root[data-theme='dark'] .warning,
+:root[data-theme='dark'] .formula,
+:root[data-theme='dark'] .meta span,
+:root[data-theme='dark'] .tag {
+  background: var(--paper-3);
+  color: var(--ink-soft);
+}
+:root[data-theme='dark'] tr:nth-child(even) td { background: var(--node); }
+:root[data-theme='dark'] h1,
+:root[data-theme='dark'] h2,
+:root[data-theme='dark'] h3,
+:root[data-theme='dark'] strong,
+:root[data-theme='dark'] .hero h1,
+:root[data-theme='dark'] .community-title { color: var(--ink); }
+:root[data-theme='dark'] .lede,
+:root[data-theme='dark'] .hero .lede,
+:root[data-theme='dark'] .community-desc,
+:root[data-theme='dark'] footer.doc { color: var(--ink-soft); }
+
+:root[data-theme='dark'] pre,
+:root[data-theme='dark'] .code-block,
+:root[data-theme='dark'] .code-body { background: var(--code-bg) !important; }
+:root[data-theme='dark'] .code-tabs,
+:root[data-theme='dark'] .code-head,
+:root[data-theme='dark'] .code-run-wrap { background: var(--code-bar) !important; }
+:root[data-theme='dark'] pre code,
+:root[data-theme='dark'] .code-body code { color: var(--code-ink) !important; }
+
+/* Theme control is injected into both the index and chapter pages. */
+.theme-toggle {
+  position: fixed;
+  top: 18px;
+  right: 20px;
+  z-index: 10001;
+  width: 38px;
+  height: 38px;
+  border: 1px solid var(--line, #d8cfbe);
+  border-radius: 8px;
+  background: var(--paper, #f3ede2);
+  color: var(--ink, #211e1a);
+  cursor: pointer;
+  font: 18px/1 'JetBrains Mono', monospace;
+  box-shadow: 0 6px 18px rgba(20, 13, 7, .18);
+}
+.theme-toggle:hover { color: var(--accent, #b8402e); border-color: var(--accent, #b8402e); }
+.theme-toggle:focus-visible { outline: 2px solid var(--accent, #b8402e); outline-offset: 3px; }
+@media (max-width: 600px) { .theme-toggle { top: 12px; right: 12px; } }

--- a/assets/theme.js
+++ b/assets/theme.js
@@ -1,0 +1,35 @@
+(function () {
+  'use strict';
+
+  var STORAGE_KEY = 'bfp-theme';
+  var stored = null;
+  try { stored = window.localStorage.getItem(STORAGE_KEY); } catch (_) { /* session-only */ }
+  var theme = stored === 'dark' || stored === 'light' ? stored : 'light';
+
+  function apply(next) {
+    theme = next === 'dark' ? 'dark' : 'light';
+    document.documentElement.dataset.theme = theme;
+    var meta = document.querySelector('meta[name="theme-color"]');
+    if (meta) meta.setAttribute('content', theme === 'dark' ? '#17120e' : '#f3ede2');
+    var button = document.querySelector('[data-theme-toggle]');
+    if (button) {
+      var nextTheme = theme === 'dark' ? 'light' : 'dark';
+      button.textContent = nextTheme === 'dark' ? '☾' : '☀';
+      button.setAttribute('aria-label', 'Switch to ' + nextTheme + ' theme');
+      button.title = 'Switch to ' + nextTheme + ' theme';
+    }
+    try { window.localStorage.setItem(STORAGE_KEY, theme); } catch (_) { /* session-only */ }
+  }
+
+  // Apply before the body paints to avoid a dark-mode flash.
+  document.documentElement.dataset.theme = theme;
+  document.addEventListener('DOMContentLoaded', function () {
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'theme-toggle';
+    button.dataset.themeToggle = 'true';
+    button.addEventListener('click', function () { apply(theme === 'dark' ? 'light' : 'dark'); });
+    document.body.appendChild(button);
+    apply(theme);
+  });
+}());

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,900;1,9..144,400;1,9..144,600&family=Spline+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="assets/enhancements.css">
+<link rel="stylesheet" href="assets/theme.css">
 <link rel="stylesheet" href="assets/copy-button.css">
 <style>
 :root{--paper:#f3ede2;--paper-2:#ece3d4;--paper-3:#e6dcca;--ink:#211e1a;--ink-soft:#5b5347;--ink-faint:#8d8475;--accent:#b8402e;--accent-2:#8f2f20;--green:#3f6f4e;--blue:#37607f;--gold:#b07d2b;--line:#d8cfbe;--line-strong:#c7bca6;--code-bg:#232019;--shadow:0 1px 0 rgba(0,0,0,.04),0 18px 40px -28px rgba(40,30,20,.5);}
@@ -61,6 +62,7 @@ footer.doc .big{font-family:"Fraunces",serif;font-style:italic;font-size:24px;co
 
 @media(max-width:600px){.chapter-card{padding:14px 16px;gap:14px;}.card-title{font-size:16px;}.card-num{width:36px;height:36px;font-size:12px;}.community-card{padding:20px 18px;}.community-title{font-size:20px;}.card-meta{display:none;}}
 </style>
+<script src="assets/theme.js"></script>
 </head>
 <body>
 <div class="container">

--- a/index.html
+++ b/index.html
@@ -62,7 +62,7 @@ footer.doc .big{font-family:"Fraunces",serif;font-style:italic;font-size:24px;co
 
 @media(max-width:600px){.chapter-card{padding:14px 16px;gap:14px;}.card-title{font-size:16px;}.card-num{width:36px;height:36px;font-size:12px;}.community-card{padding:20px 18px;}.community-title{font-size:20px;}.card-meta{display:none;}}
 </style>
-<script src="assets/theme.js"></script>
+<script src="assets/theme.js" defer></script>
 </head>
 <body>
 <div class="container">

--- a/tests/dark-mode.test.js
+++ b/tests/dark-mode.test.js
@@ -1,0 +1,62 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+const themeCss = fs.readFileSync(path.join(root, 'assets/theme.css'), 'utf8');
+const themeJs = fs.readFileSync(path.join(root, 'assets/theme.js'), 'utf8');
+const homepage = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
+const chapter = fs.readFileSync(path.join(root, '1.HTTP-AND-CORS/html_notes/notes.html'), 'utf8');
+const themeCssText = themeCss;
+const chapterPages = [
+  ...fs.readdirSync(root, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(root, entry.name, 'html_notes', 'notes.html'))
+    .filter((file) => fs.existsSync(file)),
+];
+
+for (const color of ['#17120e', '#1b1511', '#201914', '#251d17', '#f2e8dc', '#b8a898', '#3d332b', '#f0a03c', '#ffc46b', '#8fce87', '#ff7a6b']) {
+  assert.match(themeCss, new RegExp(color, 'i'), `Underhood color ${color} is missing`);
+}
+
+assert.match(themeCss, /:root\[data-theme=['"]dark['"]\]/);
+assert.doesNotMatch(themeCss, /:root\[data-theme=['"]light['"]\][^{]*\{/);
+assert.match(themeJs, /localStorage/);
+assert.match(themeJs, /data-theme/);
+assert.match(homepage, /assets\/theme\.css/);
+assert.match(homepage, /assets\/theme\.js/);
+assert.match(chapter, /assets\/theme\.css/);
+assert.match(chapter, /assets\/theme\.js/);
+assert.match(themeCssText, /:root\[data-theme=['"]dark['"]\] \.chapter-nav/);
+assert.match(themeCssText, /\.chapter-nav[\s\S]*background: #201914/);
+assert.match(themeCssText, /:root\[data-theme=['"]dark['"]\] \.chapter-nav \.nav-indicator/);
+assert.match(themeCssText, /\.nav-indicator[\s\S]*background: #17120e/);
+assert.match(themeCssText, /:root\[data-theme=['"]dark['"]\] \.viz/);
+assert.match(themeCssText, /\.viz[\s\S]*background: linear-gradient\(180deg, #201914, #17120e\)/);
+assert.match(themeCssText, /rect\[fill='#ece3d4'\]/);
+assert.match(themeCssText, /rect\[fill='#f7e9e2'\]/);
+assert.match(themeCssText, /rect\[fill='#eccdc2'\]/);
+assert.match(themeCssText, /text\[fill='#211e1a'\][\s\S]*fill: #f2e8dc/);
+assert.match(themeCssText, /figure svg text\[fill='#211e1a'\]/);
+assert.match(themeCssText, /figure svg rect\[fill\^='rgba'\]/);
+assert.match(themeCssText, /\.fig-frame[\s\S]*background: #201914 !important/);
+assert.match(themeCssText, /\.diagram[\s\S]*background: #201914 !important/);
+assert.match(themeCssText, /figure svg rect\[fill='#fff'\]/);
+assert.match(themeCssText, /figure svg rect\[fill='#f7d9d1'\]/);
+assert.match(themeCssText, /figure svg rect\[fill='var\(--ink\)'\]/);
+assert.match(themeCssText, /figure svg text\[fill='#fff'\]/);
+assert.match(themeCssText, /\.steps\s*>\s*li::before[\s\S]*background: #251d17/);
+assert.match(themeCssText, /\.flow[\s\S]*\.fig-wrap[\s\S]*\.diagram-wrap/);
+assert.match(themeCssText, /figure > div[\s\S]*background: #201914 !important/);
+assert.match(themeCssText, /\.ec-logic[\s\S]*background: #2c1a14 !important/);
+assert.match(themeCssText, /\.ec-db[\s\S]*background: #1c2830 !important/);
+assert.match(themeCssText, /\.ec-ext[\s\S]*background: #1c2a20 !important/);
+assert.match(themeCssText, /\.card-grid \.card[\s\S]*background: #251d17 !important/);
+assert.equal(chapterPages.length, 24, 'all 24 chapter pages should be present');
+for (const page of chapterPages) {
+  const html = fs.readFileSync(page, 'utf8');
+  assert.match(html, /assets\/theme\.css/, `${page} is missing dark-mode CSS`);
+  assert.match(html, /assets\/theme\.js/, `${page} is missing theme JavaScript`);
+}
+
+console.log('dark mode checks passed');

--- a/tests/dark-mode.test.js
+++ b/tests/dark-mode.test.js
@@ -20,7 +20,7 @@ for (const color of ['#17120e', '#1b1511', '#201914', '#251d17', '#f2e8dc', '#b8
 }
 
 assert.match(themeCss, /:root\[data-theme=['"]dark['"]\]/);
-assert.doesNotMatch(themeCss, /:root\[data-theme=['"]light['"]\][^{]*\{/);
+assert.doesNotMatch(themeCss, /:root\[data-theme=['"]light['"]\][\s\S]*?\{/);
 assert.match(themeJs, /localStorage/);
 assert.match(themeJs, /data-theme/);
 assert.match(homepage, /assets\/theme\.css/);
@@ -56,7 +56,7 @@ assert.equal(chapterPages.length, 24, 'all 24 chapter pages should be present');
 for (const page of chapterPages) {
   const html = fs.readFileSync(page, 'utf8');
   assert.match(html, /assets\/theme\.css/, `${page} is missing dark-mode CSS`);
-  assert.match(html, /assets\/theme\.js/, `${page} is missing theme JavaScript`);
+  assert.match(html, /assets\/theme\.js" defer/, `${page} is missing deferred theme JavaScript`);
 }
 
 console.log('dark mode checks passed');


### PR DESCRIPTION
Implemented a consistent dark mode across the documentation site.
- Added a dark-mode toggle with localStorage persistence.
- Applied the Underhood warm charcoal, cream, amber, green, blue, and rust palette.
- Updated diagrams, SVGs, cards, badges, tables, code blocks, navigation, and callouts for readability.
- Audited and wired dark mode across all 24 chapter pages and the homepage.
- Preserved the existing light mode unchanged.
- Added automated dark-mode regression checks.
Validation completed with:
node tests/dark-mode.test.js
node --check assets/theme.js
git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Added dark theme support across the main site and all 24 chapter pages.
* Added a theme toggle with saved preferences, accessible labels, and responsive styling.
* Updated cards, navigation, tables, diagrams, code blocks, callouts, and search elements for dark mode.
* Improved page loading by loading theme behavior after content parsing.

## Tests
* Added coverage validating theme assets, page integration, colors, and dark-mode styling across chapter pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->