### PR TITLE
Fix contribution CTA hover and show all contributors

### DIFF
--- a/assets/enhancements.css
+++ b/assets/enhancements.css
@@ -2319,7 +2319,7 @@ figure.highlight-pulse {
 
 /* Universal Link Hovers */
 a:hover {
-  color: var(--accent-hover) !important;
+  color: var(--accent-hover);
 }
 
 /* Dock Button Hovers */
@@ -2472,4 +2472,3 @@ a:hover {
 .bfp-toc-link.is-active .bfp-toc-num {
   color: var(--accent) !important;
 }
-

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -75,6 +75,7 @@
 
 :root[data-theme='dark'] .progress-pill { color: var(--green); border-color: var(--green); }
 :root[data-theme='dark'] .contributor-link { background: rgba(242, 232, 220, .06); color: var(--ink); border-color: var(--line-strong); }
+:root[data-theme='dark'] .contributor-link:hover { background: rgba(var(--accent-rgb), .1); color: var(--accent); border-color: var(--accent); }
 :root[data-theme='dark'] .ch-done-btn { border-color: var(--line-strong); }
 :root[data-theme='dark'] .ch-done-btn:hover { border-color: var(--green); background: rgba(143, 206, 135, .1); }
 :root[data-theme='dark'] .ch-done-btn.done { border-color: var(--green); background: var(--green); }

--- a/assets/theme.css
+++ b/assets/theme.css
@@ -74,8 +74,7 @@
 }
 
 :root[data-theme='dark'] .progress-pill { color: var(--green); border-color: var(--green); }
-:root[data-theme='dark'] .btn-author { background: rgba(242, 232, 220, .06); color: var(--ink); border-color: var(--line-strong); }
-:root[data-theme='dark'] .btn-author:hover { background: rgba(242, 232, 220, .1); }
+:root[data-theme='dark'] .contributor-link { background: rgba(242, 232, 220, .06); color: var(--ink); border-color: var(--line-strong); }
 :root[data-theme='dark'] .ch-done-btn { border-color: var(--line-strong); }
 :root[data-theme='dark'] .ch-done-btn:hover { border-color: var(--green); background: rgba(143, 206, 135, .1); }
 :root[data-theme='dark'] .ch-done-btn.done { border-color: var(--green); background: var(--green); }

--- a/index.html
+++ b/index.html
@@ -58,8 +58,10 @@ footer.doc .big{font-family:"Fraunces",serif;font-style:italic;font-size:24px;co
 .community-actions{display:flex;flex-wrap:wrap;align-items:center;gap:14px;margin-top:8px;}
 .btn-contribute{display:inline-flex;align-items:center;gap:8px;background:var(--accent);color:#fff;text-decoration:none;font-family:"JetBrains Mono",monospace;font-size:13px;font-weight:600;padding:11px 22px;border-radius:8px;transition:all .2s ease;box-shadow:0 4px 12px -4px var(--accent);}
 .btn-contribute:hover{background:var(--accent-2);transform:translateY(-1px);box-shadow:0 6px 16px -4px var(--accent-2);color:#fff;}
-.btn-author{display:inline-flex;align-items:center;gap:6px;background:rgba(0,0,0,.04);color:var(--ink);border:1px solid var(--line-strong);text-decoration:none;font-family:"JetBrains Mono",monospace;font-size:13px;font-weight:600;padding:11px 20px;border-radius:8px;transition:all .2s ease;}
-.btn-author:hover{background:rgba(0,0,0,.08);border-color:var(--accent);color:var(--accent);}
+.contributors{display:flex;flex-wrap:wrap;align-items:center;gap:8px;margin-top:4px;}
+.contributors-label{font-family:"JetBrains Mono",monospace;font-size:11px;font-weight:700;letter-spacing:.12em;text-transform:uppercase;color:var(--ink-soft);margin-right:4px;}
+.contributor-link{background:rgba(0,0,0,.04);color:var(--ink);border:1px solid var(--line-strong);text-decoration:none;font-family:"JetBrains Mono",monospace;font-size:12px;font-weight:600;padding:6px 10px;border-radius:999px;transition:all .2s ease;}
+.contributor-link:hover{background:rgba(var(--accent-rgb),.1);border-color:var(--accent);color:var(--accent);}
 
 @media(max-width:600px){.chapter-card{padding:14px 16px;gap:14px;}.card-title{font-size:16px;}.card-num{width:36px;height:36px;font-size:12px;}.community-card{padding:20px 18px;}.community-title{font-size:20px;}.card-meta{display:none;}}
 </style>
@@ -122,9 +124,17 @@ footer.doc .big{font-family:"Fraunces",serif;font-style:italic;font-size:24px;co
         <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
         Contribute on GitHub <svg class="ico-arrow" width="15" height="15" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="2.5" y1="8" x2="12.5" y2="8"/><polyline points="8.5,4 12.5,8 8.5,12"/></svg>
       </a>
-      <a class="btn-author" href="https://github.com/DsThakurRawat" target="_blank" rel="noopener noreferrer">
-        Curated with dedication by <b>@DsThakurRawat</b>
-      </a>
+    </div>
+    <div class="contributors" aria-label="Project contributors">
+      <span class="contributors-label">Contributors</span>
+      <a class="contributor-link" href="https://github.com/DsThakurRawat" target="_blank" rel="noopener noreferrer">@DsThakurRawat</a>
+      <a class="contributor-link" href="https://github.com/yogeshsingh63" target="_blank" rel="noopener noreferrer">@yogeshsingh63</a>
+      <a class="contributor-link" href="https://github.com/SaikrishnaReddy1919" target="_blank" rel="noopener noreferrer">@SaikrishnaReddy1919</a>
+      <a class="contributor-link" href="https://github.com/abhishek-bhatkar" target="_blank" rel="noopener noreferrer">@abhishek-bhatkar</a>
+      <a class="contributor-link" href="https://github.com/Prashantkmr389" target="_blank" rel="noopener noreferrer">@Prashantkmr389</a>
+      <a class="contributor-link" href="https://github.com/parthpatyl" target="_blank" rel="noopener noreferrer">@parthpatyl</a>
+      <a class="contributor-link" href="https://github.com/dhrumilbhut" target="_blank" rel="noopener noreferrer">@dhrumilbhut</a>
+      <a class="contributor-link" href="https://github.com/jainsparsh5" target="_blank" rel="noopener noreferrer">@jainsparsh5</a>
     </div>
   </div>
 

--- a/tests/homepage.test.js
+++ b/tests/homepage.test.js
@@ -1,0 +1,25 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+const homepage = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
+const enhancements = fs.readFileSync(path.join(root, 'assets/enhancements.css'), 'utf8');
+
+assert.match(homepage, /\.btn-contribute:hover\{[^}]*color:#fff;/);
+assert.doesNotMatch(enhancements, /a:hover\s*\{[^}]*color:[^;}]+!important/);
+
+for (const contributor of [
+  'DsThakurRawat',
+  'yogeshsingh63',
+  'SaikrishnaReddy1919',
+  'abhishek-bhatkar',
+  'Prashantkmr389',
+  'parthpatyl',
+  'dhrumilbhut',
+  'jainsparsh5',
+]) {
+  assert.match(homepage, new RegExp(`github\\.com/${contributor}`));
+}
+
+console.log('homepage checks passed');

--- a/tests/homepage.test.js
+++ b/tests/homepage.test.js
@@ -6,8 +6,8 @@ const root = path.resolve(__dirname, '..');
 const homepage = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
 const enhancements = fs.readFileSync(path.join(root, 'assets/enhancements.css'), 'utf8');
 
-assert.match(homepage, /\.btn-contribute:hover\{[^}]*color:#fff;/);
-assert.doesNotMatch(enhancements, /a:hover\s*\{[^}]*color:[^;}]+!important/);
+assert.match(homepage, /\.btn-contribute:hover\s*\{[^}]*color:\s*#fff\s*;[^}]*\}/);
+assert.doesNotMatch(enhancements, /a:hover\s*\{[^}]*color:\s*[^;}]+!important[^}]*\}/);
 
 for (const contributor of [
   'DsThakurRawat',
@@ -19,7 +19,7 @@ for (const contributor of [
   'dhrumilbhut',
   'jainsparsh5',
 ]) {
-  assert.match(homepage, new RegExp(`github\\.com/${contributor}`));
+  assert.match(homepage, new RegExp(`href="https://github\\.com/${contributor}"`));
 }
 
 console.log('homepage checks passed');


### PR DESCRIPTION
Fixes #9.

- Keeps the contribution CTA text and icons visible on hover.
- Replaces the single curator link with links to the maintainer and every merged-PR contributor.
- Adds a small regression check for both changes.

Tested with:

```sh
node tests/dark-mode.test.js
node tests/homepage.test.js
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Contributors section to the community card with links for eight contributors.
  * Improved contributor link styling, including accent-colored hover states in dark mode.

* **Style**
  * Updated link hover behavior so theme styling no longer overrides other hover colors unexpectedly.

* **Tests**
  * Added homepage checks covering contributor links and hover styling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->