### PR TITLE
Sidebar: collapse by default on desktop, push content when open

### DIFF
--- a/assets/shell.js
+++ b/assets/shell.js
@@ -21,6 +21,7 @@
   /* ---------- drawer ---------- */
   function setOpen(open) {
     toc.classList.toggle('is-open', open);
+    document.body.classList.toggle('bfp-toc-open', open);
     if (scrim) scrim.classList.toggle('is-open', open);
     if (toggle) toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
     document.body.style.overflow = open && window.matchMedia('(max-width: 1000px)').matches ? 'hidden' : '';
@@ -31,7 +32,13 @@
   document.addEventListener('keydown', function (e) {
     if (e.key === 'Escape' && toc.classList.contains('is-open')) setOpen(false);
   });
-  links.forEach(function (l) { l.addEventListener('click', function () { setOpen(false); }); });
+  /* On the mobile drawer, picking a link should close it. On desktop the
+     panel pushes the content rather than covering it, so leave it open. */
+  links.forEach(function (l) {
+    l.addEventListener('click', function () {
+      if (window.matchMedia('(max-width: 1000px)').matches) setOpen(false);
+    });
+  });
 
   /* ---------- scroll spy ---------- */
   var byId = {};


### PR DESCRIPTION
## What this changes

On desktop, the table of contents used to always take up a fixed 280px column. This PR makes it collapse by default and slide open (pushing the article over) when the "Contents" button is clicked, instead of always being visible.

- TOC panel is collapsed (0px) by default on desktop (≥1001px), expands to 280px on click
- Clicking the toggle pushes the article content over, rather than overlaying it
- Article is centered in the remaining space instead of sitting flush against the panel
- Clicking a chapter link auto-closes the panel only on mobile — stays open on desktop
- Mobile drawer behavior (overlay + dark backdrop) is completely unchanged

## Files changed

Only `assets/shell.css` and `assets/shell.js` — since every chapter page shares these, the change applies across all 24 chapters automatically.

## Testing

Verified locally across desktop (1440px, 1920px) and mobile (390px) viewports, both open and closed states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved navigation drawer behavior on larger screens.
  - Drawer links now close the drawer only on mobile-sized viewports.
  - Added state tracking to reflect when the navigation drawer is open.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->