### PR TITLE
fix: add chapter home link and fix dark-mode contrast on badges/callouts

### DIFF
--- a/assets/shell.css
+++ b/assets/shell.css
@@ -38,6 +38,23 @@
   background-clip: content-box;
 }
 
+.bfp-home-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--bfp-font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: var(--bfp-ink-faint);
+  text-decoration: none;
+  margin-bottom: 20px;
+  transition: color .15s ease;
+}
+.bfp-home-link:hover { color: var(--bfp-accent); }
+.bfp-home-link svg { flex: none; }
+
 .bfp-brand {
   font-family: var(--bfp-font-display);
   font-weight: 900;

--- a/assets/shell.js
+++ b/assets/shell.js
@@ -7,6 +7,13 @@
   var toc = document.querySelector('.bfp-toc');
   if (!toc) return;
 
+  /* ---------- home link ---------- */
+  var home = document.createElement('a');
+  home.className = 'bfp-home-link';
+  home.href = '../../index.html';
+  home.innerHTML = '<svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12.5" y1="8" x2="2.5" y2="8"/><polyline points="6.5,4 2.5,8 6.5,12"/></svg><span>Home</span>';
+  toc.insertBefore(home, toc.firstChild);
+
   var toggle = document.querySelector('.bfp-toc-toggle');
   var scrim = document.querySelector('.bfp-toc-scrim');
   var links = [].slice.call(document.querySelectorAll('.bfp-toc-link'));

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -192,34 +192,6 @@
   background: rgba(240, 160, 60, .12);
   color: var(--accent);
 }
-/* Callout boxes & eviction-policy badges (Caching, Config Mgmt, Graceful Shutdown) */
-:root[data-theme='dark'] .callout {
-  background: rgba(255, 122, 107, .12);
-  border-left-color: var(--danger);
-}
-:root[data-theme='dark'] .callout-label { color: var(--danger); }
-:root[data-theme='dark'] .callout-gold {
-  background: rgba(255, 196, 107, .12);
-  border-left-color: var(--gold);
-}
-:root[data-theme='dark'] .callout-gold .callout-label { color: var(--gold); }
-:root[data-theme='dark'] .callout-teal {
-  background: rgba(143, 206, 135, .12);
-  border-left-color: var(--green);
-}
-:root[data-theme='dark'] .callout-teal .callout-label { color: var(--green); }
-:root[data-theme='dark'] .badge-ttl {
-  background: rgba(255, 122, 107, .12);
-  color: var(--danger);
-}
-:root[data-theme='dark'] .badge-lfu {
-  background: rgba(255, 196, 107, .12);
-  color: var(--gold);
-}
-:root[data-theme='dark'] .badge-lru {
-  background: rgba(143, 206, 135, .12);
-  color: var(--green);
-}
 :root[data-theme='dark'] .ec-logic,
 :root[data-theme='dark'] .ec-config,
 :root[data-theme='dark'] .s400 {
@@ -319,6 +291,36 @@
 :root[data-theme='dark'] .tag {
   background: var(--paper-3);
   color: var(--ink-soft);
+}
+/* Callout boxes & eviction-policy badges (Caching, Config Mgmt, Graceful Shutdown).
+   Must come after the generic .callout rule above: same specificity, and this
+   one needs to win. */
+:root[data-theme='dark'] .callout {
+  background: rgba(255, 122, 107, .12);
+  border-left-color: var(--danger);
+}
+:root[data-theme='dark'] .callout-label { color: var(--danger); }
+:root[data-theme='dark'] .callout-gold {
+  background: rgba(255, 196, 107, .12);
+  border-left-color: var(--gold);
+}
+:root[data-theme='dark'] .callout-gold .callout-label { color: var(--gold); }
+:root[data-theme='dark'] .callout-teal {
+  background: rgba(143, 206, 135, .12);
+  border-left-color: var(--green);
+}
+:root[data-theme='dark'] .callout-teal .callout-label { color: var(--green); }
+:root[data-theme='dark'] .badge-ttl {
+  background: rgba(255, 122, 107, .12);
+  color: var(--danger);
+}
+:root[data-theme='dark'] .badge-lfu {
+  background: rgba(255, 196, 107, .12);
+  color: var(--gold);
+}
+:root[data-theme='dark'] .badge-lru {
+  background: rgba(143, 206, 135, .12);
+  color: var(--green);
 }
 :root[data-theme='dark'] tr:nth-child(even) td { background: var(--node); }
 :root[data-theme='dark'] h1,

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -182,11 +182,43 @@
   border-color: #3d332b;
   color: #f2e8dc;
 }
-:root[data-theme='dark'] .flow .step .b,
+:root[data-theme='dark'] .flow .step .b {
+  background: var(--paper);
+  color: var(--ink);
+}
 :root[data-theme='dark'] .section-num,
 :root[data-theme='dark'] .section-badge,
 :root[data-theme='dark'] .sec-num {
-  color: #f2e8dc;
+  background: rgba(240, 160, 60, .12);
+  color: var(--accent);
+}
+/* Callout boxes & eviction-policy badges (Caching, Config Mgmt, Graceful Shutdown) */
+:root[data-theme='dark'] .callout {
+  background: rgba(255, 122, 107, .12);
+  border-left-color: var(--danger);
+}
+:root[data-theme='dark'] .callout-label { color: var(--danger); }
+:root[data-theme='dark'] .callout-gold {
+  background: rgba(255, 196, 107, .12);
+  border-left-color: var(--gold);
+}
+:root[data-theme='dark'] .callout-gold .callout-label { color: var(--gold); }
+:root[data-theme='dark'] .callout-teal {
+  background: rgba(143, 206, 135, .12);
+  border-left-color: var(--green);
+}
+:root[data-theme='dark'] .callout-teal .callout-label { color: var(--green); }
+:root[data-theme='dark'] .badge-ttl {
+  background: rgba(255, 122, 107, .12);
+  color: var(--danger);
+}
+:root[data-theme='dark'] .badge-lfu {
+  background: rgba(255, 196, 107, .12);
+  color: var(--gold);
+}
+:root[data-theme='dark'] .badge-lru {
+  background: rgba(143, 206, 135, .12);
+  color: var(--green);
 }
 :root[data-theme='dark'] .ec-logic,
 :root[data-theme='dark'] .ec-config,


### PR DESCRIPTION
## Summary
- Add a "Home" link to the chapter sidebar (all 24 chapters) — previously there was no obvious way back to the index from a chapter page
- Fix dark-mode contrast: `.section-num`/`.section-badge`/`.sec-num` badges were rendering light text on an un-themed light background, making them nearly invisible (affects 17 chapters)
- Fix the same light-background leak on callout boxes and eviction-policy badges in the Caching, Configuration Management, and Graceful Shutdown chapters

## Note for maintainer
While reviewing themes, I noticed the site has three theme states (`default`/"Original", `dark`, `light`), and `light` (a stark white/blue palette) is currently set as the first-visit default in `theme.js`/`enhancements.js`, with a test enforcing it — even though the "Original" warm parchment theme is what the rest of the site's content is visually designed around. Wasn't sure if that's intentional, so left it untouched, but flagging in case it's worth a second look.

## Test plan
- [x] `node tests/dark-mode.test.js` passes
- [x] Verified Home link works on light/dark/Original themes
- [x] Verified badge/callout contrast fix in dark mode (Caching, Config Mgmt, Graceful Shutdown chapters)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Home link to the table of contents for easier navigation.

* **Style**
  * Improved dark-theme contrast for flow steps and section markers.
  * Refined callout and eviction-policy badge colors, borders, and labels.
  * Added hover styling, spacing, typography, and icon treatment for the Home link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->