### PR TITLE
feat: add client-side chapter progress tracking

### DIFF
--- a/src/layouts/Chapter.astro
+++ b/src/layouts/Chapter.astro
@@ -45,6 +45,11 @@ const num = String(order).padStart(2, '0');
         <slot />
       </article>
 
+      <label class="complete-toggle">
+        <input type="checkbox" data-complete-toggle data-chapter-id={chapter.id} />
+        <span>Mark this chapter complete</span>
+      </label>
+
       <nav class="chapter-nav" aria-label="Chapter navigation">
         {prev ? (
           <a class="nav-card is-prev" href={`/${prev.id}/`} rel="prev">
@@ -202,6 +207,25 @@ const num = String(order).padStart(2, '0');
     text-wrap: pretty;
   }
 
+  /* --- mark complete ----------------------------------------------------- */
+  .complete-toggle {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    margin-top: var(--space-8);
+    padding: var(--space-4) var(--space-5);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    background: var(--surface);
+    font-size: var(--text-sm);
+    font-weight: 600;
+    cursor: pointer;
+    transition: border-color 120ms ease, background-color 120ms ease;
+  }
+  .complete-toggle:hover { border-color: var(--line-2); }
+  .complete-toggle:has(input:checked) { border-color: var(--accent); background: var(--accent-bg); }
+  .complete-toggle input { width: 16px; height: 16px; accent-color: var(--accent); cursor: pointer; }
+
   /* --- prev / next ------------------------------------------------------ */
   .chapter-nav {
     display: grid;
@@ -299,6 +323,33 @@ const num = String(order).padStart(2, '0');
     links.forEach((_, id) => {
       const el = document.getElementById(id);
       if (el) io.observe(el);
+    });
+  }
+
+  // --- mark chapter complete --------------------------------------------
+  const PROGRESS_KEY = 'bfp-progress';
+  const readProgress = (): string[] => {
+    // A hand-edited or half-written value would otherwise throw on .includes
+    // below and take the keyboard nav down with it.
+    try {
+      const raw = JSON.parse(localStorage.getItem(PROGRESS_KEY) ?? '[]');
+      return Array.isArray(raw) ? raw : [];
+    } catch { return []; }
+  };
+  const writeProgress = (ids: string[]) => {
+    try { localStorage.setItem(PROGRESS_KEY, JSON.stringify(ids)); } catch { /* storage blocked */ }
+  };
+
+  const completeToggle = document.querySelector<HTMLInputElement>('[data-complete-toggle]');
+  if (completeToggle) {
+    const id = completeToggle.dataset.chapterId!;
+    completeToggle.checked = readProgress().includes(id);
+    completeToggle.addEventListener('change', () => {
+      const ids = readProgress();
+      const next = completeToggle.checked
+        ? [...ids.filter((x) => x !== id), id]
+        : ids.filter((x) => x !== id);
+      writeProgress(next);
     });
   }
 

--- a/src/layouts/Chapter.astro
+++ b/src/layouts/Chapter.astro
@@ -358,7 +358,8 @@ const num = String(order).padStart(2, '0');
     // another tab changes the same key.
     addEventListener('pageshow', sync);
     addEventListener('storage', (e) => {
-      if (e.key === PROGRESS_KEY) sync();
+      // e.key is null when another tab calls localStorage.clear().
+      if (e.key === PROGRESS_KEY || e.key === null) sync();
     });
   }
 

--- a/src/layouts/Chapter.astro
+++ b/src/layouts/Chapter.astro
@@ -343,13 +343,22 @@ const num = String(order).padStart(2, '0');
   const completeToggle = document.querySelector<HTMLInputElement>('[data-complete-toggle]');
   if (completeToggle) {
     const id = completeToggle.dataset.chapterId!;
-    completeToggle.checked = readProgress().includes(id);
+    const sync = () => { completeToggle.checked = readProgress().includes(id); };
+    sync();
+
     completeToggle.addEventListener('change', () => {
       const ids = readProgress();
       const next = completeToggle.checked
         ? [...ids.filter((x) => x !== id), id]
         : ids.filter((x) => x !== id);
       writeProgress(next);
+    });
+
+    // Re-sync on bfcache restore (this script won't re-run) and when
+    // another tab changes the same key.
+    addEventListener('pageshow', sync);
+    addEventListener('storage', (e) => {
+      if (e.key === PROGRESS_KEY) sync();
     });
   }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -396,6 +396,7 @@ const grouped = PARTS.map((p) => ({
   render();
   addEventListener('pageshow', render);
   addEventListener('storage', (e) => {
-    if (e.key === PROGRESS_KEY) render();
+    // e.key is null when another tab calls localStorage.clear().
+    if (e.key === PROGRESS_KEY || e.key === null) render();
   });
 </script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -352,35 +352,50 @@ const grouped = PARTS.map((p) => ({
 
 <script>
   const PROGRESS_KEY = 'bfp-progress';
-  let done = new Set<string>();
-  try {
-    const raw = JSON.parse(localStorage.getItem(PROGRESS_KEY) ?? '[]');
-    if (Array.isArray(raw)) done = new Set<string>(raw);
-  } catch { /* storage blocked or value corrupt */ }
+  const readProgress = (): Set<string> => {
+    try {
+      const raw = JSON.parse(localStorage.getItem(PROGRESS_KEY) ?? '[]');
+      return new Set<string>(Array.isArray(raw) ? raw : []);
+    } catch { return new Set(); }
+  };
 
-  // Every count is derived from the cards actually rendered, never from the
-  // size of the stored list: a renamed or retired chapter leaves a stale id
-  // behind, and a stale id must not show up as 25 / 24.
-  let doneCount = 0;
-  let cardCount = 0;
+  // Re-run on pageshow (bfcache restores the DOM without re-executing this
+  // script, so a completion made on another page and then reached via the
+  // back button would otherwise render stale) and on storage (another tab
+  // changing the same key).
+  const render = () => {
+    const done = readProgress();
 
-  document.querySelectorAll<HTMLElement>('.part').forEach((part) => {
-    const cards = part.querySelectorAll<HTMLAnchorElement>('[data-chapter-id]');
-    let completed = 0;
+    // Every count is derived from the cards actually rendered, never from
+    // the size of the stored list: a renamed or retired chapter leaves a
+    // stale id behind, and a stale id must not show up as 25 / 24.
+    let doneCount = 0;
+    let cardCount = 0;
 
-    cards.forEach((card) => {
-      const isDone = done.has(card.dataset.chapterId!);
-      card.classList.toggle('is-done', isDone);
-      if (isDone) completed += 1;
+    document.querySelectorAll<HTMLElement>('.part').forEach((part) => {
+      const cards = part.querySelectorAll<HTMLAnchorElement>('[data-chapter-id]');
+      let completed = 0;
+
+      cards.forEach((card) => {
+        const isDone = done.has(card.dataset.chapterId!);
+        card.classList.toggle('is-done', isDone);
+        if (isDone) completed += 1;
+      });
+
+      const label = part.querySelector<HTMLElement>('[data-part-progress]');
+      if (label) label.textContent = `${completed} / ${cards.length}`;
+
+      doneCount += completed;
+      cardCount += cards.length;
     });
 
-    const label = part.querySelector<HTMLElement>('[data-part-progress]');
-    if (label) label.textContent = `${completed} / ${cards.length}`;
+    const progressFact = document.querySelector<HTMLElement>('[data-progress-fact]');
+    if (progressFact) progressFact.textContent = `${doneCount} / ${cardCount}`;
+  };
 
-    doneCount += completed;
-    cardCount += cards.length;
+  render();
+  addEventListener('pageshow', render);
+  addEventListener('storage', (e) => {
+    if (e.key === PROGRESS_KEY) render();
   });
-
-  const progressFact = document.querySelector<HTMLElement>('[data-progress-fact]');
-  if (progressFact) progressFact.textContent = `${doneCount} / ${cardCount}`;
 </script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -49,6 +49,7 @@ const grouped = PARTS.map((p) => ({
         <div class="fact"><dt>Chapters</dt><dd>{chapters.length}</dd></div>
         <div class="fact"><dt>Languages</dt><dd>Go · Python</dd></div>
         <div class="fact"><dt>Format</dt><dd>Theory + code</dd></div>
+        <div class="fact"><dt>Progress</dt><dd data-progress-fact>0 / {chapters.length}</dd></div>
       </dl>
     </section>
 
@@ -61,18 +62,24 @@ const grouped = PARTS.map((p) => ({
             <p class="part-range">
               {String(part.from).padStart(2, '0')}–{String(part.to).padStart(2, '0')}
             </p>
+            <p class="part-progress" data-part-progress>0 / {part.chapters.length}</p>
           </header>
 
           <ul class="grid">
             {part.chapters.map((c) => (
               <li>
-                <a class="card" href={`/${c.id}/`}>
+                <a class="card" href={`/${c.id}/`} data-chapter-id={c.id}>
                   <span class="card-num">{String(c.data.order).padStart(2, '0')}</span>
                   <span class="card-body">
                     <span class="card-title">{c.data.navTitle ?? c.data.title}</span>
                     <span class="card-summary">{c.data.summary}</span>
                   </span>
-                  <span class="card-time">{c.data.readingTime}</span>
+                  <span class="card-foot">
+                    <span class="card-time">{c.data.readingTime}</span>
+                    <span class="card-check">
+                      <span aria-hidden="true">✓</span><span class="sr-only">Completed</span>
+                    </span>
+                  </span>
                 </a>
               </li>
             ))}
@@ -216,6 +223,14 @@ const grouped = PARTS.map((p) => ({
     font-size: var(--text-sm);
     color: var(--ink-3);
   }
+  .part-progress {
+    grid-row: 3;
+    grid-column: 2;
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--ink-3);
+    letter-spacing: var(--tracking-wide);
+  }
 
   .grid {
     display: grid;
@@ -244,6 +259,16 @@ const grouped = PARTS.map((p) => ({
     background: var(--accent-bg);
     transform: translateY(-2px);
   }
+  .card.is-done { border-color: var(--accent); }
+
+  .card-check {
+    display: none;
+    color: var(--accent);
+    font-size: var(--text-sm);
+    font-weight: 700;
+    line-height: 1;
+  }
+  .card.is-done .card-check { display: block; }
 
   .card-num {
     font-family: var(--font-mono);
@@ -265,8 +290,14 @@ const grouped = PARTS.map((p) => ({
     -webkit-box-orient: vertical;
     overflow: hidden;
   }
-  .card-time {
+  .card-foot {
     grid-column: 2;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+  }
+  .card-time {
     font-family: var(--font-mono);
     font-size: var(--text-2xs);
     letter-spacing: var(--tracking-wide);
@@ -315,5 +346,41 @@ const grouped = PARTS.map((p) => ({
   @media (max-width: 560px) {
     .part-head { grid-template-columns: 1fr; }
     .part-range { grid-row: auto; grid-column: 1; }
+    .part-progress { grid-row: auto; grid-column: 1; }
   }
 </style>
+
+<script>
+  const PROGRESS_KEY = 'bfp-progress';
+  let done = new Set<string>();
+  try {
+    const raw = JSON.parse(localStorage.getItem(PROGRESS_KEY) ?? '[]');
+    if (Array.isArray(raw)) done = new Set<string>(raw);
+  } catch { /* storage blocked or value corrupt */ }
+
+  // Every count is derived from the cards actually rendered, never from the
+  // size of the stored list: a renamed or retired chapter leaves a stale id
+  // behind, and a stale id must not show up as 25 / 24.
+  let doneCount = 0;
+  let cardCount = 0;
+
+  document.querySelectorAll<HTMLElement>('.part').forEach((part) => {
+    const cards = part.querySelectorAll<HTMLAnchorElement>('[data-chapter-id]');
+    let completed = 0;
+
+    cards.forEach((card) => {
+      const isDone = done.has(card.dataset.chapterId!);
+      card.classList.toggle('is-done', isDone);
+      if (isDone) completed += 1;
+    });
+
+    const label = part.querySelector<HTMLElement>('[data-part-progress]');
+    if (label) label.textContent = `${completed} / ${cards.length}`;
+
+    doneCount += completed;
+    cardCount += cards.length;
+  });
+
+  const progressFact = document.querySelector<HTMLElement>('[data-progress-fact]');
+  if (progressFact) progressFact.textContent = `${doneCount} / ${cardCount}`;
+</script>


### PR DESCRIPTION
- Adds a "Mark this chapter complete" checkbox to each chapter page
- Homepage reflects it: completed cards get a checkmark, each part shows an X / Y count, and the hero facts get an overall total
- State lives in localStorage (`bfp-progress`), keyed by chapter id — no backend changes needed
- Counts are always derived from the chapters actually rendered (not the stored list), so a renamed/retired chapter can never inflate the total

Closes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a checkbox to mark chapters as complete.
  - Chapter completion status is saved and restored automatically.
  - Added reading-progress indicators showing completed chapters by section and overall.
  - Completed chapters are visually distinguished in the chapter list.
  - Progress data is validated against currently available chapters.
  - Progress indicators stay synchronized when navigating back to the site or updating progress in another browser tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->