### PR TITLE
fix(toc): auto-scroll sidebar to keep active heading in view

### DIFF
--- a/assets/shell.js
+++ b/assets/shell.js
@@ -54,22 +54,27 @@
   if (!targets.length) return;
 
   var current = null;
+  function scrollToCurrent() {
+    if (!current || toc.scrollHeight <= toc.clientHeight || toc.matches(':hover')) return;
+    var tocRect = toc.getBoundingClientRect();
+    var linkRect = current.getBoundingClientRect();
+    var buffer = 48;
+    if (linkRect.top < tocRect.top + buffer || linkRect.bottom > tocRect.bottom - buffer) {
+      var top = toc.scrollTop + (linkRect.top - tocRect.top) - (tocRect.height / 2 - linkRect.height / 2);
+      var prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+      toc.scrollTo({ top: Math.max(0, top), behavior: prefersReducedMotion ? 'auto' : 'smooth' });
+    }
+  }
+
   function activate(link) {
     if (link === current) return;
     if (current) current.classList.remove('is-active');
     if (link) link.classList.add('is-active');
     current = link;
-    if (link && toc.scrollHeight > toc.clientHeight && !toc.matches(':hover')) {
-      var tocRect = toc.getBoundingClientRect();
-      var linkRect = link.getBoundingClientRect();
-      var buffer = 48;
-      if (linkRect.top < tocRect.top + buffer || linkRect.bottom > tocRect.bottom - buffer) {
-        var top = toc.scrollTop + (linkRect.top - tocRect.top) - (tocRect.height / 2 - linkRect.height / 2);
-        var prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-        toc.scrollTo({ top: Math.max(0, top), behavior: prefersReducedMotion ? 'auto' : 'smooth' });
-      }
-    }
+    scrollToCurrent();
   }
+
+  toc.addEventListener('mouseleave', scrollToCurrent);
 
   function pick() {
     var line = window.scrollY + window.innerHeight * 0.22;

--- a/assets/shell.js
+++ b/assets/shell.js
@@ -59,10 +59,14 @@
     if (current) current.classList.remove('is-active');
     if (link) link.classList.add('is-active');
     current = link;
-    if (link && toc.scrollHeight > toc.clientHeight) {
-      var top = link.offsetTop - toc.clientHeight / 2;
-      if (Math.abs(toc.scrollTop - top) > toc.clientHeight / 3) {
-        toc.scrollTo({ top: Math.max(top, 0), behavior: 'smooth' });
+    if (link && toc.scrollHeight > toc.clientHeight && !toc.matches(':hover')) {
+      var tocRect = toc.getBoundingClientRect();
+      var linkRect = link.getBoundingClientRect();
+      var buffer = 48;
+      if (linkRect.top < tocRect.top + buffer || linkRect.bottom > tocRect.bottom - buffer) {
+        var top = toc.scrollTop + (linkRect.top - tocRect.top) - (tocRect.height / 2 - linkRect.height / 2);
+        var prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        toc.scrollTo({ top: Math.max(0, top), behavior: prefersReducedMotion ? 'auto' : 'smooth' });
       }
     }
   }

--- a/src/layouts/Chapter.astro
+++ b/src/layouts/Chapter.astro
@@ -276,6 +276,28 @@ const num = String(order).padStart(2, '0');
     const rail = document.querySelector<HTMLElement>('.rail-inner');
     let currentActive: string | null = null;
 
+    const scrollToActive = () => {
+      if (!rail || !currentActive || rail.scrollHeight <= rail.clientHeight || rail.matches(':hover')) return;
+      const activeLink = links.get(currentActive);
+      if (!activeLink) return;
+
+      const railRect = rail.getBoundingClientRect();
+      const linkRect = activeLink.getBoundingClientRect();
+      const buffer = 48;
+
+      if (linkRect.top < railRect.top + buffer || linkRect.bottom > railRect.bottom - buffer) {
+        const targetScrollTop =
+          rail.scrollTop +
+          (linkRect.top - railRect.top) -
+          (railRect.height / 2 - linkRect.height / 2);
+        const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        rail.scrollTo({
+          top: Math.max(0, targetScrollTop),
+          behavior: prefersReducedMotion ? 'auto' : 'smooth',
+        });
+      }
+    };
+
     const paint = () => {
       // The topmost visible heading wins; if none is on screen (mid-section
       // scroll) keep the last one we set rather than clearing the rail.
@@ -288,25 +310,12 @@ const num = String(order).padStart(2, '0');
         else a.removeAttribute('aria-current');
       });
 
-      const activeLink = links.get(active);
-      if (rail && activeLink && rail.scrollHeight > rail.clientHeight && !rail.matches(':hover')) {
-        const railRect = rail.getBoundingClientRect();
-        const linkRect = activeLink.getBoundingClientRect();
-        const buffer = 48;
-
-        if (linkRect.top < railRect.top + buffer || linkRect.bottom > railRect.bottom - buffer) {
-          const targetScrollTop =
-            rail.scrollTop +
-            (linkRect.top - railRect.top) -
-            (railRect.height / 2 - linkRect.height / 2);
-          const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-          rail.scrollTo({
-            top: Math.max(0, targetScrollTop),
-            behavior: prefersReducedMotion ? 'auto' : 'smooth',
-          });
-        }
-      }
+      scrollToActive();
     };
+
+    if (rail) {
+      rail.addEventListener('mouseleave', scrollToActive);
+    }
 
     const io = new IntersectionObserver(
       (entries) => {

--- a/src/layouts/Chapter.astro
+++ b/src/layouts/Chapter.astro
@@ -273,16 +273,39 @@ const num = String(order).padStart(2, '0');
   if (links.size) {
     const visible = new Set<string>();
     const order = [...links.keys()];
+    const rail = document.querySelector<HTMLElement>('.rail-inner');
+    let currentActive: string | null = null;
 
     const paint = () => {
       // The topmost visible heading wins; if none is on screen (mid-section
       // scroll) keep the last one we set rather than clearing the rail.
       const active = order.find((id) => visible.has(id));
-      if (!active) return;
+      if (!active || active === currentActive) return;
+      currentActive = active;
+
       links.forEach((a, id) => {
         if (id === active) a.setAttribute('aria-current', 'true');
         else a.removeAttribute('aria-current');
       });
+
+      const activeLink = links.get(active);
+      if (rail && activeLink && rail.scrollHeight > rail.clientHeight && !rail.matches(':hover')) {
+        const railRect = rail.getBoundingClientRect();
+        const linkRect = activeLink.getBoundingClientRect();
+        const buffer = 48;
+
+        if (linkRect.top < railRect.top + buffer || linkRect.bottom > railRect.bottom - buffer) {
+          const targetScrollTop =
+            rail.scrollTop +
+            (linkRect.top - railRect.top) -
+            (railRect.height / 2 - linkRect.height / 2);
+          const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+          rail.scrollTo({
+            top: Math.max(0, targetScrollTop),
+            behavior: prefersReducedMotion ? 'auto' : 'smooth',
+          });
+        }
+      }
     };
 
     const io = new IntersectionObserver(

--- a/tests/homepage.test.js
+++ b/tests/homepage.test.js
@@ -1,8 +1,8 @@
-const assert = require('node:assert/strict');
-const fs = require('node:fs');
-const path = require('node:path');
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
 
-const root = path.resolve(__dirname, '..');
+const root = path.resolve(import.meta.dirname, '..');
 const homepage = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
 const enhancements = fs.readFileSync(path.join(root, 'assets/enhancements.css'), 'utf8');
 

--- a/tests/homepage.test.js
+++ b/tests/homepage.test.js
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const root = path.resolve(import.meta.dirname, '..');
+const root = fileURLToPath(new URL('..', import.meta.url));
 const homepage = fs.readFileSync(path.join(root, 'index.html'), 'utf8');
 const enhancements = fs.readFileSync(path.join(root, 'assets/enhancements.css'), 'utf8');
 


### PR DESCRIPTION
 Previously, scrolling down long chapters highlighted the active heading                                                                           
    in the table of contents via aria-current, but the scrollable sidebar                                                                             
    rail (.rail-inner) did not scroll along. This left active topics hidden                                                                           
    below the sidebar fold.                                                                                                                           
                                                                                                                                                      
    - Smoothly scroll the sidebar rail when the active link nears the edges                                                                           
    - Add a 48px buffer to avoid jitter and thrashing between close headings                                                                          
    - Pause auto-scrolling when hovering over the rail to respect user interaction                                                                    
    - Honor `prefers-reduced-motion` for accessibility                                                                                                
    - Fix CommonJS require in homepage.test.js to restore green tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the table of contents so the active section stays visible and centered while scrolling.
  * Prevented automatic table-of-contents movement while it is hovered.
  * Added a retry when the pointer leaves the table of contents, ensuring deferred scrolling completes.
  * Added support for reduced-motion preferences to provide less animated scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->