### PR TITLE
feat(ch2,ch3): add JavaScript sections

### DIFF
--- a/src/content/chapters/01-http-and-cors.mdx
+++ b/src/content/chapters/01-http-and-cors.mdx
@@ -1752,4 +1752,4 @@ The payoff of understanding the machinery is fast triage: map a symptom straight
 
 Grounded in MDN (developer.mozilla.org/en-US/docs/Web/HTTP) & RFC 9110 / Go 1.22+ / Python 3.11+ examples.
 
-Backend from First Principles / Chapter 01 / HTTP. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 01 / HTTP. Code targets Go 1.22+, Python 3.11+ and Node.js 20+.

--- a/src/content/chapters/02-routing-in-backend.mdx
+++ b/src/content/chapters/02-routing-in-backend.mdx
@@ -2,7 +2,7 @@
 order: 2
 title: "Routing, the where of every request."
 navTitle: "Routing in Backend"
-summary: "HTTP methods describe the what of a request, your intent. Routing describes the where : which resource on the server your intent is aimed at. This manual covers routing end to end, static and dynamic routes, path and query parameters, nesting, versioning, and catch-alls, with worked routers in Go and Python."
+summary: "HTTP methods describe the what of a request, your intent. Routing describes the where : which resource on the server your intent is aimed at. This manual covers routing end to end, static and dynamic routes, path and query parameters, nesting, versioning, and catch-alls, with worked routers in Go, Python and JavaScript."
 readingTime: "2-3 hours"
 keywords:
   - "routing"
@@ -409,11 +409,125 @@ if __name__ == "__main__":
     print(r.dispatch("GET", "/api/books?page=2").body) # books page 2
 ```
 
-<Callout type="info" title="Same architecture, two languages">
-Go reaches it through interfaces + embedding; Python through ABCs + class inheritance. Both are a private dispatch table keyed on **method + route**, an abstract **handler** contract, polymorphic dispatch, and a catch-all fallback, the whole routing model from this manual, in code.
+13
+
+## A Router in JavaScript
+
+The same architecture once more, this time with no `interface` keyword to lean on: the contract is a base class whose `handle()` throws until a subclass overrides it (abstraction + polymorphism), `extends` gives real inheritance, and a `#` field is private at runtime rather than by convention (encapsulation).
+
+```js title="Node 20+ router.js"
+// ABSTRACTION: JavaScript has no `interface` keyword, so the contract is a
+// base class whose handle() refuses to run. Anything that extends Handler
+// and overrides handle() IS-A Handler. The router depends only on that
+// contract, never on a concrete type.
+class Handler {
+  handle(req) {
+    throw new Error("handle() must be implemented");
+  }
+}
+
+class Request {
+  constructor(method, path, params = {}, query = {}) {
+    this.method = method;
+    this.path = path;
+    this.params = params; // extracted path params (:id)
+    this.query = query;   // query params (?page=2)
+  }
+}
+
+class Response {
+  constructor(status, body) {
+    this.status = status;
+    this.body = body;
+  }
+}
+
+// INHERITANCE: BaseHandler is a concrete parent holding shared behaviour
+// (logging). Subclasses inherit and reuse log().
+class BaseHandler extends Handler {
+  #name; // ENCAPSULATION: a # field is truly private, not a convention
+
+  constructor(name) {
+    super();
+    this.#name = name;
+  }
+
+  log(req) {
+    console.log(`[${this.#name}] ${req.method} ${req.path}`);
+  }
+}
+
+// POLYMORPHISM: each subclass OVERRIDES handle() differently, yet the
+// router calls them all identically, handler.handle(req).
+class GetUser extends BaseHandler {   // IS-A BaseHandler IS-A Handler
+  handle(req) {
+    this.log(req);                    // inherited from the parent
+    return new Response(200, `user id = ${req.params.id}`);
+  }
+}
+
+class ListBooks extends BaseHandler {
+  handle(req) {
+    this.log(req);
+    const page = req.query.page ?? "1"; // query param drives pagination
+    return new Response(200, `books page ${page}`);
+  }
+}
+
+// ENCAPSULATION: #routes is unreachable from outside the class, so the
+// table stays hidden. The public surface is register() and dispatch().
+class Router {
+  #routes = new Map(); // key = "METHOD /route"
+
+  register(method, pattern, handler) {
+    this.#routes.set(`${method} ${pattern}`, handler); // method + path = the key
+  }
+
+  dispatch(method, url) {
+    const { pathname, searchParams } = new URL(url, "http://localhost");
+    const query = Object.fromEntries(searchParams.entries()); // ?a=1&b=2 -> object
+
+    for (const [key, handler] of this.#routes) {
+      const [m, pattern] = key.split(" ");
+      const params = Router.#match(pattern, pathname);
+      if (m === method && params !== null) {
+        // polymorphic dispatch: the router never asks which class this is
+        return handler.handle(new Request(method, pathname, params, query));
+      }
+    }
+    return new Response(404, "route not found"); // catch-all fallback
+  }
+
+  // #match compares "/users/:id" against "/users/123", returning the params.
+  static #match(pattern, path) {
+    const p = pattern.replace(/^\/|\/$/g, "").split("/");
+    const q = path.replace(/^\/|\/$/g, "").split("/");
+    if (p.length !== q.length) return null;
+
+    const params = {};
+    for (const [i, seg] of p.entries()) {
+      if (seg.startsWith(":")) {   // dynamic segment
+        params[seg.slice(1)] = q[i]; // bind :id -> "123"
+      } else if (seg !== q[i]) {   // static segment must match exactly
+        return null;
+      }
+    }
+    return params;
+  }
+}
+
+const r = new Router();
+r.register("GET", "/api/users/:id", new GetUser("users"));
+r.register("GET", "/api/books",     new ListBooks("books"));
+
+console.log(r.dispatch("GET", "/api/users/123").body);    // user id = 123
+console.log(r.dispatch("GET", "/api/books?page=2").body); // books page 2
+```
+<Callout type="info" title="Same architecture, three languages">
+Go reaches it through interfaces + embedding; Python through ABCs + class inheritance; JavaScript through a base class whose method throws and `#private` fields. All three are a private dispatch table keyed on **method + route**, an abstract **handler** contract, polymorphic dispatch, and a catch-all fallback, the whole routing model from this manual, in code.
 </Callout>
 
-13
+14
 
 ## Routing Glossary
 

--- a/src/content/chapters/02-routing-in-backend.mdx
+++ b/src/content/chapters/02-routing-in-backend.mdx
@@ -557,4 +557,4 @@ Every routing term used above, in one place.
 A request bundles a **method** (the what) and a **route** (the where). The server joins them into a unique key, matches it against its table, static routes first, dynamic next, catch-all last, extracts any **path params** from the route and **query params** from the query string, then calls the matched **handler**. Version the route to evolve, deprecate to retire, and catch-all to fail gracefully.
 </Callout>
 
-Backend from First Principles / Chapter 02 / Routing. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 02 / Routing. Code targets Go 1.22+, Python 3.11+ and Node.js 20+.

--- a/src/content/chapters/03-serialization-and-deserialization.mdx
+++ b/src/content/chapters/03-serialization-and-deserialization.mdx
@@ -2,7 +2,7 @@
 order: 3
 title: "Serialization, the shared language of machines."
 navTitle: "Serialization & Deserialization"
-summary: "A JavaScript client and a Rust server have nothing in common at the level of data types. Serialization is how they talk anyway: both convert their native data to and from one agreed format for the trip across the network. This manual covers the whole idea, the language barrier, the common standard, text vs binary formats, JSON in depth, the OSI mental model, and the full client<->server round-trip, with worked code in Go and Python."
+summary: "A JavaScript client and a Rust server have nothing in common at the level of data types. Serialization is how they talk anyway: both convert their native data to and from one agreed format for the trip across the network. This manual covers the whole idea, the language barrier, the common standard, text vs binary formats, JSON in depth, the OSI mental model, and the full client<->server round-trip, with worked code in Go, Python and JavaScript."
 readingTime: "2-3 hours"
 keywords:
   - "serialization"
@@ -313,11 +313,94 @@ if __name__ == "__main__":
     print(data["name"], data["address"]["country"])  # Lin IN
 ```
 
-<Callout type="info" title="Same shape, two languages">
-Both define a **Serializer** contract (abstraction), implement it for JSON (polymorphism), share fields through a base model (inheritance / composition), and keep secrets out of the wire format (encapsulation). The verbs are universal: **serialize** = native -> JSON (Go `Marshal`, Python `dumps`); **deserialize** = JSON -> native (Go `Unmarshal`, Python `loads`).
+11
+
+## Serialization in JavaScript
+
+JavaScript uses the built-in `JSON` object: `JSON.stringify` = serialize, `JSON.parse` = deserialize. The same OOP architecture, with one twist worth noticing: a `#private` field is invisible to `JSON.stringify`, so the language itself keeps the secret off the wire, and `toJSON()` is the hook that decides which keys leave the object, JavaScript's answer to Go's struct tags.
+
+```js title="Node 20+ serialize.js"
+// ABSTRACTION: JavaScript has no interface keyword, so the contract is a base
+// class whose methods refuse to run. Callers depend only on this shape, so
+// JSON could be swapped for another format without touching them.
+class Serializer {
+  serialize(value) { throw new Error("serialize() must be implemented"); }    // native -> common
+  deserialize(data) { throw new Error("deserialize() must be implemented"); } // common -> native
+}
+
+// POLYMORPHISM: JsonSerializer implements the contract. Any other format
+// (YAML, Protobuf) can extend the same base and be swapped in unchanged.
+class JsonSerializer extends Serializer {
+  serialize(value) {
+    return JSON.stringify(value);  // SERIALIZE: object -> JSON text
+  }
+  deserialize(data) {
+    return JSON.parse(data);       // DESERIALIZE: JSON text -> object
+  }
+}
+
+// "INHERITANCE": BaseModel holds the shared fields; User extends it and
+// reuses them, the counterpart of Go's struct embedding.
+class BaseModel {
+  constructor(id = 0, createdAt = new Date()) {
+    this.id = id;
+    this.createdAt = createdAt;
+  }
+}
+
+class Address {
+  constructor(country, phone) {
+    this.country = country;
+    this.phone = phone; // nested object
+  }
+}
+
+// ENCAPSULATION: #password is private at RUNTIME, so it is both unreachable
+// from outside AND invisible to JSON.stringify, the secret never reaches the
+// wire. toJSON() is the hook stringify calls: it is JavaScript's answer to
+// Go's struct tags, deciding exactly which keys leave the object.
+class User extends BaseModel {
+  #password;
+
+  constructor({ id, name, active = true, address = null, password = "" }) {
+    super(id);
+    this.name = name;
+    this.active = active;
+    this.address = address;
+    this.#password = password;
+  }
+
+  toJSON() {
+    return {
+      id: this.id,
+      created_at: this.createdAt, // rename on the way out, like a json tag
+      name: this.name,
+      active: this.active,
+      address: this.address,
+    };
+  }
+}
+
+const codec = new JsonSerializer(); // program to the contract
+
+const user = new User({ id: 1, name: "Ada", address: new Address("India", 123456) });
+
+// SERIALIZE, native object into the common JSON format
+const payload = codec.serialize(user);
+console.log(payload);
+// {"id":1,"created_at":"...","name":"Ada","active":true,
+//  "address":{"country":"India","phone":123456}}
+
+// DESERIALIZE, JSON received over HTTP back into native data
+const incoming = '{"name":"Lin","address":{"country":"IN","phone":42}}';
+const data = codec.deserialize(incoming);
+console.log(data.name, data.address.country); // Lin IN
+```
+<Callout type="info" title="Same shape, three languages">
+All three define a **Serializer** contract (abstraction), implement it for JSON (polymorphism), share fields through a base model (inheritance / composition), and keep secrets out of the wire format (encapsulation). The verbs are universal: **serialize** = native -> JSON (Go `Marshal`, Python `dumps`, JavaScript `JSON.stringify`); **deserialize** = JSON -> native (Go `Unmarshal`, Python `loads`, JavaScript `JSON.parse`).
 </Callout>
 
-11
+12
 
 ## Glossary
 

--- a/src/content/chapters/03-serialization-and-deserialization.mdx
+++ b/src/content/chapters/03-serialization-and-deserialization.mdx
@@ -431,4 +431,4 @@ Every term from the source, in one place.
 Two machines with incompatible native data types agree on a **common format** (usually **JSON**). Each **serializes** its data into that format before sending and **deserializes** it back after receiving, so communication is **language- and domain-agnostic**. The network turns JSON into bits and back; at the **application layer** you only ever deal with the JSON.
 </Callout>
 
-Backend from First Principles / Chapter 03 / Serialization. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 03 / Serialization. Code targets Go 1.22+, Python 3.11+ and Node.js 20+.


### PR DESCRIPTION
Added js to Chapters 2 and 3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the backend routing chapter with JavaScript coverage, including routing, handler contracts, dynamic paths, query parsing, dispatch, and 404 handling.
  * Added a JavaScript serialization and deserialization section with practical examples using JSON APIs, object-oriented patterns, private fields, and custom serialization hooks.
  * Updated chapter summaries, comparison callouts, and supported runtime targets to include JavaScript and Node.js 20+ across the relevant backend chapters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->