### PR TITLE
Fix horizontal overflow on mobile screens

### DIFF
--- a/assets/shell.css
+++ b/assets/shell.css
@@ -16,6 +16,14 @@
   align-items: start;
 }
 
+/* Chapter-local styles predate the shared shell and do not all establish the
+   same box model. Keep the fixed bottom navigation inside the viewport even
+   when its own stylesheet applies horizontal padding. */
+.chapter-nav {
+  box-sizing: border-box;
+  max-width: 100vw;
+}
+
 /* ---------- Table of contents ---------- */
 .bfp-toc {
   position: sticky;
@@ -235,6 +243,57 @@
   .bfp-content { padding: 70px 18px 120px; }
   .bfp-brand { font-size: 20px; }
   .bfp-brand-lens { font-size: 17px; }
+
+  /* Inline code is normally kept on one line for readability. On narrow
+     screens, long header names, URLs, and commands can otherwise widen the
+     entire document and make the article appear shifted off-screen. */
+  .bfp-content code:not(pre code) {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .bfp-content :is(h1, h2, h3) {
+    overflow-wrap: anywhere;
+  }
+
+  /* Chapters use a mix of responsive and fixed-size diagrams. Constrain the
+     latter to the article column while retaining their viewBox proportions. */
+  .bfp-content svg {
+    max-width: 100%;
+    height: auto;
+    overflow: hidden;
+  }
+
+  /* Some older chapters do not wrap comparison tables in a scroll container.
+     Keep the table readable, but contain its scrolling within the article. */
+  .bfp-content table {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+  }
+
+  /* The URL-anatomy legend uses flex rows inside a multi-column grid. A
+     single column prevents the anonymous text items from setting a wider
+     min-content size than the phone viewport. */
+  .bfp-content .ulegend {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  /* Collapse chapter-specific comparison layouts before their cards reach
+     their min-content width. These classes recur across the older chapters. */
+  .bfp-content :is(.vuln-grid, .compare-grid, .usecase-grid, .error-cards) {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .bfp-content .defs .row,
+  .bfp-content .policy-list li {
+    flex-direction: column;
+  }
+
+  .bfp-content .defs .term {
+    flex-basis: auto;
+  }
 }
 
 @media print {


### PR DESCRIPTION
In the current version, some of the pages show overflow when text doesn't wrap.

<img width="948" height="985" alt="Screenshot from 2026-08-31 11-10-15" src="https://github.com/user-attachments/assets/45a97567-3796-4918-8767-4d25853c1e05" />

<img width="948" height="985" alt="Screenshot from 2026-08-31 11-09-16" src="https://github.com/user-attachments/assets/beca14d0-d17a-4b9b-b426-c912e1bc0b54" />

The current commit updates the css for mobile views to prevent this, mostly by wrapping the text and setting max width to 100%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile layout behavior to prevent horizontal overflow.
  * Kept bottom chapter navigation within the viewport.
  * Enabled long code snippets, headings, tables, and diagrams to wrap or scroll appropriately on narrow screens.
  * Adjusted multi-column content layouts to display cleanly in a single column on small devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->