### PR TITLE
feat: add language tabs to Go/Python code blocks

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,13 +4,14 @@ import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
 import { rehypeHeadingAnchors } from './src/plugins/rehype-heading-anchors.mjs';
 import { rehypeWrapTables } from './src/plugins/rehype-wrap-tables.mjs';
+import { rehypeCodeTabs } from './src/plugins/rehype-code-tabs.mjs';
 import { shikiCodeTitle } from './src/plugins/shiki-code-title.mjs';
 
 export default defineConfig({
   site: 'https://backend-from-first-principle.vercel.app',
   integrations: [mdx(), sitemap()],
   markdown: {
-    rehypePlugins: [rehypeHeadingAnchors, rehypeWrapTables],
+    rehypePlugins: [rehypeHeadingAnchors, rehypeWrapTables, rehypeCodeTabs],
     // Code blocks are highlighted at build time. Zero runtime cost, and it
     // replaces the hand-rolled highlighter that lived in enhancements.js.
     shikiConfig: {

--- a/src/content/chapters/04-authentication-and-authorization.mdx
+++ b/src/content/chapters/04-authentication-and-authorization.mdx
@@ -120,7 +120,7 @@ We still use sessions today, for exactly the same purpose: giving our servers so
 
 A session login first verifies credentials against a stored _hash_ (never plain text), then mints a random session ID and stores the user payload in Redis with a TTL.
 
-G&#x6F;_&#xNAN;_____
+Go
 
 ```go
 package main
@@ -182,7 +182,7 @@ func Login(w http.ResponseWriter, u User) error {
 }
 ```
 
-Pytho&#x6E;_&#xNAN;_____
+Python
 
 ```python
 import json, secrets
@@ -262,7 +262,7 @@ FIG 4, Pepper (secret) -> KDF with per-password salt + cost -> store salt, param
 
 #### Code: Argon2id with a pepper
 
-G&#x6F;_&#xNAN;_____
+Go
 
 ```go
 import (
@@ -313,7 +313,7 @@ func VerifyArgon(encoded, pw string) bool {
 }
 ```
 
-Pytho&#x6E;_&#xNAN;_____
+Python
 
 ```python
 import os, hmac, hashlib
@@ -401,7 +401,7 @@ For a medium-to-large system, don't agonise over hashing, salting, algorithms an
 
 #### Code: sign & verify a JWT
 
-G&#x6F;_&#xNAN;_____
+Go
 
 ```go
 package auth
@@ -441,7 +441,7 @@ func Verify(tokenStr string) (jwt.MapClaims, error) {
 }
 ```
 
-Pytho&#x6E;_&#xNAN;_____
+Python
 
 ```python
 import jwt   # PyJWT
@@ -502,7 +502,7 @@ FIG 6, Short access token for speed, rotating refresh token for control.
 
 #### Code: RS256 verify + refresh rotation
 
-G&#x6F;_&#xNAN;_____
+Go
 
 ```go
 // Verify with a PUBLIC key, pinning RS256 (blocks alg:none & key confusion)
@@ -538,7 +538,7 @@ func Refresh(rdb *redis.Client, presented string) (string, error) {
 }
 ```
 
-Pytho&#x6E;_&#xNAN;_____
+Python
 
 ```python
 # Verify with a PUBLIC key, pinning RS256 (blocks alg:none & key confusion)
@@ -599,7 +599,7 @@ Here the attacker _plants_ a session ID they already know, e.g. by feeding the v
 
 #### Code: double-submit CSRF + session regeneration
 
-G&#x6F;_&#xNAN;_____
+Go
 
 ```go
 // Double-submit: compare the CSRF cookie against the header.
@@ -629,7 +629,7 @@ func RegenerateSession(oldSID string, u User) (string, error) {
 }
 ```
 
-Pytho&#x6E;_&#xNAN;_____
+Python
 
 ```python
 import hmac
@@ -670,7 +670,7 @@ FIG 8, Stateful: the proof lives in the store; the cookie only points to it.
 
 #### Code: middleware that validates a session
 
-G&#x6F;_&#xNAN;_____
+Go
 
 ```go
 // RequireSession reads the sid cookie and looks it up in Redis.
@@ -695,7 +695,7 @@ func RequireSession(next http.HandlerFunc) http.HandlerFunc {
 }
 ```
 
-Pytho&#x6E;_&#xNAN;_____
+Python
 
 ```python
 from functools import wraps
@@ -734,7 +734,7 @@ FIG 9, Stateless: the proof travels inside the token; the server stores nothing.
 
 #### Code: Bearer-token middleware
 
-G&#x6F;_&#xNAN;_____
+Go
 
 ```go
 import "strings"
@@ -758,7 +758,7 @@ func RequireJWT(next http.HandlerFunc) http.HandlerFunc {
 }
 ```
 
-Pytho&#x6E;_&#xNAN;_____
+Python
 
 ```python
 def require_jwt(view):
@@ -817,7 +817,7 @@ Stateful/stateless auth assume a human trigger: a login form to type into, a tok
 
 #### Code: verifying an API key
 
-G&#x6F;_&#xNAN;_____
+Go
 
 ```go
 import (
@@ -850,7 +850,7 @@ func RequireAPIKey(lookup func(hash string) (*Client, bool)) func(http.HandlerFu
 }
 ```
 
-Pytho&#x6E;_&#xNAN;_____
+Python
 
 ```python
 import hashlib, hmac
@@ -944,7 +944,7 @@ The Authorization Code flow is the one to actually understand, because it's what
 
 The client sends the user to the authorization server with query parameters:
 
-HTTP / redirec&#x74;_&#xNAN;_____
+HTTP / redirect
 
 ```text
 GET /authorize?
@@ -961,7 +961,7 @@ After the user logs in and consents, the server redirects back: `https://notes.a
 
 #### Leg 2: the token exchange (back channel, server-to-server)
 
-HTTP / POST /toke&#x6E;_&#xNAN;_____
+HTTP / POST /token
 
 ```text
 POST /token
@@ -993,7 +993,7 @@ FIG 12, PKCE: the intercepted code can't be redeemed without the verifier, which
 
 #### Code: PKCE values + token exchange
 
-G&#x6F;_&#xNAN;_____
+Go
 
 ```go
 // Build the PKCE pair before redirecting the user.
@@ -1024,7 +1024,7 @@ func exchange(code, verifier string) (*TokenResp, error) {
 }
 ```
 
-Pytho&#x6E;_&#xNAN;_____
+Python
 
 ```python
 import base64, hashlib, secrets, requests
@@ -1116,7 +1116,7 @@ The runtime flow: a user signs up and the server assigns a role (user, admin, ..
 
 #### Code: RBAC middleware
 
-G&#x6F;_&#xNAN;_____
+Go
 
 ```go
 // RequireRole runs AFTER an auth middleware that set "user".
@@ -1142,7 +1142,7 @@ func RequireRole(roles ...string) func(http.HandlerFunc) http.HandlerFunc {
 //     RequireJWT(RequireRole("admin")(deadZoneHandler)))
 ```
 
-Pytho&#x6E;_&#xNAN;_____
+Python
 
 ```python
 # require_role runs AFTER an auth decorator that set g.user
@@ -1189,7 +1189,7 @@ Many real systems are hybrids: RBAC for coarse roles, ABAC policies for the cond
 
 #### Code: a tiny ABAC policy evaluator
 
-G&#x6F;_&#xNAN;_____
+Go
 
 ```go
 type Subject struct{ ID, Dept, Role string }
@@ -1213,7 +1213,7 @@ func CanEdit(s Subject, r Resource, hour int) bool {
 // }
 ```
 
-Pytho&#x6E;_&#xNAN;_____
+Python
 
 ```python
 from dataclasses import dataclass
@@ -1267,7 +1267,7 @@ Passwords are stored as a **hash** (never plain text): at signup the password is
 
 #### Code: generic message + equalized timing
 
-G&#x6F;_&#xNAN;_____
+Go
 
 ```go
 // dummyHash: a fixed, precomputed bcrypt hash, used to equalize timing.
@@ -1299,7 +1299,7 @@ func Authenticate(w http.ResponseWriter, email, pw string) {
 }
 ```
 
-Pytho&#x6E;_&#xNAN;_____
+Python
 
 ```python
 import time

--- a/src/layouts/Chapter.astro
+++ b/src/layouts/Chapter.astro
@@ -62,6 +62,76 @@ const num = String(order).padStart(2, '0');
       </nav>
     </main>
   </div>
+
+  <noscript>
+    <style>
+      /* Switching needs JS, so show every language stacked rather than
+         stranding the reader on one panel with dead buttons. */
+      .prose .codeblock .code-bar { display: none; }
+      .prose .codeblock .code-panel { display: block; }
+    </style>
+  </noscript>
+
+  <!-- Runs where it sits, after the article markup and before paint, for
+       the same reason as the theme bootstrap in Base.astro: applying a
+       remembered language later swaps every code block at once and shoves
+       the page around. See rehype-code-tabs.mjs for the markup. -->
+  <script is:inline>
+    (function () {
+      var KEY = 'bfp-code-lang';
+      var blocks = document.querySelectorAll('.codeblock');
+      if (!blocks.length) return;
+
+      function activate(block, lang) {
+        var tab = block.querySelector('.code-tab[data-lang="' + lang + '"]');
+        if (!tab) return; // this block has no such language; leave it alone
+        block.querySelectorAll('.code-tab').forEach(function (b) {
+          var on = b === tab;
+          b.classList.toggle('on', on);
+          b.setAttribute('aria-pressed', String(on));
+        });
+        block.querySelectorAll('.code-panel').forEach(function (p) {
+          var on = p.getAttribute('data-panel') === lang;
+          p.classList.toggle('on', on);
+          if (on) p.removeAttribute('hidden');
+          else p.setAttribute('hidden', '');
+        });
+      }
+
+      var stored = null;
+      try { stored = localStorage.getItem(KEY); } catch (e) { /* storage blocked */ }
+      if (stored) {
+        blocks.forEach(function (b) { activate(b, stored); });
+      }
+
+      blocks.forEach(function (block) {
+        block.querySelectorAll('.code-tab').forEach(function (tab) {
+          tab.addEventListener('click', function () {
+            var lang = tab.getAttribute('data-lang');
+            // Every block on the page resizes at once (Go and Python
+            // snippets rarely have the same line count), which shifts
+            // everything below the blocks above this one. Re-anchor on the
+            // clicked button so the block being read stays put.
+            var anchor = tab.getBoundingClientRect().top;
+            try { localStorage.setItem(KEY, lang); } catch (e) { /* storage blocked */ }
+            blocks.forEach(function (b) { activate(b, lang); });
+
+            var delta = tab.getBoundingClientRect().top - anchor;
+            if (delta) {
+              // The document sets scroll-behavior: smooth, which animates
+              // this correction — the block lurches, then glides back, and
+              // reads as jitter. Re-anchoring has to be instant.
+              var root = document.documentElement;
+              var previous = root.style.scrollBehavior;
+              root.style.scrollBehavior = 'auto';
+              window.scrollBy(0, delta);
+              root.style.scrollBehavior = previous;
+            }
+          });
+        });
+      });
+    })();
+  </script>
 </Base>
 
 <style>
@@ -245,4 +315,5 @@ const num = String(order).padStart(2, '0');
     if (e.key === 'ArrowLeft') go('prev');
     if (e.key === 'ArrowRight') go('next');
   });
+
 </script>

--- a/src/plugins/rehype-code-tabs.mjs
+++ b/src/plugins/rehype-code-tabs.mjs
@@ -1,0 +1,258 @@
+/**
+ * Groups a code block with the ones right after it into a language-tabbed
+ * block, but only when the content actually says they're alternatives: a
+ * short paragraph naming the languages ("Go Python" before the pair, or
+ * "Go" / "Python" before each one individually) is the pre-Astro content's
+ * way of marking two blocks as the same snippet in a different language.
+ * Adjacency alone is not enough to merge two blocks — plenty of chapters put
+ * a vulnerable example next to its fix, or a command next to its output,
+ * and those are sequential reading, not alternatives to toggle between.
+ *
+ * Shiki has already run by the time this executes, so every `<pre>` carries
+ * `data-lang` (see shiki-code-title.mjs).
+ */
+const LANG_LABELS = new Map([
+  ['go', 'Go'],
+  ['python', 'Python'],
+  ['sql', 'SQL'],
+]);
+
+// Sorted longest-first so "SQL" is tried before anything that could be a
+// prefix of a longer name (not currently an issue, but peeling depends on
+// checking longer candidates first).
+const DISPLAY_NAMES = [...LANG_LABELS.values()].sort((a, b) => b.length - a.length);
+const LANG_BY_DISPLAY_NAME = new Map([...LANG_LABELS].map(([lang, display]) => [display, lang]));
+const TRAILING_TITLE_LABEL_RE = new RegExp(`(?:\\s+(?:${DISPLAY_NAMES.join('|')}))+$`);
+
+export function rehypeCodeTabs() {
+  return (tree) => collapse(tree);
+}
+
+function collapse(node) {
+  if (!node.children) return;
+  node.children = collapseChildren(node.children);
+  for (const child of node.children) collapse(child);
+}
+
+function collapseChildren(children) {
+  const result = [];
+  let i = 0;
+
+  while (i < children.length) {
+    const node = children[i];
+    if (!isCodeBlock(node)) {
+      result.push(node);
+      i++;
+      continue;
+    }
+
+    // A block only becomes the start of a tab group if a label names its
+    // language: a paragraph right before it, right before a single caption
+    // line that sits between the label and the code ("GoPython" / "PATCH
+    // with ... guard" / go fence / python fence), or — chapter 6's style —
+    // baked into the fence's own `title="... Go Python"`. No label, no
+    // group: that's what keeps unrelated, merely-adjacent blocks (a fix
+    // after a vulnerable example, a command after its output) from being
+    // treated as language alternatives.
+    const lead = trailingLabelInfo(result);
+    const fromParagraph = lead?.words.has(getLang(node)) === true;
+    const titleLead = fromParagraph ? null : titleLabelInfo(node);
+    const leadWords = fromParagraph
+      ? lead.words
+      : titleLead?.words.has(getLang(node))
+        ? titleLead.words
+        : null;
+    if (!leadWords) {
+      result.push(node);
+      i++;
+      continue;
+    }
+
+    const group = [node];
+    const seenLangs = new Set([getLang(node)]);
+    let next = i + 1;
+
+    while (next < children.length) {
+      const k = skipWhitespace(children, next);
+      const betweenLabel = wordsOf(children[k]);
+      const afterLabel = betweenLabel ? skipWhitespace(children, k + 1) : k;
+      const candidate = children[afterLabel];
+      const lang = candidate && getLang(candidate);
+      const covered = lang && (leadWords.has(lang) || (betweenLabel && betweenLabel.has(lang)));
+
+      if (isCodeBlock(candidate) && !seenLangs.has(lang) && covered) {
+        group.push(candidate);
+        seenLangs.add(lang);
+        next = afterLabel + 1;
+      } else {
+        break;
+      }
+    }
+
+    if (group.length >= 2) {
+      if (fromParagraph) {
+        // Drop only the label paragraph itself — a real caption sitting
+        // between it and the code ("PATCH with ... guard") stays put.
+        result.splice(lead.labelIndex, 1);
+      } else if (titleLead.clean) {
+        node.properties['data-title'] = titleLead.clean;
+      } else {
+        delete node.properties['data-title'];
+      }
+      result.push(buildTabs(group));
+    } else {
+      result.push(node);
+    }
+    i = next;
+  }
+
+  return result;
+}
+
+// Plain toggle buttons, not ARIA `role="tab"`: the tab role promises the
+// arrow-key model from the ARIA tabs pattern, and announcing that without
+// implementing it is worse than leaving these as the buttons they are.
+// `aria-pressed` carries the selected state and Tab/Enter work for free.
+function buildTabs(group) {
+  const tabs = group.map((pre, idx) => ({
+    type: 'element',
+    tagName: 'button',
+    properties: {
+      type: 'button',
+      className: idx === 0 ? ['code-tab', 'on'] : ['code-tab'],
+      'data-lang': getLang(pre),
+      'aria-pressed': idx === 0 ? 'true' : 'false',
+    },
+    children: [{ type: 'text', value: langLabel(getLang(pre)) }],
+  }));
+
+  const panels = group.map((pre, idx) => ({
+    type: 'element',
+    tagName: 'div',
+    properties: {
+      className: idx === 0 ? ['code-panel', 'on'] : ['code-panel'],
+      'data-panel': getLang(pre),
+      hidden: idx === 0 ? undefined : true,
+    },
+    children: [pre],
+  }));
+
+  return {
+    type: 'element',
+    tagName: 'div',
+    properties: { className: ['codeblock'] },
+    children: [
+      {
+        type: 'element',
+        tagName: 'div',
+        properties: { className: ['code-bar'] },
+        children: tabs,
+      },
+      ...panels,
+    ],
+  };
+}
+
+function isWhitespaceText(node) {
+  return node?.type === 'text' && /^\s*$/.test(node.value);
+}
+
+function skipWhitespace(children, idx) {
+  while (idx < children.length && isWhitespaceText(children[idx])) idx++;
+  return idx;
+}
+
+// Looks back from the end of `result` for a label paragraph, tolerating one
+// plain caption paragraph sitting between the label and the code that
+// follows. Returns the label's languages and its index, so only the label
+// itself gets removed once a group forms — the caption, if any, stays.
+function trailingLabelInfo(result) {
+  const idx = skipWhitespaceBack(result, result.length - 1);
+  if (idx < 0) return null;
+
+  const direct = wordsOf(result[idx]);
+  if (direct) return { words: direct, labelIndex: idx };
+
+  if (result[idx].type === 'element' && result[idx].tagName === 'p') {
+    const labelIdx = skipWhitespaceBack(result, idx - 1);
+    const words = labelIdx >= 0 ? wordsOf(result[labelIdx]) : null;
+    if (words) return { words, labelIndex: labelIdx };
+  }
+
+  return null;
+}
+
+// A fence's own `title="create_book / handler Go Python"` can carry the
+// label instead of a separate paragraph. `clean` is the title with that
+// trailing tag removed, for once the tab bar makes it redundant.
+function titleLabelInfo(pre) {
+  const title = pre.properties?.['data-title'];
+  if (typeof title !== 'string') return null;
+  const m = title.match(TRAILING_TITLE_LABEL_RE);
+  if (!m) return null;
+  const words = peelDisplayNames(m[0].replace(/\s+/g, ''));
+  return words && { words, clean: title.slice(0, m.index).trimEnd() };
+}
+
+function skipWhitespaceBack(arr, idx) {
+  while (idx >= 0 && isWhitespaceText(arr[idx])) idx--;
+  return idx;
+}
+
+function isCodeBlock(node) {
+  if (node?.type !== 'element' || node.tagName !== 'pre') return false;
+  const cls = node.properties?.class;
+  const isAstroCode = typeof cls === 'string' ? cls.includes('astro-code') : Array.isArray(cls) && cls.includes('astro-code');
+  return isAstroCode && !!node.properties?.['data-lang'];
+}
+
+function getLang(pre) {
+  return pre.properties?.['data-lang'];
+}
+
+function langLabel(lang) {
+  return LANG_LABELS.get(lang) ?? (lang ? lang[0].toUpperCase() + lang.slice(1) : lang);
+}
+
+// A label names one or more languages by their display name, written with
+// or without spaces/case variation between them ("Go Python", "GoPython",
+// "SQLGoPython"), optionally led by a filename with no separator before the
+// name ("pipeline.goGo", "type_validation.goGo"). The whole paragraph must
+// resolve this way, so real captions ("PATCH with optimistic-concurrency
+// guard") never get mistaken for one.
+function wordsOf(node) {
+  if (node?.type !== 'element' || node.tagName !== 'p') return null;
+  const text = toText(node);
+  if (!text.trim() || text.length > 60) return null;
+
+  // Bullets/dots are sometimes used as separators instead of a plain
+  // space ("● Go● Python"); strip those too before trying a pure match.
+  const pure = peelDisplayNames(text.replace(/[\s●•·]+/g, ''));
+  if (pure) return pure;
+
+  const compact = text.replace(/\s+/g, '');
+  for (const name of DISPLAY_NAMES) {
+    if (!compact.endsWith(name)) continue;
+    const prefix = compact.slice(0, -name.length);
+    if (prefix && /^[\w./-]+$/.test(prefix)) return new Set([LANG_BY_DISPLAY_NAME.get(name)]);
+  }
+  return null;
+}
+
+function peelDisplayNames(text) {
+  let rest = text;
+  const langs = new Set();
+  while (rest.length) {
+    const name = DISPLAY_NAMES.find((n) => rest.startsWith(n));
+    if (!name) return null;
+    langs.add(LANG_BY_DISPLAY_NAME.get(name));
+    rest = rest.slice(name.length);
+  }
+  return langs.size ? langs : null;
+}
+
+function toText(node) {
+  if (node.type === 'text') return node.value;
+  if (!node.children) return '';
+  return node.children.map(toText).join('');
+}

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -276,6 +276,54 @@
   font-size: inherit;
 }
 
+/* --- language-tabbed code blocks -----------------------------------------
+   Emitted by rehype-code-tabs.mjs when a chapter gives the same snippet in
+   more than one language. Only the active .code-panel is shown; the pre
+   inside keeps all of the .astro-code styling above unchanged. */
+.prose .codeblock {
+  margin: var(--space-6) 0;
+  border-radius: var(--radius);
+  border: 1px solid var(--code-line);
+  overflow: hidden;
+}
+.prose .codeblock .code-bar {
+  display: flex;
+  background: var(--code-surface);
+  border-bottom: 1px solid var(--code-line);
+}
+.prose .codeblock .code-tab {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--code-ink-3);
+  padding: var(--space-3) var(--space-4);
+  cursor: pointer;
+  transition: color 120ms ease, border-color 120ms ease;
+}
+.prose .codeblock .code-tab:hover { color: var(--code-ink); }
+.prose .codeblock .code-tab.on {
+  color: var(--code-ink);
+  border-bottom-color: var(--accent);
+}
+.prose .codeblock .code-panel {
+  display: none;
+  /* Keep the browser from picking a scroll anchor inside a panel that is
+     about to be hidden; losing it mid-switch causes a jump of its own, on
+     top of the re-anchoring the tab handler already does. */
+  overflow-anchor: none;
+}
+.prose .codeblock .code-panel.on { display: block; }
+.prose .codeblock pre.astro-code {
+  margin: 0;
+  border: none;
+  border-radius: 0;
+}
+/* The tab button already names the language; skip the pre's own corner tag. */
+.prose .codeblock pre.astro-code::after { display: none; }
+
 /* Code scrollbars: visible enough to signal overflow, quiet enough to ignore. */
 .prose pre.astro-code::-webkit-scrollbar { height: 9px; }
 .prose pre.astro-code::-webkit-scrollbar-track { background: transparent; }


### PR DESCRIPTION
Chapters showed every language's snippet stacked with no way to pick one. A build-time plugin now groups blocks the content already marks as alternatives (several label styles across chapters) into a single tabbed block, leaving sequential blocks (fix after a vulnerable example, command after its output) untouched. Choice syncs across the page via localStorage, with a no-JS fallback and a scroll re-anchor fix so switching doesn't jump the page.

Also fixes corrupted Go/Python labels in the authentication chapter left over from an earlier migration.

Closes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added language tabs for grouped code examples, allowing readers to switch between implementations.
  - Preserves selected language choices across code blocks and page visits.
  - Added a no-JavaScript fallback that displays all code examples.

- **Bug Fixes**
  - Corrected programming-language labels across authentication and authorization documentation examples.

- **Style**
  - Added styling for code tabs, panels, and active states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->