### PR TITLE
Add Chapter 26: WebRTC & Real-Time Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The documentation is organized into the following topics:
 22. **Automated Testing** - Writing effective Unit, Integration, and End-to-End (E2E) tests.
 23. **Message Brokers and Event Streaming** - Using tools like Kafka for event-driven architectures.
 24. **WebSockets and Real-Time Communication** - Building real-time features using WebSockets.
+26. **WebRTC and Real-Time Media** - Peer-to-peer audio and video from first principles: NAT traversal with STUN/TURN/ICE, DTLS-SRTP, congestion control, and the SFU infrastructure behind it.
 
 ## Getting Started
 

--- a/src/content/chapters/26-webrtc-and-real-time-media.mdx
+++ b/src/content/chapters/26-webrtc-and-real-time-media.mdx
@@ -1,0 +1,2276 @@
+---
+order: 26
+title: "WebRTC & Real-Time Media"
+navTitle: "WebRTC & Real-Time Media"
+summary: "A first-principles derivation of the stack behind every video call, live-audio room and cloud-gaming stream. It starts from six numbers you can measure — the speed of light in glass, the size of a packet, the bitrate of raw video, the size of the IPv4 address space — and shows that WebRTC is what you are forced to build once you accept them. Then out into the infrastructure: signaling, TURN fleets, SFUs, simulcast, media-plane scaling, and the operational traps of running UDP in the cloud. Signaling, peer and media-server code in both Go and Python."
+readingTime: "5-6 hours"
+keywords:
+  - "webrtc"
+  - "ice"
+  - "stun"
+  - "turn"
+  - "sdp"
+  - "sfu"
+  - "rtp"
+  - "rtcp"
+  - "srtp"
+  - "dtls"
+  - "nat traversal"
+  - "signaling"
+  - "simulcast"
+  - "svc"
+  - "jitter buffer"
+  - "congestion control"
+  - "echo cancellation"
+  - "media server"
+  - "peer-to-peer"
+  - "video calling"
+---
+Part I / First Principles
+
+## The Problem WebRTC Solves
+
+The WebSockets chapter ended with a connection that can push a message the instant it exists. That solves chat, presence, cursors, tickers, anything made of _discrete events_. Now change the payload to a live camera feed and the whole design falls apart, because media is not events. Media is a **continuous stream with a deadline**: 50 audio packets and 30 video frames every second, each one useful only if it arrives before the moment it is meant to be played, and worthless afterwards.
+
+That deadline is what breaks TCP, and with it WebSockets, HTTP and every transport you have used so far. TCP guarantees that every byte arrives, in order. To keep that promise it retransmits anything lost and **holds back everything behind the gap** until the missing piece arrives, which is head-of-line blocking. For a JSON message that is exactly right; you want the message, and 200ms late is fine. For a video call it is exactly wrong: while TCP is busy re-fetching a packet from a frame that should have been shown a quarter of a second ago, the frames behind it pile up in a buffer, and the call visibly freezes and then lurches. The right behaviour for a late video packet is not to fetch it again, it is to **give up on it and move on**.
+
+That single inversion — _completeness is no longer the goal_ — invalidates the entire toolkit from the previous twenty-four chapters, and everything in this one follows from working out what replaces it.
+
+<Callout type="info" title="How this chapter is built">
+Most WebRTC material hands you a stack of acronyms and explains each one. This chapter does the opposite. Section 2 puts six measurable numbers on the table. Section 3 then derives the whole protocol stack from them, one forced move at a time, and arrives at exactly WebRTC — because almost nothing in WebRTC was a choice. Everything after that is detail on a shape you will already have reasoned your way to.
+</Callout>
+
+## The Numbers That Decide Everything
+
+You cannot reason from first principles without knowing what the principles _are_. For real-time media there are six, they are all measurable, none of them is a matter of opinion, and every architectural decision in the rest of this chapter is traceable to one of them. Read this section slowly; it is the foundation the other thirty-six sit on.
+
+<Diagram caption="The six constraints, and what each one forces">
+<svg viewBox="0 0 720 330" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Six measurable constraints, each with the design consequence it forces: light speed forces regional placement, human turn-taking forces a 150 millisecond budget, MTU forces 1200-byte packets, raw video bitrate forces temporal compression, temporal compression forces loss intolerance, and IPv4 exhaustion forces NAT traversal">
+  <rect x="16" y="14" width="330" height="46" rx="9" fill="var(--dg-info-surface)" stroke="var(--dg-info-border)" />
+  <text x="30" y="34" font-size="11" font-weight="700" fill="var(--dg-info)">1 / Light in glass: 200,000 km/s</text>
+  <text x="30" y="50" class="mono" font-size="8.5" fill="var(--dg-ink-2)">Sydney to London is 85ms one way, minimum</text>
+
+  <rect x="374" y="14" width="330" height="46" rx="9" fill="var(--dg-info-surface)" stroke="var(--dg-info-border)" />
+  <text x="388" y="34" font-size="11" font-weight="700" fill="var(--dg-info)">2 / Conversational gap: ~200ms</text>
+  <text x="388" y="50" class="mono" font-size="8.5" fill="var(--dg-ink-2)">so the whole budget is 150ms mouth to ear</text>
+
+  <rect x="16" y="70" width="330" height="46" rx="9" fill="var(--dg-warn-surface)" stroke="var(--dg-warn-border)" />
+  <text x="30" y="90" font-size="11" font-weight="700" fill="var(--dg-warn)">3 / Path MTU: 1500 bytes</text>
+  <text x="30" y="106" class="mono" font-size="8.5" fill="var(--dg-ink-2)">so a media packet is ~1200 bytes, never fragmented</text>
+
+  <rect x="374" y="70" width="330" height="46" rx="9" fill="var(--dg-warn-surface)" stroke="var(--dg-warn-border)" />
+  <text x="388" y="90" font-size="11" font-weight="700" fill="var(--dg-warn)">4 / Raw 720p30: 332 Mbps</text>
+  <text x="388" y="106" class="mono" font-size="8.5" fill="var(--dg-ink-2)">target 1.5 Mbps, so compression must be ~200:1</text>
+
+  <rect x="16" y="126" width="330" height="46" rx="9" fill="var(--dg-accent-surface)" stroke="var(--dg-accent-border)" />
+  <text x="30" y="146" font-size="11" font-weight="700" fill="var(--dg-accent)">5 / 200:1 needs temporal prediction</text>
+  <text x="30" y="162" class="mono" font-size="8.5" fill="var(--dg-ink-2)">so one lost packet corrupts every later frame</text>
+
+  <rect x="374" y="126" width="330" height="46" rx="9" fill="var(--dg-accent-surface)" stroke="var(--dg-accent-border)" />
+  <text x="388" y="146" font-size="11" font-weight="700" fill="var(--dg-accent)">6 / IPv4: 4.3bn addresses, 20bn devices</text>
+  <text x="388" y="162" class="mono" font-size="8.5" fill="var(--dg-ink-2)">so almost nobody has a reachable address</text>
+
+  <path fill="none" d="M360 178 V196" stroke="var(--dg-line-2)" stroke-width="1.4" />
+  <path fill="none" d="M180 178 V196" stroke="var(--dg-line-2)" stroke-width="1.4" />
+  <path fill="none" d="M540 178 V196" stroke="var(--dg-line-2)" stroke-width="1.4" />
+  <path fill="none" d="M180 196 H540" stroke="var(--dg-line-2)" stroke-width="1.4" />
+  <defs><marker id="n6" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0 0 L7 3 L0 6 Z" fill="var(--dg-line-2)" /></marker></defs>
+  <path fill="none" d="M360 196 V216" stroke="var(--dg-line-2)" stroke-width="1.4" marker-end="url(#n6)" />
+
+  <rect x="16" y="220" width="688" height="94" rx="10" fill="var(--dg-inverse)" />
+  <text x="360" y="244" font-size="12" font-weight="700" fill="var(--dg-on-inverse)" text-anchor="middle">Everything downstream is a consequence, not a choice</text>
+  <text x="130" y="270" class="mono" font-size="9" fill="var(--dg-on-inverse-info)" text-anchor="middle">1 + 2 forces</text>
+  <text x="130" y="286" font-size="10" fill="var(--dg-on-inverse)" text-anchor="middle">regional servers,</text>
+  <text x="130" y="300" font-size="10" fill="var(--dg-on-inverse)" text-anchor="middle">tight buffers</text>
+  <text x="360" y="270" class="mono" font-size="9" fill="var(--dg-on-inverse-warn)" text-anchor="middle">3 + 4 + 5 forces</text>
+  <text x="360" y="286" font-size="10" fill="var(--dg-on-inverse)" text-anchor="middle">RTP, NACK, PLI, FEC,</text>
+  <text x="360" y="300" font-size="10" fill="var(--dg-on-inverse)" text-anchor="middle">simulcast, congestion control</text>
+  <text x="592" y="270" class="mono" font-size="9" fill="var(--dg-on-inverse-accent)" text-anchor="middle">6 forces</text>
+  <text x="592" y="286" font-size="10" fill="var(--dg-on-inverse)" text-anchor="middle">STUN, TURN, ICE,</text>
+  <text x="592" y="300" font-size="10" fill="var(--dg-on-inverse)" text-anchor="middle">signaling, hole punching</text>
+</svg>
+</Diagram>
+
+#### One: light is slow, and the map is not the territory
+
+Light in a vacuum covers 300,000 km/s. In optical fibre the refractive index is about 1.5, so signals travel at roughly **200,000 km/s**, or **5ms per 1000 km**. Cable does not run in straight lines either — it follows coasts, existing rights of way and landing stations — so the fibre distance is typically 1.5 to 2 times the great-circle distance.
+
+That gives you a floor that no amount of engineering removes:
+
+| Route              | Great circle | Realistic fibre | One-way floor | Typical measured RTT |
+| ------------------ | ------------ | --------------- | ------------- | -------------------- |
+| London ↔ Paris     | 340 km       | ~500 km         | 2.5ms         | 8-12ms               |
+| Mumbai ↔ Singapore | 3,900 km     | ~5,500 km       | 28ms          | 55-75ms              |
+| London ↔ New York  | 5,600 km     | ~7,000 km       | 35ms          | 70-85ms              |
+| Mumbai ↔ London    | 7,200 km     | ~11,000 km      | 55ms          | 110-130ms            |
+| Sydney ↔ London    | 17,000 km    | ~22,000 km      | 110ms         | 240-280ms            |
+
+Read the last row again, because it is the most important line in this section. **A Sydney-to-London call has already spent most of its conversational budget before a single line of your code runs.** No CDN, no protocol, no clever buffer helps. This is why sec 34 says put media servers in every region where you have users, and why sec 31 says a TURN relay on the wrong continent is a bug and not an inefficiency: routing a Sydney↔Melbourne call through a relay in Virginia turns a 15ms path into a 320ms one, and does it silently.
+
+#### Two: humans notice 150ms because of how conversation works
+
+The ITU's guidance (G.114) is that one-way mouth-to-ear delay should stay under **150ms**, with 400ms as the point where interactive conversation stops working. Those are not arbitrary thresholds; they come from turn-taking. In natural speech the gap between one person finishing and the next starting is around **200ms**, and it is remarkably consistent across languages. When network delay approaches that gap, both parties start speaking into each other's silence, then both stop, then both apologise. The call has not lost a single packet. It has simply become unusable.
+
+So 150ms one way is the whole budget, and it must cover every stage:
+
+| Stage                     | Typical cost | Notes                                                                 |
+| ------------------------- | ------------ | ---------------------------------------------------------------------- |
+| Capture + audio processing | 10-25ms      | Echo cancellation needs a lookahead window (sec 20)                    |
+| Encode                    | 5-30ms       | Hardware encoders are fast; software at high quality is not            |
+| Packetise + pace          | 5-15ms       | The pacer deliberately spreads a burst over time (sec 19)              |
+| **Network**               | **10-150ms** | The floor above, plus queueing                                          |
+| Jitter buffer             | 20-100ms     | The one knob you control directly, and it is a pure latency tax (sec 18) |
+| Decode + render           | 10-25ms      | Plus up to one frame interval (33ms at 30fps) waiting for the display   |
+
+Add the middle of those ranges for a domestic call and you land around 120ms — inside budget, with very little room. Add a transatlantic hop and you are at 190ms and it is noticeable. **The network is frequently not the biggest line in the budget**, which is why the jitter-buffer tuning in sec 18 matters as much as the server placement in sec 34, and why "just add more buffer" is never free.
+
+#### Three: a packet is about 1200 bytes, and fragmenting one is a disaster
+
+Ethernet's payload limit is 1500 bytes, and that number propagates end to end because the path MTU is the minimum along the route. Subtract what the stack must carry:
+
+```text title="where the 1500 bytes go"
+1500   Ethernet MTU
+ -20   IPv4 header (IPv6 is 40, so assume the worse case)
+  -8   UDP header
+ -12   RTP header
+ -20   RTP header extensions: transport-cc seq, mid, rid, abs-send-time (sec 15)
+ -10   SRTP authentication tag (sec 13)
+------
+ 1430  theoretically available
+ ~1200 what implementations actually use
+```
+
+The gap between 1430 and 1200 is deliberate slack for the layers you cannot see: a VPN, a PPPoE link with 1492, an IPv6-in-IPv4 tunnel, a mobile carrier's GTP encapsulation. Any of those can shrink the real MTU below your assumption.
+
+Why does the slack matter so much? Because of what happens when you exceed the MTU. IP will fragment the datagram, and **a fragmented datagram is lost if _any_ fragment is lost**. Split a packet into three fragments on a link with 1% independent loss, and the datagram's loss rate becomes `1 - 0.99³ ≈ 3%`. You have tripled your loss to save one packet header. So WebRTC never lets IP fragment: it keeps every datagram under the MTU and splits large frames itself, at the RTP layer, where it can control exactly what a loss costs.
+
+This is also why the 60 KB keyframe in sec 17 is not one packet but **fifty**, and why a single lost packet can destroy a whole keyframe.
+
+#### Four: raw video is a thousand times too big
+
+Take 720p at 30 frames per second, in the YUV 4:2:0 format every codec works in — 8 bits of brightness per pixel plus quarter-resolution colour, which averages **1.5 bytes per pixel**:
+
+```text title="the raw bitrate, computed"
+1280 x 720 pixels          =    921,600 pixels
+        x 1.5 bytes/pixel  =  1,382,400 bytes per frame   (1.38 MB)
+        x 30 frames/sec    = 41,472,000 bytes per second
+        x 8                =    332 Mbps
+
+1080p30 by the same arithmetic  =    746 Mbps
+1080p60                          =  1,493 Mbps
+```
+
+A good video call runs at **1.5 Mbps**. So the codec must achieve a compression ratio of roughly **220:1** for 720p, and **500:1** for 1080p. For comparison, JPEG at pleasant quality manages about 10:1 and a ZIP of English text about 3:1. Those ratios are not in the same universe.
+
+You cannot get 200:1 by compressing each frame better. You get it by **not sending most frames at all** — by sending, for each frame, only what changed since the previous one. In a talking-head video that is a small patch around the mouth and eyes; the wall behind the speaker is transmitted once and then referenced for minutes. That is where the factor of 200 comes from, and there is no other way to get it.
+
+#### Five: because of four, one lost packet corrupts the future
+
+This is the consequence people skip, and it explains more day-to-day WebRTC behaviour than any other single fact.
+
+If frame 100 is encoded as "the changes since frame 99", then a decoder that never received part of frame 99 cannot decode frame 100 either. Nor 101, which references 100. **The damage propagates forward indefinitely**, and the only way to stop it is a frame that depends on nothing — a **keyframe**, which is a complete standalone image, which is 10 to 20 times the size of a delta frame.
+
+<Diagram caption="Why a single lost packet has a long tail in video and almost none in audio">
+<svg viewBox="0 0 720 260" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Top row: video frames form a dependency chain, so losing one frame corrupts every following frame until a keyframe arrives. Bottom row: audio frames are independent, so losing one leaves a single concealed gap">
+  <text x="20" y="22" class="mono" font-size="10.5" font-weight="700" fill="var(--dg-accent-2)">VIDEO</text>
+  <text x="700" y="22" font-size="9" fill="var(--dg-ink-2)" text-anchor="end">every frame references the one before it</text>
+
+  <rect x="20" y="34" width="52" height="42" rx="7" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)" />
+  <text x="46" y="52" class="mono" font-size="10" font-weight="700" fill="var(--dg-ok)" text-anchor="middle">I</text>
+  <text x="46" y="68" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">60 KB</text>
+
+  <g fill="var(--dg-ink-2)">
+    <rect x="88" y="40" width="44" height="30" rx="6" fill="var(--dg-surface)" stroke="var(--dg-line)" />
+    <text x="110" y="60" class="mono" font-size="9.5" fill="var(--dg-ink)" text-anchor="middle">P</text>
+    <rect x="148" y="40" width="44" height="30" rx="6" fill="var(--dg-accent)" stroke="var(--dg-accent-2)" />
+    <text x="170" y="60" class="mono" font-size="9.5" font-weight="700" fill="var(--dg-on-accent)" text-anchor="middle">P</text>
+    <rect x="208" y="40" width="44" height="30" rx="6" fill="var(--dg-accent-surface)" stroke="var(--dg-accent-border)" stroke-dasharray="3 2" />
+    <text x="230" y="60" class="mono" font-size="9.5" fill="var(--dg-accent)" text-anchor="middle">P</text>
+    <rect x="268" y="40" width="44" height="30" rx="6" fill="var(--dg-accent-surface)" stroke="var(--dg-accent-border)" stroke-dasharray="3 2" />
+    <text x="290" y="60" class="mono" font-size="9.5" fill="var(--dg-accent)" text-anchor="middle">P</text>
+    <rect x="328" y="40" width="44" height="30" rx="6" fill="var(--dg-accent-surface)" stroke="var(--dg-accent-border)" stroke-dasharray="3 2" />
+    <text x="350" y="60" class="mono" font-size="9.5" fill="var(--dg-accent)" text-anchor="middle">P</text>
+    <rect x="388" y="40" width="44" height="30" rx="6" fill="var(--dg-accent-surface)" stroke="var(--dg-accent-border)" stroke-dasharray="3 2" />
+    <text x="410" y="60" class="mono" font-size="9.5" fill="var(--dg-accent)" text-anchor="middle">P</text>
+  </g>
+  <rect x="448" y="34" width="52" height="42" rx="7" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)" />
+  <text x="474" y="52" class="mono" font-size="10" font-weight="700" fill="var(--dg-ok)" text-anchor="middle">I</text>
+  <text x="474" y="68" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">60 KB</text>
+  <rect x="516" y="40" width="44" height="30" rx="6" fill="var(--dg-surface)" stroke="var(--dg-line)" />
+  <text x="538" y="60" class="mono" font-size="9.5" fill="var(--dg-ink)" text-anchor="middle">P</text>
+
+  <text x="170" y="30" font-size="9" font-weight="700" fill="var(--dg-accent-2)" text-anchor="middle">packet lost here</text>
+  <path fill="none" d="M170 76 V88" stroke="var(--dg-accent-2)" stroke-width="1.2" />
+  <path fill="none" d="M170 88 H410" stroke="var(--dg-accent-2)" stroke-width="1.2" stroke-dasharray="4 3" />
+  <text x="292" y="102" font-size="9.5" font-style="italic" fill="var(--dg-accent-2)" text-anchor="middle">every later frame is undecodable — 5 frames = 166ms of frozen picture</text>
+  <path d="M474 76 V88 H410" fill="none" stroke="var(--dg-ok)" stroke-width="1.2" />
+  <text x="700" y="92" font-size="9" fill="var(--dg-ok)" text-anchor="end">recovery needs a whole new keyframe</text>
+
+  <line x1="20" y1="126" x2="700" y2="126" stroke="var(--dg-line)" stroke-dasharray="4 4" />
+
+  <text x="20" y="150" class="mono" font-size="10.5" font-weight="700" fill="var(--dg-ok)">AUDIO</text>
+  <text x="700" y="150" font-size="9" fill="var(--dg-ink-2)" text-anchor="end">each 20ms frame stands on its own</text>
+  <g>
+    <rect x="20" y="164" width="46" height="34" rx="6" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)" />
+    <rect x="76" y="164" width="46" height="34" rx="6" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)" />
+    <rect x="132" y="164" width="46" height="34" rx="6" fill="var(--dg-accent)" stroke="var(--dg-accent-2)" />
+    <rect x="188" y="164" width="46" height="34" rx="6" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)" />
+    <rect x="244" y="164" width="46" height="34" rx="6" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)" />
+    <rect x="300" y="164" width="46" height="34" rx="6" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)" />
+    <rect x="356" y="164" width="46" height="34" rx="6" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)" />
+  </g>
+  <text x="155" y="186" class="mono" font-size="9" font-weight="700" fill="var(--dg-on-accent)" text-anchor="middle">lost</text>
+  <text x="155" y="156" font-size="9" font-weight="700" fill="var(--dg-accent-2)" text-anchor="middle">packet lost here</text>
+  <path fill="none" d="M155 198 V212" stroke="var(--dg-ok)" stroke-width="1.2" />
+  <text x="300" y="224" font-size="9.5" font-style="italic" fill="var(--dg-ok)" text-anchor="middle">one 20ms gap, concealed by interpolation — usually inaudible. Nothing propagates.</text>
+  <text x="360" y="248" class="mono" font-size="9" fill="var(--dg-ink-2)" text-anchor="middle">same 1% loss: video freezes for a sixth of a second, audio does not flinch</text>
+</svg>
+</Diagram>
+
+Audio is different in kind, not degree, and the reason is again the arithmetic. Raw mono speech at 48 kHz and 16 bits is 768 kbps; Opus carries it well at 32 kbps. That is a ratio of **24:1**, which is achievable within a single 20ms frame using a psychoacoustic model — no dependency on previous frames required. So an audio frame is largely self-contained: lose one and you have a 20ms hole that the decoder fills by extrapolating the waveform, and a listener typically cannot hear it.
+
+**This asymmetry — video loss propagates for hundreds of milliseconds, audio loss is a blip — is the reason the bitrate allocator in sec 19 protects audio absolutely and lets video degrade.** It is not a product preference. It is what the compression ratios force.
+
+#### Six: almost nobody has an address
+
+IPv4 has 2³² = **4.29 billion** addresses, of which a good fraction are reserved. There are well over 20 billion connected devices. The arithmetic does not work and has not worked since the 1990s, so the internet quietly rebuilt itself around **NAT**: your device gets a private address, and a box rewrites your packets on the way out.
+
+NAT is therefore not a security decision or a vendor choice you can route around. It is a consequence of running out of numbers, it sits in front of essentially every consumer and corporate device, and its central property — **you can only receive from someone you have already sent to** — is precisely incompatible with "two peers connect directly." Sections 9 through 12 exist entirely to work around this one number.
+
+<Callout type="ok" title="Keep these six">
+Light: 5ms per 1000 km. Conversation: 150ms budget, ~200ms turn gap. Packet: ~1200 bytes, never fragment. Raw 720p30: 332 Mbps, needing 200:1. Consequence: video loss propagates until a keyframe. Addresses: there are not enough, so NAT is everywhere. If you remember nothing else from this chapter, you can re-derive most of it from these.
+</Callout>
+
+## Deriving WebRTC From Scratch
+
+Now the payoff. Give the six numbers to an engineer who has never heard of WebRTC and ask them to build live video between two browsers. Watch what they are forced to do. Every move below is compelled by the previous one — there is no point where a committee's taste enters — and at the end we will have rebuilt the entire stack.
+
+<Diagram caption="Ten forced moves, and the protocol each one lands on">
+<svg viewBox="0 0 720 470" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="A derivation chain: deadline over completeness forces UDP, which forces sequence numbers and timestamps giving RTP, which forces a feedback channel giving RTCP, encryption over datagrams giving DTLS, key export giving SRTP, trust via signaling giving the SDP fingerprint, address discovery giving STUN, relay giving TURN, trying everything giving ICE, and per-stream reliability giving SCTP">
+  <defs><marker id="dv" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0 0 L7 3 L0 6 Z" fill="var(--dg-line-2)" /></marker></defs>
+
+  <rect x="20" y="14" width="300" height="36" rx="8" fill="var(--dg-surface)" stroke="var(--dg-line)" />
+  <text x="34" y="30" font-size="10" fill="var(--dg-ink)">A late packet is worthless, so never block on it</text>
+  <text x="34" y="44" class="mono" font-size="8" fill="var(--dg-ink-3)">constraint 1, 2</text>
+  <path fill="none" d="M320 32 H392" stroke="var(--dg-line-2)" stroke-width="1.3" marker-end="url(#dv)" />
+  <rect x="396" y="14" width="304" height="36" rx="8" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)" />
+  <text x="410" y="37" font-size="11" font-weight="700" fill="var(--dg-ok)">UDP  — the only transport that will drop for you</text>
+
+  <path fill="none" d="M170 50 V64" stroke="var(--dg-line-2)" stroke-width="1.3" marker-end="url(#dv)" />
+  <rect x="20" y="68" width="300" height="36" rx="8" fill="var(--dg-surface)" stroke="var(--dg-line)" />
+  <text x="34" y="84" font-size="10" fill="var(--dg-ink)">…but now: what is missing? when do I play it?</text>
+  <text x="34" y="98" class="mono" font-size="8" fill="var(--dg-ink-3)">UDP tells you nothing</text>
+  <path fill="none" d="M320 86 H392" stroke="var(--dg-line-2)" stroke-width="1.3" marker-end="url(#dv)" />
+  <rect x="396" y="68" width="304" height="36" rx="8" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)" />
+  <text x="410" y="91" font-size="11" font-weight="700" fill="var(--dg-ok)">RTP  — add sequence number + timestamp</text>
+
+  <path fill="none" d="M170 104 V118" stroke="var(--dg-line-2)" stroke-width="1.3" marker-end="url(#dv)" />
+  <rect x="20" y="122" width="300" height="36" rx="8" fill="var(--dg-surface)" stroke="var(--dg-line)" />
+  <text x="34" y="138" font-size="10" fill="var(--dg-ink)">Sender must learn what the receiver got</text>
+  <text x="34" y="152" class="mono" font-size="8" fill="var(--dg-ink-3)">no adaptation without feedback</text>
+  <path fill="none" d="M320 140 H392" stroke="var(--dg-line-2)" stroke-width="1.3" marker-end="url(#dv)" />
+  <rect x="396" y="122" width="304" height="36" rx="8" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)" />
+  <text x="410" y="145" font-size="11" font-weight="700" fill="var(--dg-ok)">RTCP  — a control channel beside the media</text>
+
+  <path fill="none" d="M170 158 V172" stroke="var(--dg-line-2)" stroke-width="1.3" marker-end="url(#dv)" />
+  <rect x="20" y="176" width="300" height="36" rx="8" fill="var(--dg-surface)" stroke="var(--dg-line)" />
+  <text x="34" y="192" font-size="10" fill="var(--dg-ink)">It is a camera in someone's home. Encrypt it.</text>
+  <text x="34" y="206" class="mono" font-size="8" fill="var(--dg-ink-3)">but TLS assumes a reliable stream</text>
+  <path fill="none" d="M320 194 H392" stroke="var(--dg-line-2)" stroke-width="1.3" marker-end="url(#dv)" />
+  <rect x="396" y="176" width="304" height="36" rx="8" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)" />
+  <text x="410" y="199" font-size="11" font-weight="700" fill="var(--dg-ok)">DTLS  — TLS that tolerates loss and reordering</text>
+
+  <path fill="none" d="M170 212 V226" stroke="var(--dg-line-2)" stroke-width="1.3" marker-end="url(#dv)" />
+  <rect x="20" y="230" width="300" height="36" rx="8" fill="var(--dg-surface)" stroke="var(--dg-line)" />
+  <text x="34" y="246" font-size="10" fill="var(--dg-ink)">Wrapping RTP hides the header routers need</text>
+  <text x="34" y="260" class="mono" font-size="8" fill="var(--dg-ink-3)">and costs bytes we do not have</text>
+  <path fill="none" d="M320 248 H392" stroke="var(--dg-line-2)" stroke-width="1.3" marker-end="url(#dv)" />
+  <rect x="396" y="230" width="304" height="36" rx="8" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)" />
+  <text x="410" y="253" font-size="11" font-weight="700" fill="var(--dg-ok)">SRTP  — export keys; encrypt payload, expose header</text>
+
+  <path fill="none" d="M170 266 V280" stroke="var(--dg-line-2)" stroke-width="1.3" marker-end="url(#dv)" />
+  <rect x="20" y="284" width="300" height="36" rx="8" fill="var(--dg-surface)" stroke="var(--dg-line)" />
+  <text x="34" y="300" font-size="10" fill="var(--dg-ink)">No CA vouches for a laptop. Who do we trust?</text>
+  <text x="34" y="314" class="mono" font-size="8" fill="var(--dg-ink-3)">only the channel that introduced them</text>
+  <path fill="none" d="M320 302 H392" stroke="var(--dg-line-2)" stroke-width="1.3" marker-end="url(#dv)" />
+  <rect x="396" y="284" width="304" height="36" rx="8" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)" />
+  <text x="410" y="307" font-size="11" font-weight="700" fill="var(--dg-ok)">SDP fingerprint  — trust comes from signaling</text>
+
+  <path fill="none" d="M170 320 V334" stroke="var(--dg-line-2)" stroke-width="1.3" marker-end="url(#dv)" />
+  <rect x="20" y="338" width="300" height="36" rx="8" fill="var(--dg-surface)" stroke="var(--dg-line)" />
+  <text x="34" y="354" font-size="10" fill="var(--dg-ink)">Neither peer has a reachable address</text>
+  <text x="34" y="368" class="mono" font-size="8" fill="var(--dg-ink-3)">constraint 6</text>
+  <path fill="none" d="M320 356 H392" stroke="var(--dg-line-2)" stroke-width="1.3" marker-end="url(#dv)" />
+  <rect x="396" y="338" width="304" height="36" rx="8" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)" />
+  <text x="410" y="361" font-size="11" font-weight="700" fill="var(--dg-ok)">STUN + TURN + ICE  — ask, relay, and try everything</text>
+
+  <path fill="none" d="M170 374 V388" stroke="var(--dg-line-2)" stroke-width="1.3" marker-end="url(#dv)" />
+  <rect x="20" y="392" width="300" height="36" rx="8" fill="var(--dg-surface)" stroke="var(--dg-line)" />
+  <text x="34" y="408" font-size="10" fill="var(--dg-ink)">Some payloads DO need reliability</text>
+  <text x="34" y="422" class="mono" font-size="8" fill="var(--dg-ink-3)">but a second TCP means a second traversal</text>
+  <path fill="none" d="M320 410 H392" stroke="var(--dg-line-2)" stroke-width="1.3" marker-end="url(#dv)" />
+  <rect x="396" y="392" width="304" height="36" rx="8" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)" />
+  <text x="410" y="415" font-size="11" font-weight="700" fill="var(--dg-ok)">SCTP over DTLS  — reliability as a per-channel dial</text>
+
+  <rect x="20" y="436" width="680" height="26" rx="7" fill="var(--dg-inverse)" />
+  <text x="360" y="453" font-size="11" font-weight="700" fill="var(--dg-on-inverse)" text-anchor="middle">That list is WebRTC. Not one line of it was a preference.</text>
+</svg>
+</Diagram>
+
+**Move 1 — the transport must be willing to lose.** Constraint 2 says a packet that misses its playout deadline is garbage. TCP's contract is the opposite: it will spend unbounded time and bandwidth making sure you get that garbage, and block everything behind it while doing so. You need a transport that hands you what arrived and says nothing about what did not. That is **UDP**. There is no third option in a browser.
+
+**Move 2 — UDP gives you nothing, so you must add the minimum back.** Now you have a stream of anonymous datagrams. Two questions are unanswerable: _did I miss anything?_ and _when should this be played?_ Add a counter that increments per packet and you can detect both loss and reordering. Add a media clock reading and you know the playout instant. Those two fields — plus an identifier for _which stream_ this is, since one connection will carry several — are essentially the entire RTP header. **You have just designed RTP** without being told about it.
+
+**Move 3 — adaptation is impossible without a back channel.** Constraint 4 says you are compressing 200:1, and how hard you compress must depend on how much bandwidth exists, which only the receiver can observe. The sender needs to hear about loss, jitter, round-trip time and arrival timings. That reporting has to travel somewhere, it is not media, and it must not be confused with media. **You have just designed RTCP.**
+
+**Move 4 — media must be encrypted, and TLS does not fit.** Nobody ships an unencrypted camera feed in 2026. But TLS assumes an ordered, reliable byte stream underneath, and we deliberately chose a transport that has neither. The datagram variant, **DTLS**, adds its own sequence numbers and retransmission to the _handshake_ only, so it can complete over a lossy path.
+
+**Move 5 — but do not carry the media inside DTLS.** Two reasons, both from the constraints. Constraint 3: every DTLS record adds header and MAC bytes to a budget that is already tight. And more fundamentally, an SFU (sec 28) must be able to read a packet's stream identifier and sequence number to route it to twelve subscribers **without holding the media keys**. So use the DTLS handshake purely to agree on keys, export them, and hand them to **SRTP**, which encrypts the payload, authenticates the header, and leaves the header legible. **The design of SRTP is forced by the need for a middlebox that routes without decrypting.**
+
+**Move 6 — encryption without identity is theatre, and there is no CA.** DTLS will happily complete a handshake with an attacker in the middle. Normally a certificate authority resolves this, but no CA will issue a certificate to "Priya's laptop, this afternoon". So where does trust come from? The only place available: **the channel that introduced the two peers in the first place.** Put a hash of your certificate into the setup blob, send it over that channel, and have the peer verify the certificate against the hash. That is `a=fingerprint` (sec 8), and it is why sec 7 insists your signaling security _is_ your media security.
+
+**Move 7 — you cannot send a packet without an address.** Constraint 6 says neither peer has one. So you need an outside observer that can tell you what your traffic looks like from the internet — a trivial two-packet protocol, **STUN**. When the observer's answer turns out to be unusable, you need something both peers _can_ reach that will forward for them — a relay, **TURN**. And since you cannot know in advance which of your half-dozen addresses will work with which of theirs, you must **try them all at once and keep whichever answers**. That is **ICE**, and its brute-force character is not inelegance; it is the only correct response to a network whose behaviour you cannot query.
+
+**Move 8 — but exchanging addresses needs a channel you do not have yet.** This is the bootstrap problem, and it is genuinely unsolvable inside the protocol. Two browsers that have never met have no way to send each other anything. Something outside must introduce them — and every product already has that something: a backend the users are logged into. So the standard **deliberately leaves the hole** rather than inventing a second identity system (sec 7).
+
+**Move 9 — and the two sides must agree on what they are sending.** Codecs, resolutions, which stream is which, which feedback mechanisms each supports. One side proposes, the other accepts a subset, and the subset is the contract. **You have just designed offer/answer**, carried in **SDP** (sec 8).
+
+**Move 10 — non-media payloads want the opposite guarantees.** Chat, game state, file transfer. You could open a WebSocket, but that is a second connection, with a second TLS handshake, and it does not benefit from the NAT hole you just spent a second punching. You want a protocol that rides the DTLS association you already have and lets _each logical channel_ choose its own reliability — fully reliable for a file, fire-and-forget for a cursor position. **SCTP** is that protocol (sec 21).
+
+<Callout type="ok" title="What the derivation buys you">
+Every acronym in WebRTC is now a place-holder for a question you have already answered: RTP is "what did UDP forget", RTCP is "how does the sender learn", DTLS-SRTP is "encrypt without blinding the router", ICE is "which of these addresses works", SDP is "what did we agree", signaling is "who introduces them". When something breaks in production, you can ask which of the six constraints is being violated rather than which library to blame — and that reframing is worth more than any amount of API familiarity.
+</Callout>
+
+## What WebRTC Actually Is
+
+The derivation produced a stack; here is that stack as it is actually assembled, which is worth seeing once, because every later section is a floor of this building.
+
+<Diagram caption="What is inside a peer connection">
+<svg viewBox="0 0 720 300" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="The WebRTC protocol stack: application API on top, then media and data paths, SRTP and SCTP over DTLS, all over ICE, UDP and IP">
+  <rect x="20" y="20" width="680" height="44" rx="9" fill="var(--dg-accent)" />
+  <text x="360" y="41" font-size="12" font-weight="700" fill="var(--dg-on-accent)" text-anchor="middle">Your application</text>
+  <text x="360" y="56" class="mono" font-size="8.5" fill="var(--dg-on-accent)" text-anchor="middle">RTCPeerConnection · getUserMedia · RTCDataChannel</text>
+
+  <rect x="20" y="76" width="330" height="52" rx="9" fill="var(--dg-info-surface)" stroke="var(--dg-info-border)" />
+  <text x="185" y="97" font-size="11.5" font-weight="700" fill="var(--dg-info)" text-anchor="middle">Media path</text>
+  <text x="185" y="115" class="mono" font-size="8.5" fill="var(--dg-ink-2)" text-anchor="middle">Opus / VP8 / VP9 / H.264 / AV1 (sec 17)</text>
+
+  <rect x="370" y="76" width="330" height="52" rx="9" fill="var(--dg-plum-surface)" stroke="var(--dg-plum-soft)" />
+  <text x="535" y="97" font-size="11.5" font-weight="700" fill="var(--dg-plum)" text-anchor="middle">Data path</text>
+  <text x="535" y="115" class="mono" font-size="8.5" fill="var(--dg-ink-2)" text-anchor="middle">your bytes, per-channel reliability (sec 21)</text>
+
+  <rect x="20" y="140" width="330" height="46" rx="9" fill="var(--dg-info-surface)" stroke="var(--dg-info-border)" />
+  <text x="185" y="160" font-size="11" font-weight="700" fill="var(--dg-info)" text-anchor="middle">SRTP / SRTCP</text>
+  <text x="185" y="177" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">payload encrypted, header readable (sec 13-14)</text>
+
+  <rect x="370" y="140" width="330" height="46" rx="9" fill="var(--dg-plum-surface)" stroke="var(--dg-plum-soft)" />
+  <text x="535" y="160" font-size="11" font-weight="700" fill="var(--dg-plum)" text-anchor="middle">SCTP</text>
+  <text x="535" y="177" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">ordered? reliable? your choice, per channel</text>
+
+  <rect x="20" y="198" width="680" height="40" rx="9" fill="var(--dg-warn-surface)" stroke="var(--dg-warn-border)" />
+  <text x="360" y="216" font-size="11.5" font-weight="700" fill="var(--dg-warn)" text-anchor="middle">DTLS</text>
+  <text x="360" y="232" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">one handshake, verified against the SDP fingerprint, exports the SRTP keys (sec 13)</text>
+
+  <rect x="20" y="248" width="680" height="40" rx="9" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)" />
+  <text x="360" y="266" font-size="11.5" font-weight="700" fill="var(--dg-ok)" text-anchor="middle">ICE  ·  UDP  ·  IP</text>
+  <text x="360" y="282" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">find a path that works, then keep proving it works (sec 12)</text>
+</svg>
+</Diagram>
+
+Read it bottom-up and it is the derivation in reverse. **UDP** at the base because we must be able to abandon data. **ICE** above it because we have no address. **DTLS** above that because we must encrypt over datagrams. **SRTP** for media and **SCTP** for data because those two payloads want opposite guarantees. And one API — `RTCPeerConnection` — hiding all of it.
+
+There is one more component, the one people are always surprised by: **WebRTC does not include signaling.** Move 8 explains why. Nothing in the standard tells two browsers how to find each other, and that is deliberate; it is your job (sec 7).
+
+<Callout type="info" title="Naming, so the later sections read cleanly">
+A **track** is one media source (a camera, a microphone). A **stream** groups tracks that belong together and should stay in sync. An **SSRC** is the 32-bit number identifying one track's packets on the wire. A **transceiver** is the sender/receiver pair for one media section in the SDP. A **peer connection** is the whole thing: one ICE agent, one DTLS session, and every track riding it.
+</Callout>
+
+## The Three Hard Problems
+
+Ten moves compress into three problems. Every section in this chapter is an answer to one of them, and when a call misbehaves the useful first question is which of the three it is.
+
+**One: peers cannot address each other** — constraint 6. Your laptop is `192.168.1.34`, which means nothing outside your home, and it does not even know its own public address. Fixing this needs an outside observer (STUN, sec 10), a fallback relay (TURN, sec 11), and an algorithm that tries every possibility and keeps the best working one (ICE, sec 12). **This is where connection failures live.**
+
+**Two: peers must agree on what they are sending** — codecs, resolutions, keys, stream identities, feedback mechanisms. Written in SDP, exchanged as offer and answer (sec 8), over a channel WebRTC does not provide (sec 7). **This is where "audio works but video is black" lives.**
+
+**Three: the network is unknown, hostile and changes by the second** — constraints 4 and 5 meeting reality. Capacity is not advertised anywhere; you discover it by sending and watching. Packets are lost in bursts, Wi-Fi degrades, a phone hands over to cellular. So the media path is a permanent control loop: measure, estimate, adjust the encoder, repair what is worth repairing, discard what is not (sec 18-19). **This is where "the video went blurry" lives.**
+
+<Callout type="info" title="Mental model">
+Signaling is the phone book and the introduction. ICE is the two of you working out which door is actually unlocked. DTLS is the sealed envelope. RTP is the conveyor belt. Congestion control is the hand on the speed dial of that belt, adjusting it every few hundred milliseconds for the rest of the call.
+</Callout>
+
+## Deciding Whether You Need Any of This
+
+Sections 1 to 5 argued that WebRTC is forced. That is true _given the requirement_. The most valuable thing in this chapter is the observation that **the requirement is usually negotiable**, and WebRTC is by a wide margin the most operationally demanding way to move a picture.
+
+<Diagram caption="Where the delivery technologies sit, and what each costs to run">
+<svg viewBox="0 0 720 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="A latency axis from ten milliseconds to thirty seconds, showing WebRTC at the low end with high operational cost and HLS at the high end riding ordinary CDNs cheaply">
+  <defs><marker id="lb" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0 0 L7 3 L0 6 Z" fill="var(--dg-ink-2)" /></marker></defs>
+  <line x1="40" y1="150" x2="690" y2="150" stroke="var(--dg-ink-2)" stroke-width="1.3" marker-end="url(#lb)" />
+  <text x="40" y="176" class="mono" font-size="9" fill="var(--dg-ink-3)">10ms</text>
+  <text x="200" y="176" class="mono" font-size="9" fill="var(--dg-ink-3)">150ms</text>
+  <text x="360" y="176" class="mono" font-size="9" fill="var(--dg-ink-3)">1s</text>
+  <text x="520" y="176" class="mono" font-size="9" fill="var(--dg-ink-3)">5s</text>
+  <text x="655" y="176" class="mono" font-size="9" fill="var(--dg-ink-3)">30s</text>
+
+  <rect x="40" y="52" width="200" height="80" rx="10" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)" />
+  <text x="140" y="74" font-size="12" font-weight="700" fill="var(--dg-ok)" text-anchor="middle">WebRTC</text>
+  <text x="140" y="92" font-size="9.5" fill="var(--dg-ink-2)" text-anchor="middle">conversation, control loops</text>
+  <text x="140" y="108" font-size="9.5" fill="var(--dg-ink-2)" text-anchor="middle">calls, telehealth, cloud gaming</text>
+  <text x="140" y="124" class="mono" font-size="8.5" font-weight="700" fill="var(--dg-accent-2)" text-anchor="middle">cost: stateful media servers</text>
+
+  <rect x="256" y="52" width="190" height="80" rx="10" fill="var(--dg-warn-surface)" stroke="var(--dg-warn-border)" />
+  <text x="351" y="74" font-size="12" font-weight="700" fill="var(--dg-warn)" text-anchor="middle">LL-HLS / LL-DASH</text>
+  <text x="351" y="92" font-size="9.5" fill="var(--dg-ink-2)" text-anchor="middle">live sport, auctions,</text>
+  <text x="351" y="108" font-size="9.5" fill="var(--dg-ink-2)" text-anchor="middle">a broadcast with a chat</text>
+  <text x="351" y="124" class="mono" font-size="8.5" font-weight="700" fill="var(--dg-ok)" text-anchor="middle">cost: an ordinary CDN</text>
+
+  <rect x="462" y="52" width="228" height="80" rx="10" fill="var(--dg-info-surface)" stroke="var(--dg-info-border)" />
+  <text x="576" y="74" font-size="12" font-weight="700" fill="var(--dg-info)" text-anchor="middle">HLS / DASH</text>
+  <text x="576" y="92" font-size="9.5" fill="var(--dg-ink-2)" text-anchor="middle">no feedback loop at all</text>
+  <text x="576" y="108" font-size="9.5" fill="var(--dg-ink-2)" text-anchor="middle">VOD, one-way streams</text>
+  <text x="576" y="124" class="mono" font-size="8.5" font-weight="700" fill="var(--dg-ok)" text-anchor="middle">cost: nearly nothing</text>
+
+  <text x="140" y="204" font-size="10" font-style="italic" fill="var(--dg-accent-2)" text-anchor="middle">a human must react</text>
+  <text x="140" y="220" font-size="10" font-style="italic" fill="var(--dg-accent-2)" text-anchor="middle">inside their own reaction time</text>
+  <text x="500" y="204" font-size="10" font-style="italic" fill="var(--dg-info)" text-anchor="middle">nobody is waiting on anyone —</text>
+  <text x="500" y="220" font-size="10" font-style="italic" fill="var(--dg-info)" text-anchor="middle">latency is invisible without a comparison</text>
+</svg>
+</Diagram>
+
+The test is one question, and it comes straight from constraint 2: **does a human have to react to what they just saw, within their own reaction time?** Two people talking: yes. A surgeon steering a robot: yes. A driving instructor watching a remote camera: yes. Forty thousand people watching a football match: no — nobody in that audience is responding to anyone, so a five-second delay is invisible to every one of them, and the only thing that would expose it is a neighbour cheering through the wall.
+
+<Callout type="warn" title="The cost of being wrong in the expensive direction">
+Choosing HLS when you needed WebRTC produces an obviously broken product on day one and you fix it. Choosing WebRTC when HLS would have done produces a product that works in the demo and then hands you a permanent operational burden: a media plane that cannot be load-balanced (sec 33), cannot be rolled without dropping calls (sec 33), scales on bandwidth rather than CPU (sec 32), and bills you for relay traffic (sec 31). That mistake is not visible until you have users, and by then it is architecture. Spend an hour on the question before you spend a year on the stack.
+</Callout>
+Part II / Finding Each Other
+
+## Signaling: the Part WebRTC Doesn't Give You
+
+Move 8 of the derivation named the bootstrap problem: two browsers that have never met cannot exchange anything, yet to start a call they must first swap a fairly large blob of setup information. WebRTC solves this by **refusing to solve it**. The specification defines the format of what you exchange (SDP, sec 8) and says nothing at all about how it travels.
+
+That looks like an omission until you notice it is the reason WebRTC fits everywhere. You already have a server your users are authenticated against. It already knows who may call whom, who is in which room, who is online. Forcing a standard signaling protocol on top of that would mean a second identity system in every product that uses it. So the standard leaves a hole exactly the shape of your existing backend, and you fill it.
+
+<Diagram caption="Two planes: signaling through your server, media around it">
+<svg viewBox="0 0 720 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Two peers each connect to a signaling server over WebSocket to exchange offer, answer and candidates, while the media flows directly between them over an encrypted UDP path">
+  <defs>
+    <marker id="sig-a" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0 0 L7 3 L0 6 Z" fill="var(--dg-info)" /></marker>
+    <marker id="sig-b" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0 0 L7 3 L0 6 Z" fill="var(--dg-ok)" /></marker>
+  </defs>
+  <rect x="270" y="20" width="180" height="52" rx="10" fill="var(--dg-info-surface)" stroke="var(--dg-info-border)" />
+  <text x="360" y="42" font-size="11.5" font-weight="700" fill="var(--dg-info)" text-anchor="middle">Your signaling server</text>
+  <text x="360" y="60" class="mono" font-size="8.5" fill="var(--dg-ink-2)" text-anchor="middle">WebSocket, auth, rooms</text>
+
+  <rect x="30" y="150" width="170" height="56" rx="10" fill="var(--dg-accent)" />
+  <text x="115" y="173" font-size="12" font-weight="700" fill="var(--dg-on-accent)" text-anchor="middle">Peer A</text>
+  <text x="115" y="190" class="mono" font-size="8.5" fill="var(--dg-on-accent)" text-anchor="middle">behind NAT</text>
+
+  <rect x="520" y="150" width="170" height="56" rx="10" fill="var(--dg-accent)" />
+  <text x="605" y="173" font-size="12" font-weight="700" fill="var(--dg-on-accent)" text-anchor="middle">Peer B</text>
+  <text x="605" y="190" class="mono" font-size="8.5" fill="var(--dg-on-accent)" text-anchor="middle">behind NAT</text>
+
+  <path fill="none" d="M140 148 L300 76" stroke="var(--dg-info)" stroke-width="1.6" stroke-dasharray="5 3" marker-end="url(#sig-a)" />
+  <path fill="none" d="M580 148 L420 76" stroke="var(--dg-info)" stroke-width="1.6" stroke-dasharray="5 3" marker-end="url(#sig-a)" />
+  <text x="150" y="112" class="mono" font-size="8.5" fill="var(--dg-info)">offer / answer</text>
+  <text x="470" y="112" class="mono" font-size="8.5" fill="var(--dg-info)">ice candidates</text>
+
+  <path fill="none" d="M204 178 H516" stroke="var(--dg-ok)" stroke-width="2.4" marker-end="url(#sig-b)" />
+  <text x="360" y="170" font-size="11" font-weight="700" fill="var(--dg-ok)" text-anchor="middle">SRTP media, direct</text>
+  <text x="360" y="200" class="mono" font-size="8.5" fill="var(--dg-ink-2)" text-anchor="middle">never touches the signaling server</text>
+
+  <text x="360" y="234" font-size="11" font-style="italic" fill="var(--dg-ink-2)" text-anchor="middle">Signaling is small, bursty and reliable. Media is large, continuous and lossy. Different problems, different paths.</text>
+</svg>
+</Diagram>
+
+In practice signaling is a WebSocket connection to your own backend (the WebSockets chapter, in full), carrying four message types:
+
+| Message      | Direction        | Carries                                                             |
+| ------------ | ---------------- | ------------------------------------------------------------------- |
+| `offer`      | caller → callee  | The caller's SDP: what it wants to send and can receive              |
+| `answer`     | callee → caller  | The callee's SDP: what it accepts and will send back                 |
+| `candidate`  | both ways        | One network address to try, sent as it is discovered (sec 12)        |
+| `bye`        | both ways        | Hang up, so the other side tears down instead of waiting for timeout |
+
+The formal name for this dance is **JSEP**, the JavaScript Session Establishment Protocol (RFC 8829), the rulebook for what a peer connection does when you hand it an offer or an answer. You will never implement JSEP; you will just obey its one visible rule, that offers and answers must alternate and both sides must be in a matching state, or `setRemoteDescription` throws (sec 23).
+
+<Callout type="warn" title="Signaling is where your security lives">
+This follows directly from move 6. Media is encrypted by the protocol whether you do anything or not, and the peer's identity is verified against a fingerprint that arrived **through signaling**. So an attacker who can rewrite SDP in flight substitutes their own fingerprint and reads the whole call, and DTLS cannot help — it will faithfully verify the attacker's certificate against the attacker's fingerprint. Authenticate the WebSocket, authorize every room join, never let a client tell you who it is (the auth chapter's rules apply unchanged), and treat SDP arriving from a client as untrusted input.
+</Callout>
+
+## SDP: the Session Contract
+
+The blob you pass through signaling is **SDP**, the Session Description Protocol. It is old, it is line-oriented, it looks like nothing else in modern engineering, and it is not going away, so it is worth ten minutes to be able to read one.
+
+An SDP is a list of `key=value` lines, grouped into a session-level block and then one **media section** (an `m=` line and everything after it, until the next `m=`) per track or data channel. Here is a trimmed offer for one audio and one video track, with the noise removed and the important lines kept.
+
+```text title="a trimmed SDP offer, one audio and one video track"
+v=0
+o=- 4611731400430051336 2 IN IP4 127.0.0.1     # origin: session id and version
+s=-                                            # session name, nobody uses it
+t=0 0                                          # timing, always 0 0 for WebRTC
+a=group:BUNDLE 0 1                             # run BOTH media sections over ONE transport
+a=fingerprint:sha-256 4A:AD:B9:B1:3F:...:C8    # hash of my DTLS certificate (sec 13)
+a=ice-ufrag:F7gI                               # ICE username fragment  \  credentials for
+a=ice-pwd:x9cvVN6Q2sX3n8Kk7Pq1L5aZ             # ICE password           /  connectivity checks
+
+m=audio 9 UDP/TLS/RTP/SAVPF 111 63 9 0 8       # audio, encrypted RTP, payload types offered
+c=IN IP4 0.0.0.0                               # port/address are placeholders: ICE decides
+a=mid:0                                        # media id, referenced by the BUNDLE group
+a=rtcp-mux                                     # RTP and RTCP share one port
+a=sendrecv                                     # I will send and receive audio
+a=rtpmap:111 opus/48000/2                      # payload type 111 means Opus, 48kHz, stereo
+a=fmtp:111 minptime=10;useinbandfec=1          # codec parameters: enable Opus in-band FEC
+a=extmap:1 urn:ietf:params:rtp-hdrext:ssrc-audio-level   # speaker detection (sec 29)
+a=ssrc:1234567890 cname:s9Hf2                  # the stream identifier I will send with
+
+m=video 9 UDP/TLS/RTP/SAVPF 96 97 98 39        # video section, four codecs offered
+a=mid:1
+a=sendrecv
+a=rtpmap:96 VP8/90000                          # VP8, 90kHz clock (always, for video)
+a=rtpmap:98 H264/90000
+a=fmtp:98 profile-level-id=42e01f              # H.264 profile: must match or no video
+a=rtcp-fb:96 nack                              # I support NACK retransmission (sec 18)
+a=rtcp-fb:96 nack pli                          # ...and picture-loss indication (keyframe req)
+a=rtcp-fb:96 transport-cc                      # ...and per-packet feedback for BWE (sec 19)
+a=extmap:3 http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01
+a=rid:hi send                                  # simulcast layer identifiers (sec 30)
+a=rid:lo send
+a=simulcast:send hi;lo
+```
+
+Four things in there deserve to be understood rather than skimmed.
+
+**The offer/answer model is a negotiation, not an announcement.** The offerer lists everything it supports, in preference order. The answerer replies with the subset it accepts, and _that subset is the contract_. If the caller offers VP8, VP9, H.264 and AV1 and the answer contains only H.264, the call runs on H.264. This is also how a codec mismatch turns into "audio works, video is black": the video section survived negotiation but no codec profile was common to both, or the profile matched and the hardware decoder refused it.
+
+**`a=group:BUNDLE` is why a modern call uses one port, not six.** The original design gave every media section its own transport, and separate RTP and RTCP ports on top, so a simple call needed four to six holes punched through NAT and four to six ICE negotiations — and by sec 9's arithmetic, each of those is an independent chance to fail. BUNDLE (RFC 9143) multiplexes every section onto a single transport, and `a=rtcp-mux` (RFC 5761) folds RTCP onto the same port as RTP. Modern WebRTC therefore does ICE **once**, gets **one** UDP flow, and demultiplexes audio, video and data inside it. Turning BUNDLE off is a reliable way to make a working call fail on a hotel network.
+
+**`c=IN IP4 0.0.0.0` and `m=... 9 ...` are placeholders.** The address and port in the SDP are meaningless in WebRTC; ICE picks the real ones later. This surprises people who know SDP from SIP, where those fields are the whole point.
+
+**The fingerprint binds the whole thing together.** `a=fingerprint` is a hash of the certificate the peer will present during the DTLS handshake — move 6 made flesh. Because it travels inside the SDP, over your authenticated signaling channel, it is what stops a man in the middle from substituting its own certificate (sec 13). Signaling integrity is media integrity.
+
+<Callout type="info" title="Reference">
+SDP itself is RFC 8866, the offer/answer model is RFC 3264, and how WebRTC uses them is JSEP, RFC 8829. You will not write SDP by hand, but you will read it in a bug report roughly once a month, usually to find out which codec line went missing.
+</Callout>
+
+## NAT: Why Two Peers Can't Just Connect
+
+Constraint 6 said there are not enough addresses. This section works out exactly what that costs you, and it is worth deriving rather than memorising, because the usual presentation — a taxonomy of four NAT types with confusing names — hides a very simple mechanism.
+
+**A NAT is a table with a rewrite rule.** That is all. When a packet leaves your network, the NAT invents a public `(address, port)` for it, writes down the association, and rewrites the source. When a packet comes back to that public port, it looks up the table and rewrites the destination. The table entry is created by outbound traffic and expires after a period of silence (often 30 seconds for UDP, which is why sec 12's consent checks matter).
+
+```text title="one NAT table entry, and the fields a NAT may key on"
+  inside                          outside                    peer
+  192.168.1.34:51000    <-->    203.0.113.7:62145    <-->    198.51.100.5:3478
+  \__________________/          \__________________/         \_______________/
+     what you sent from            what the world sees          who you sent to
+
+  Two independent policy questions, and the whole taxonomy is their answers:
+
+  MAPPING   : when I contact a DIFFERENT peer from 51000, do I get 62145 again?
+  FILTERING : which senders may deliver INBOUND to 62145?
+```
+
+Everything follows from those two questions, so answer them yourself before reading on.
+
+**Mapping** decides whether an address you learned is worth anything. If the NAT reuses `62145` for every destination you contact from local port `51000` — **endpoint-independent mapping** — then the address a STUN server reports back is the same address your peer should aim at, and the whole scheme works. If instead the NAT allocates a fresh public port per destination — **address-dependent mapping**, the behaviour that gives a NAT the name **symmetric** — then the address you learned from the STUN server describes only the path to the STUN server. By the time you tell your peer about it, it is a lie. **This is not a filtering problem you can punch through; the address itself is wrong**, and the only remedy is a relay (sec 11).
+
+**Filtering** decides whether the far peer's packet is admitted. A NAT may accept anything sent to that public port (endpoint-independent), only packets from an address you have contacted (address-dependent), or only from the exact address _and_ port you contacted (address-and-port-dependent, which is the common default). Note that filtering, unlike mapping, is defeatable: if the rule is "only from someone you have contacted", then **contacting them first satisfies it.**
+
+That is exactly the trick.
+
+<Diagram caption="The stand-off, and the trick that breaks it">
+<svg viewBox="0 0 720 260" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Peer A and Peer B behind separate NATs. An unsolicited inbound packet is dropped, but if both peers send outward at the same time each NAT has an entry for the other and the packets get through">
+  <defs>
+    <marker id="nat-x" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0 0 L7 3 L0 6 Z" fill="var(--dg-accent-2)" /></marker>
+    <marker id="nat-o" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0 0 L7 3 L0 6 Z" fill="var(--dg-ok)" /></marker>
+  </defs>
+  <rect x="20" y="30" width="150" height="80" rx="9" fill="var(--dg-surface)" stroke="var(--dg-line)" />
+  <text x="95" y="55" font-size="11" font-weight="700" fill="var(--dg-ink)" text-anchor="middle">Peer A</text>
+  <text x="95" y="74" class="mono" font-size="8.5" fill="var(--dg-ink-2)" text-anchor="middle">192.168.1.34</text>
+  <text x="95" y="92" class="mono" font-size="8.5" fill="var(--dg-ink-2)" text-anchor="middle">:51000</text>
+
+  <rect x="190" y="30" width="90" height="80" rx="9" fill="var(--dg-warn-surface)" stroke="var(--dg-warn-border)" />
+  <text x="235" y="60" font-size="10.5" font-weight="700" fill="var(--dg-warn)" text-anchor="middle">NAT A</text>
+  <text x="235" y="80" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">203.0.113.7</text>
+  <text x="235" y="95" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">:62145</text>
+
+  <rect x="440" y="30" width="90" height="80" rx="9" fill="var(--dg-warn-surface)" stroke="var(--dg-warn-border)" />
+  <text x="485" y="60" font-size="10.5" font-weight="700" fill="var(--dg-warn)" text-anchor="middle">NAT B</text>
+  <text x="485" y="80" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">198.51.100.4</text>
+  <text x="485" y="95" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">:41003</text>
+
+  <rect x="550" y="30" width="150" height="80" rx="9" fill="var(--dg-surface)" stroke="var(--dg-line)" />
+  <text x="625" y="55" font-size="11" font-weight="700" fill="var(--dg-ink)" text-anchor="middle">Peer B</text>
+  <text x="625" y="74" class="mono" font-size="8.5" fill="var(--dg-ink-2)" text-anchor="middle">10.0.0.7</text>
+  <text x="625" y="92" class="mono" font-size="8.5" fill="var(--dg-ink-2)" text-anchor="middle">:49200</text>
+
+  <path fill="none" d="M436 140 H286" stroke="var(--dg-accent-2)" stroke-width="1.6" stroke-dasharray="5 3" marker-end="url(#nat-x)" />
+  <text x="360" y="133" class="mono" font-size="9" fill="var(--dg-accent-2)" text-anchor="middle">unsolicited inbound</text>
+  <text x="360" y="156" font-size="10" font-weight="700" fill="var(--dg-accent-2)" text-anchor="middle">DROPPED: no table entry</text>
+
+  <path fill="none" d="M286 196 H434" stroke="var(--dg-ok)" stroke-width="1.8" marker-end="url(#nat-o)" />
+  <path fill="none" d="M434 214 H288" stroke="var(--dg-ok)" stroke-width="1.8" marker-end="url(#nat-o)" />
+  <text x="360" y="189" class="mono" font-size="9" fill="var(--dg-ok)" text-anchor="middle">both send outward, at the same time</text>
+  <text x="360" y="240" font-size="10" font-weight="700" fill="var(--dg-ok)" text-anchor="middle">each NAT now has an entry for the other: the path is open</text>
+</svg>
+</Diagram>
+
+**Hole punching** is the direct consequence of the filtering rule. If both peers send outward to the other's public address at roughly the same moment, each NAT creates a mapping and an admission rule for the other's traffic, so what would have been an unsolicited inbound packet is now, from the NAT's point of view, a reply to something already sent. The stand-off breaks. Note carefully what it requires: **friendly mapping on at least one side** (so the advertised address is real) and outbound traffic from both (so both filters open). The first packets are usually lost — one side punches before the other — which is why ICE retries rather than giving up.
+
+Combine the two dimensions and you can predict your own failure rate:
+
+| Peer A mapping | Peer B mapping | Direct connection? | Why |
+| -------------- | -------------- | ------------------ | ---- |
+| Endpoint-independent | Endpoint-independent | Yes, reliably | Both advertised addresses are true; filters open on contact |
+| Endpoint-independent | Address-dependent (symmetric) | Usually yes | B's address is wrong, but B can still reach A's true address and A's filter opens |
+| Address-dependent | Address-dependent | **No** | Neither side's advertised address is real. Nothing to aim at. Relay only (sec 11) |
+| Any | UDP blocked entirely | **No** | Corporate firewall; needs TURN over TCP or TLS on 443 (sec 31) |
+
+Row three is the reason 10 to 20 percent of real-world sessions need a relay, and row four is why that relay must also speak TCP on port 443. Carrier-grade NAT on mobile networks and hardened corporate firewalls are the usual offenders, which is why **"it works at home, it fails in the office"** is the single most common WebRTC bug report — and why testing on your own Wi-Fi proves nothing at all.
+
+<Callout type="info" title="A useful reframing">
+People describe NAT traversal as "punching through a firewall", which makes it sound adversarial and unreliable. It is neither. You are working _with_ the NAT's rule, not against it: the rule says "you may receive from anyone you have sent to", and both peers simply send first. What actually fails is never the punching — it is that in the symmetric case there was no correct address to punch toward.
+</Callout>
+
+## STUN: Learning Your Own Address
+
+**STUN answers one question: what does my traffic look like from the outside?** You send a small binding request to a STUN server, and it replies with the source address and port it saw on that packet. That pair, your **server-reflexive address**, is what a peer would have to aim at to reach you through your NAT — provided sec 9's mapping is endpoint-independent.
+
+```text title="a STUN exchange, in full"
+client 192.168.1.34:51000  ->  stun.example.com:3478   Binding Request
+client 192.168.1.34:51000  <-  stun.example.com:3478   Binding Success Response
+                                                        XOR-MAPPED-ADDRESS 203.0.113.7:62145
+```
+
+That is the whole protocol as WebRTC uses it (RFC 8489). Two packets, a few hundred bytes, and it has the useful side effect of **creating the NAT mapping in the first place**. STUN servers are therefore trivially cheap to run — they hold no per-session state at all — which is why every WebRTC tutorial hard-codes `stun:stun.l.google.com:19302` and nobody thinks about it again.
+
+STUN does more work later, and this is the part tutorials skip: **ICE's connectivity checks are themselves STUN messages, sent peer to peer** (sec 12). The same request/response, but between the two peers instead of to a server, is what proves a candidate pair actually works — and, because sending it opens the sender's own NAT filter, the check *is* the hole punch. The same mechanism keeps proving the path for the life of the call (consent freshness, RFC 7675, every 15 seconds, which also refreshes the NAT entry before its 30-second timeout).
+
+<Callout type="warn" title="Public STUN is a dependency you did not review">
+A free public STUN server is fine for a demo and questionable in production: it is an availability dependency you do not control, it sees the IP of every user who starts a call, and it can be rate-limited or withdrawn without notice. STUN is so cheap to self-host (coturn does STUN and TURN in one process, sec 31) that there is little reason not to. What you must never do is ship only STUN and assume connections will work: by the table in sec 9, a fixed fraction of your users are structurally unable to connect without a relay.
+</Callout>
+
+## TURN: Relaying When Nothing Else Works
+
+When both sides have address-dependent mapping, there is no address to aim at, and no amount of retrying invents one. Exactly one option remains: **put a server in the middle that both peers _can_ reach, and have it forward.** That server speaks **TURN** (RFC 8656), which is STUN with relaying bolted on.
+
+The mechanism is an **allocation**. The client asks a TURN server for a relayed transport address; the server allocates a public IP and port on itself and says, in effect, "traffic sent to `turn.example.com:54001` will be forwarded to you, and anything you send through me will appear to come from there". The client advertises that relayed address as one of its ICE candidates. To the far peer it looks like an ordinary public address, and it works, because the TURN server has a real public IP and no NAT problem of its own.
+
+Notice why this always works when nothing else does: the client's connection **to** the TURN server is ordinary outbound traffic, which every NAT and nearly every firewall permits. The relay is not defeating the NAT; it is standing on the correct side of it.
+
+<Diagram caption="What each candidate type costs you">
+<svg viewBox="0 0 720 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Three ways a packet can travel: host to host on the same network, server reflexive directly through both NATs, or relayed through a TURN server">
+  <rect x="20" y="24" width="680" height="62" rx="10" fill="var(--dg-ok-surface)" stroke="var(--dg-ok-border)" />
+  <text x="40" y="46" font-size="11" font-weight="700" fill="var(--dg-ok)">host</text>
+  <text x="120" y="46" class="mono" font-size="9" fill="var(--dg-ink-2)">192.168.1.34:51000</text>
+  <text x="300" y="46" font-size="10" fill="var(--dg-ink)">same LAN or VPN, no NAT in the way</text>
+  <text x="40" y="70" class="mono" font-size="9" fill="var(--dg-ok)">lowest latency · zero server cost · works for maybe 10% of sessions</text>
+
+  <rect x="20" y="96" width="680" height="62" rx="10" fill="var(--dg-warn-surface)" stroke="var(--dg-warn-border)" />
+  <text x="40" y="118" font-size="11" font-weight="700" fill="var(--dg-warn)">srflx</text>
+  <text x="120" y="118" class="mono" font-size="9" fill="var(--dg-ink-2)">203.0.113.7:62145</text>
+  <text x="300" y="118" font-size="10" fill="var(--dg-ink)">public face of your NAT, learned from STUN</text>
+  <text x="40" y="142" class="mono" font-size="9" fill="var(--dg-warn)">direct path · server cost is two packets · the case you want, ~70-80%</text>
+
+  <rect x="20" y="168" width="680" height="62" rx="10" fill="var(--dg-accent-surface)" stroke="var(--dg-accent-border)" />
+  <text x="40" y="190" font-size="11" font-weight="700" fill="var(--dg-accent-2)">relay</text>
+  <text x="120" y="190" class="mono" font-size="9" fill="var(--dg-ink-2)">turn.example.com:54001</text>
+  <text x="300" y="190" font-size="10" fill="var(--dg-ink)">a port on a TURN server that forwards to you</text>
+  <text x="40" y="214" class="mono" font-size="9" fill="var(--dg-accent-2)">always works · you pay for every byte, twice · adds a hop of latency</text>
+</svg>
+</Diagram>
+
+The economics are the whole story with TURN, and they follow from the topology. A relayed 1080p call at 2.5 Mbps costs the relay 2.5 Mbps **in and 2.5 Mbps out**, for the whole call, in each direction — the server is a full participant in the byte stream. A STUN server, by contrast, handles a few packets per session and can serve a million users from one small box. That asymmetry drives every operational decision in sec 31: place TURN close to users so the detour does not blow the latency budget from sec 2, size servers by bandwidth rather than CPU, and above all keep the fraction of sessions that relay as low as you can, because **that fraction _is_ your media bill**.
+
+<Callout type="warn" title="An open TURN server will be found and abused">
+A TURN server that accepts unauthenticated allocations is an open proxy with good bandwidth, and scanners find them within days. It will be used to relay attack traffic, scrape sites, or hop into your own private network if it sits inside your VPC. TURN must require credentials, and those credentials must be short-lived, per-session ones minted by your backend, never a static username and password shipped in your JavaScript (sec 31 has the code).
+</Callout>
+
+## ICE: the Algorithm That Ties It Together
+
+You now have three kinds of address and no way to know which will work — because, as sec 9 showed, the answer depends on the behaviour of two middleboxes that publish nothing about themselves. There is no query you can send that returns "your peer is reachable at X". So the only correct algorithm is empirical: **try everything in parallel and keep whatever answers.**
+
+That is **ICE, Interactive Connectivity Establishment** (RFC 8445). Its brute-force character is often mistaken for inelegance; it is the opposite. Given a network that will not describe itself, exhaustive probing is the only method that cannot be fooled. It is also the single most important thing to understand operationally, because **when a call fails to connect, it failed here.**
+
+ICE runs in four phases.
+
+**1. Gather candidates.** The peer enumerates every address it might be reachable at: each local interface (**host** candidates, including IPv6 and VPN interfaces), the public mapping learned from each STUN server (**srflx**), and an allocation on each TURN server (**relay**). A typical laptop produces six to twelve.
+
+**2. Exchange them.** Candidates go to the other peer through signaling. They can be sent all at once after gathering finishes, or — far better — **trickled**: emitted one at a time as they are discovered (RFC 8838), so checking starts while the slow ones are still being set up. The saving is real and it is structural: a TURN allocation involves a round trip to the relay plus authentication, so waiting for it before sending anything adds its full latency to every call, including the majority that will never use it. Trickle ICE typically cuts a second or more off setup, and every serious implementation uses it.
+
+**3. Check pairs.** Each side forms the cross product of its candidates with the remote ones, giving up to a few dozen **candidate pairs**, sorts them by a priority formula that prefers host over srflx over relay, and sends a STUN binding request on each. A pair whose request is answered **in both directions** is **valid**: a real, working, bidirectional path. Both directions matter — a one-way path is not a call.
+
+**4. Nominate.** The controlling side picks the best valid pair, flags it as nominated, and media starts flowing on it. The others are kept as spares.
+
+<Diagram caption="Candidate pairs, checked in priority order">
+<svg viewBox="0 0 720 290" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="A table of candidate pairs: host to host fails, server reflexive to server reflexive succeeds and is nominated, relay pairs are kept as backup">
+  <text x="30" y="28" class="mono" font-size="9.5" font-weight="700" fill="var(--dg-ink-2)">LOCAL</text>
+  <text x="250" y="28" class="mono" font-size="9.5" font-weight="700" fill="var(--dg-ink-2)">REMOTE</text>
+  <text x="470" y="28" class="mono" font-size="9.5" font-weight="700" fill="var(--dg-ink-2)">PRIORITY</text>
+  <text x="580" y="28" class="mono" font-size="9.5" font-weight="700" fill="var(--dg-ink-2)">CHECK</text>
+  <line x1="24" y1="38" x2="696" y2="38" stroke="var(--dg-line)" stroke-width="1" />
+
+  <rect x="24" y="48" width="672" height="40" rx="7" fill="var(--dg-surface)" stroke="var(--dg-line)" />
+  <text x="34" y="73" class="mono" font-size="9" fill="var(--dg-ink-2)">host 192.168.1.34</text>
+  <text x="254" y="73" class="mono" font-size="9" fill="var(--dg-ink-2)">host 10.0.0.7</text>
+  <text x="474" y="73" class="mono" font-size="9" fill="var(--dg-ink-2)">highest</text>
+  <text x="584" y="73" font-size="10" font-weight="700" fill="var(--dg-accent-2)">timeout, different LANs</text>
+
+  <rect x="24" y="96" width="672" height="40" rx="7" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)" stroke-width="1.6" />
+  <text x="34" y="121" class="mono" font-size="9" fill="var(--dg-ink-2)">srflx 203.0.113.7</text>
+  <text x="254" y="121" class="mono" font-size="9" fill="var(--dg-ink-2)">srflx 198.51.100.4</text>
+  <text x="474" y="121" class="mono" font-size="9" fill="var(--dg-ink-2)">high</text>
+  <text x="584" y="121" font-size="10" font-weight="700" fill="var(--dg-ok)">valid -> NOMINATED</text>
+
+  <rect x="24" y="144" width="672" height="40" rx="7" fill="var(--dg-surface)" stroke="var(--dg-line)" />
+  <text x="34" y="169" class="mono" font-size="9" fill="var(--dg-ink-2)">relay turn:54001</text>
+  <text x="254" y="169" class="mono" font-size="9" fill="var(--dg-ink-2)">srflx 198.51.100.4</text>
+  <text x="474" y="169" class="mono" font-size="9" fill="var(--dg-ink-2)">low</text>
+  <text x="584" y="169" font-size="10" fill="var(--dg-ink-2)">valid, kept as backup</text>
+
+  <rect x="24" y="192" width="672" height="40" rx="7" fill="var(--dg-surface)" stroke="var(--dg-line)" />
+  <text x="34" y="217" class="mono" font-size="9" fill="var(--dg-ink-2)">relay turn:54001</text>
+  <text x="254" y="217" class="mono" font-size="9" fill="var(--dg-ink-2)">relay turn:54118</text>
+  <text x="474" y="217" class="mono" font-size="9" fill="var(--dg-ink-2)">lowest</text>
+  <text x="584" y="217" font-size="10" fill="var(--dg-ink-2)">valid, last resort</text>
+
+  <text x="360" y="262" font-size="11" font-style="italic" fill="var(--dg-ink-2)" text-anchor="middle">Checks are STUN requests sent peer to peer. A pair is valid only when it answers in both directions.</text>
+  <text x="360" y="280" font-size="11" font-style="italic" fill="var(--dg-ink-2)" text-anchor="middle">If every pair fails, the connection state goes to "failed", and that is the bug you will actually see.</text>
+</svg>
+</Diagram>
+
+An individual candidate on the wire is one line, and you will read these in logs constantly:
+
+```text title="one ICE candidate, decoded"
+a=candidate:842163049 1 udp 1677729535 203.0.113.7 62145 typ srflx raddr 192.168.1.34 rport 51000
+                      |  |       |          |         |       |            |
+                      |  |       |          |         |       |            the local address behind it
+                      |  |       |          |         |       type: host / srflx / prflx / relay
+                      |  |       |          |         the port to aim at
+                      |  |       |          the address to aim at
+                      |  |       priority, higher is tried first
+                      |  transport
+                      component: 1 = RTP (2 = RTCP, unless rtcp-mux, which is always)
+```
+
+The fourth type, **prflx** (peer-reflexive), is the one nobody explains: it appears when a connectivity check arrives from an address that was never advertised. That happens exactly in the sec 9 case where a NAT allocated a different port for peer traffic than it did for STUN traffic — so the peer discovers a working address that neither side could have predicted. ICE learns it on the spot and adds it to the list. Empirical probing pays for itself.
+
+Two more ICE behaviours matter in production. **ICE restart** re-runs gathering and checking on an existing connection without tearing down the call, which is how a session survives a laptop moving from Wi-Fi to Ethernet or a phone handing over to cellular: the old path dies, a new one is negotiated, media resumes. And **consent freshness** keeps sending STUN checks on the chosen pair for the life of the call; if they stop being answered for a few seconds the connection is declared failed rather than sitting there silently dead. That is the same liveness principle as WebSocket heartbeats (the WebSockets chapter, sec 7) applied to a UDP path — and it doubles as the NAT keepalive from sec 9.
+
+<Callout type="info" title="Reading an ICE failure, in order">
+Resist guessing; the browser exposes the whole state machine and candidate list, and the answer is nearly always visible.
+**No relay candidates gathered at all** → TURN credentials wrong or expired, or the TURN server unreachable (sec 31).
+**Candidates gathered, every pair fails** → UDP is blocked; you need TURN over TCP or TLS on 443 (sec 31).
+**Only relay pairs succeed** → normal for symmetric NAT; watch the rate, because it is your bill (sec 34).
+**Connected, then failed after a few seconds** → consent checks stopped being answered; something in the middle dropped the mapping, or a media server was rolled (sec 33).
+**Works on your laptop, fails for a user** → sec 9, row three or four. Test from a mobile hotspot and a corporate network before you believe anything.
+</Callout>
+
+<Callout type="info" title="ICE-lite, for the server side">
+A server with a public IP and no NAT does not need to gather, prioritise or probe — it has exactly one address and it works. **ICE-lite** is the reduced role for such endpoints: it never sends connectivity checks, only answers them, and never nominates. Most SFUs and media gateways run ICE-lite, which is why sec 33 insists a media server must know and advertise its real public address: with ICE-lite there is no discovery step to paper over a wrong one, and no second candidate to fall back to.
+</Callout>
+Part III / The Media Path
+
+## DTLS and SRTP: Encryption Is Not Optional
+
+Once ICE has a working path, nothing is sent in the clear, ever. **WebRTC has no unencrypted mode** — no flag, no plaintext fallback, no "just for local testing". Every implementation must encrypt, so every deployment does.
+
+Moves 4 and 5 derived the shape. **DTLS** is TLS adapted to datagrams: the same handshake, certificates and cipher suites, but with its own sequence numbers and retransmission timers so the handshake completes over a path that loses and reorders. It runs over the ICE-selected path as soon as that path is valid. But DTLS does not carry the media, for the two reasons move 5 gave: per-record overhead against a 1200-byte budget, and — decisively — a middlebox that must route packets without holding the keys. So the handshake's job is to **agree on keys and then get out of the way**. The keys are exported (DTLS-SRTP, RFC 5764) and handed to **SRTP** (RFC 3711), which encrypts the payload, authenticates the header, and leaves the header readable.
+
+The identity problem from move 6 is solved without any public key infrastructure. WebRTC peers use **self-signed certificates**, which normally prove nothing. But the offer carried `a=fingerprint`, a hash of the certificate the peer will present. The receiver checks the certificate offered during the handshake against the fingerprint it received through signaling, and aborts if they differ. **The trust comes from your signaling channel, not from a certificate authority** — which is the entire content of the warning in sec 7.
+
+<Diagram caption="From click to first frame">
+<svg viewBox="0 0 720 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="A timeline of connection setup: signaling exchange, ICE gathering and checks, DTLS handshake with key export, then SRTP media flowing">
+  <defs>
+    <marker id="tl-a" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0 0 L7 3 L0 6 Z" fill="var(--dg-ink-2)" /></marker>
+  </defs>
+  <rect x="20" y="40" width="150" height="70" rx="10" fill="var(--dg-info-surface)" stroke="var(--dg-info-border)" />
+  <text x="95" y="64" font-size="11" font-weight="700" fill="var(--dg-info)" text-anchor="middle">1 / Signaling</text>
+  <text x="95" y="82" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">offer, answer,</text>
+  <text x="95" y="96" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">fingerprints, ufrag</text>
+
+  <path fill="none" d="M174 75 H196" stroke="var(--dg-ink-2)" stroke-width="1.5" marker-end="url(#tl-a)" />
+
+  <rect x="200" y="40" width="150" height="70" rx="10" fill="var(--dg-warn-surface)" stroke="var(--dg-warn-border)" />
+  <text x="275" y="64" font-size="11" font-weight="700" fill="var(--dg-warn)" text-anchor="middle">2 / ICE</text>
+  <text x="275" y="82" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">gather, check pairs,</text>
+  <text x="275" y="96" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">nominate a path</text>
+
+  <path fill="none" d="M354 75 H376" stroke="var(--dg-ink-2)" stroke-width="1.5" marker-end="url(#tl-a)" />
+
+  <rect x="380" y="40" width="150" height="70" rx="10" fill="var(--dg-ok-surface)" stroke="var(--dg-ok-border)" />
+  <text x="455" y="64" font-size="11" font-weight="700" fill="var(--dg-ok)" text-anchor="middle">3 / DTLS</text>
+  <text x="455" y="82" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">handshake, verify</text>
+  <text x="455" y="96" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">fingerprint, export keys</text>
+
+  <path fill="none" d="M534 75 H556" stroke="var(--dg-ink-2)" stroke-width="1.5" marker-end="url(#tl-a)" />
+
+  <rect x="560" y="40" width="140" height="70" rx="10" fill="var(--dg-accent)" />
+  <text x="630" y="64" font-size="11" font-weight="700" fill="var(--dg-on-accent)" text-anchor="middle">4 / SRTP</text>
+  <text x="630" y="82" class="mono" font-size="8" fill="var(--dg-on-accent)" text-anchor="middle">media flows,</text>
+  <text x="630" y="96" class="mono" font-size="8" fill="var(--dg-on-accent)" text-anchor="middle">RTCP feeds back</text>
+
+  <rect x="20" y="140" width="680" height="40" rx="8" fill="var(--dg-surface)" stroke="var(--dg-line)" />
+  <text x="34" y="165" class="mono" font-size="9" fill="var(--dg-ink-2)">typical budget:  ~50-150ms signaling  ·  ~50-300ms ICE (trickle helps most here)  ·  ~2 RTT DTLS  ·  then continuous</text>
+
+  <text x="360" y="212" font-size="11" font-style="italic" fill="var(--dg-ink-2)" text-anchor="middle">Everything before step 4 is setup you pay once. Everything after is the control loop you pay forever (sec 19).</text>
+  <text x="360" y="234" font-size="11" font-style="italic" fill="var(--dg-ink-2)" text-anchor="middle">Slow call setup is nearly always ICE waiting on a TURN allocation that trickle would have overlapped.</text>
+</svg>
+</Diagram>
+
+<Callout type="info" title="Which side starts the handshake">
+The SDP carries `a=setup:actpass` in the offer and `a=setup:active` or `a=setup:passive` in the answer, deciding who plays DTLS client. It matters more than it looks: the `active` side sends the ClientHello, so if both sides somehow choose `passive`, the handshake never starts and you get a connection that reaches the ICE `connected` state and then stalls forever with no media and no error. When a call connects but produces silence in both directions, check `a=setup` before anything else.
+</Callout>
+
+## RTP and RTCP: How Media Actually Moves
+
+Media on the wire is **RTP** (RFC 3550), and move 2 already derived why it contains what it contains: a 12-byte header adding exactly the things UDP left out.
+
+<Diagram caption="The RTP header, and what each field is for">
+<svg viewBox="0 0 720 240" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="RTP header fields: version, payload type, sequence number, timestamp, SSRC and then the encrypted payload">
+  <rect x="20" y="30" width="70" height="46" rx="6" fill="var(--dg-surface-2)" stroke="var(--dg-line)" />
+  <text x="55" y="50" font-size="9.5" font-weight="700" fill="var(--dg-ink)" text-anchor="middle">V P X CC</text>
+  <text x="55" y="66" class="mono" font-size="7.5" fill="var(--dg-ink-2)" text-anchor="middle">flags</text>
+
+  <rect x="94" y="30" width="60" height="46" rx="6" fill="var(--dg-warn)" />
+  <text x="124" y="50" font-size="9.5" font-weight="700" fill="var(--dg-on-accent)" text-anchor="middle">M</text>
+  <text x="124" y="66" class="mono" font-size="7.5" fill="var(--dg-on-accent)" text-anchor="middle">marker</text>
+
+  <rect x="158" y="30" width="90" height="46" rx="6" fill="var(--dg-info)" />
+  <text x="203" y="50" font-size="9.5" font-weight="700" fill="var(--dg-on-accent)" text-anchor="middle">PT</text>
+  <text x="203" y="66" class="mono" font-size="7.5" fill="var(--dg-on-accent)" text-anchor="middle">which codec</text>
+
+  <rect x="252" y="30" width="130" height="46" rx="6" fill="var(--dg-ok)" />
+  <text x="317" y="50" font-size="9.5" font-weight="700" fill="var(--dg-on-accent)" text-anchor="middle">sequence number</text>
+  <text x="317" y="66" class="mono" font-size="7.5" fill="var(--dg-on-accent)" text-anchor="middle">+1 per packet</text>
+
+  <rect x="386" y="30" width="140" height="46" rx="6" fill="var(--dg-plum)" />
+  <text x="456" y="50" font-size="9.5" font-weight="700" fill="var(--dg-on-accent)" text-anchor="middle">timestamp</text>
+  <text x="456" y="66" class="mono" font-size="7.5" fill="var(--dg-on-accent)" text-anchor="middle">sampling clock</text>
+
+  <rect x="530" y="30" width="170" height="46" rx="6" fill="var(--dg-accent)" />
+  <text x="615" y="50" font-size="9.5" font-weight="700" fill="var(--dg-on-accent)" text-anchor="middle">SSRC</text>
+  <text x="615" y="66" class="mono" font-size="7.5" fill="var(--dg-on-accent)" text-anchor="middle">which stream</text>
+
+  <rect x="20" y="88" width="680" height="42" rx="6" fill="var(--dg-inverse)" />
+  <text x="360" y="106" font-size="10.5" font-weight="700" fill="var(--dg-on-inverse-info)" text-anchor="middle">payload: encoded media, encrypted by SRTP</text>
+  <text x="360" y="122" class="mono" font-size="8" fill="var(--dg-on-inverse-3)" text-anchor="middle">header stays readable so routers, SFUs and the receiver can do their jobs</text>
+
+  <g class="mono" font-size="9" fill="var(--dg-ink)">
+    <text x="20" y="158">sequence number  -> detect loss and reordering; ask for a retransmission (sec 18)</text>
+    <text x="20" y="178">timestamp        -> when to PLAY this, not when it arrived; drives the jitter buffer</text>
+    <text x="20" y="198">SSRC             -> identifies one stream inside a bundled transport; how an SFU routes</text>
+    <text x="20" y="218">marker bit       -> for video, "this packet ends a frame"; for audio, "talk spurt starts"</text>
+  </g>
+</svg>
+</Diagram>
+
+The separation of **sequence number** from **timestamp** is the design insight, and it is worth being precise about why both are needed rather than one. Sequence numbers count *packets* and exist to detect loss and reordering. Timestamps name the *media instant* a sample belongs to. They are not redundant because the mapping between them is not one to one in either direction: a single video frame is split across many packets that all share **one timestamp** (constraint 3 — a 60 KB keyframe is fifty packets), and a silence-suppressed audio stream can advance its timestamp by seconds while the sequence number advances by one. Together they answer both questions a receiver has: *is anything missing*, and *when should this be shown*.
+
+Alongside RTP runs **RTCP**, the control channel derived in move 3, on the same port thanks to `rtcp-mux`. RTCP carries no media, only feedback, and this feedback is what makes the system adaptive rather than blind:
+
+| RTCP message                | Sent by  | Means                                                          |
+| --------------------------- | -------- | -------------------------------------------------------------- |
+| **SR** (sender report)      | sender   | "This RTP timestamp was this wall-clock time" — the basis of lip sync (sec 16) |
+| **RR** (receiver report)    | receiver | Periodic stats: packets lost, jitter, round-trip time           |
+| **NACK**                    | receiver | "I never got sequence 1042, send it again" (sec 18)             |
+| **PLI / FIR**               | receiver | "I cannot decode, send a keyframe" (picture loss indication)     |
+| **REMB**                    | receiver | "Please cap your bitrate at N" (older bandwidth estimation)      |
+| **TWCC**                    | receiver | Arrival time of *every* packet, so the _sender_ estimates capacity (sec 19) |
+
+<Callout type="info" title="Why the header is not encrypted, restated as a design constraint">
+SRTP encrypts the payload and authenticates the header but leaves it legible. That is what lets an SFU (sec 28) forward a packet to twelve people without decrypting media: it reads the SSRC and sequence number, rewrites what it must, and passes the ciphertext along untouched. It is also exactly why a plain SFU cannot give you end-to-end encryption — it terminates SRTP per hop and holds real keys. Getting true E2EE through an SFU needs a second encryption layer *inside* the payload (sec 35). The readable header is not an oversight; it is the price of a routable media plane, and E2EE is the price of that price.
+</Callout>
+
+## Header Extensions: the Metadata a Router Can Read
+
+The readable header buys more than routing, and this section covers the mechanism that most WebRTC explanations skip entirely even though the modern stack cannot function without it.
+
+Twelve bytes of RTP header were enough in 1996. They are not enough to run congestion control, simulcast, active-speaker detection or bundling. But you cannot put that information in the payload, because **the payload is encrypted and the SFU has no reason to decrypt it** — and decrypting a thousand streams to read one byte would destroy the economics of sec 28. So the information goes into **RTP header extensions** (RFC 8285): small tagged values that ride in the header area, negotiated in the SDP with `a=extmap` lines, and readable by any middlebox on the path.
+
+| Extension                 | Carries                                     | Who needs it and why                                     |
+| ------------------------- | ------------------------------------------- | --------------------------------------------------------- |
+| `transport-wide-cc`       | A per-packet sequence number across **all** streams | The receiver timestamps each arrival; the sender estimates bandwidth (sec 19) |
+| `abs-send-time`           | When the sender put it on the wire          | Lets a receiver measure one-way delay trend without clock sync |
+| `mid`                     | Which media section this packet belongs to  | Demultiplexing a BUNDLE'd transport before any SSRC is known |
+| `rid` / `repaired-rid`    | Which simulcast layer this is               | The SFU picks a layer per subscriber without decoding (sec 30) |
+| `ssrc-audio-level`        | Loudness of this audio packet, in −dBov     | Active-speaker detection without decrypting audio (sec 29) |
+| `video-orientation`       | Phone rotation                              | The renderer rotates instead of the encoder re-encoding    |
+| `playout-delay`           | A requested min/max buffer                  | Lets an application trade latency for smoothness deliberately (sec 18) |
+| `dependency-descriptor`   | This frame's layer and what it references   | SVC forwarding decisions, again without decoding (sec 30)  |
+
+Read that column of reasons and a pattern jumps out: **almost every extension exists so that a server can make a decision about a packet it is not allowed to look inside.** Header extensions are the interface between the encrypted media plane and the infrastructure that routes it. When you understand that, the SFU in sec 28 stops being magic — it is a router acting entirely on metadata it was deliberately handed.
+
+<Callout type="warn" title="The extensions are metadata leaks, and there is a fix">
+Anything an SFU can read, a network observer can read: who is speaking and when (`ssrc-audio-level`) is a meaningful privacy leak even when the audio is perfectly encrypted, since it reconstructs the entire turn-taking structure of a private conversation. **Cryptex** (RFC 9335) encrypts header extensions while keeping the base RTP header readable, closing that gap for peers that support it. If you are building anything where the *pattern* of a conversation is sensitive, negotiate it — and note it interacts with sec 29, since an SFU that cannot read audio levels needs another way to rank speakers.
+</Callout>
+
+## Clocks, Timestamps and the Lip Sync Problem
+
+Here is a question the RTP header seems to answer and does not: **how do audio and video stay in sync?**
+
+They are two separate RTP streams, with two separate SSRCs, and — this is the part that surprises people — two timestamp spaces that have nothing to do with each other. Video uses a 90 kHz clock, audio typically 48 kHz. Worse, RFC 3550 requires each stream's timestamp to **start at a random value**, so that a captured stream reveals nothing about how long the session has run. Audio timestamp 4,113,220,096 and video timestamp 88,201 might be the same instant, or three seconds apart. Nothing inside RTP can tell you.
+
+The missing piece is the **RTCP Sender Report**, and this is its real job. Every few seconds, each sender transmits a pair:
+
+```text title="the sender report, and the correspondence it establishes"
+  audio SR :  NTP wall clock 1793214451.732   <->   RTP timestamp 4113220096  (48 kHz)
+  video SR :  NTP wall clock 1793214451.749   <->   RTP timestamp      88201  (90 kHz)
+
+  Both name the SAME sender clock, so the receiver can now convert either
+  stream's timestamps into wall-clock time, and therefore to each other:
+
+     audio ts + 48000 ticks  ==  +1.000s wall clock
+     video ts + 90000 ticks  ==  +1.000s wall clock
+
+  Line them up on that shared axis and you have lip sync. Without a sender
+  report for a stream, a receiver has no basis to align it at all — which is
+  exactly what "audio is ahead of the video by half a second" looks like.
+```
+
+So lip sync is not a feature of the media path; it is **a derived quantity that depends on RTCP arriving**. That has a practical consequence worth remembering: a middlebox or firewall that drops RTCP while forwarding RTP produces a call where both streams play, both look healthy, and they drift apart. It is also why an SFU must generate correct sender reports for the streams it forwards (sec 28) rather than passing the publisher's through unchanged — it has rewritten the timestamps, so the original correspondence is no longer true.
+
+#### The second clock problem: drift
+
+There is a subtler issue that has nothing to do with the network. The sender's audio hardware samples at "48 kHz" and the receiver's plays at "48 kHz", but both figures come from crystal oscillators with a tolerance of perhaps 50 parts per million. If the sender runs 50 ppm fast, it produces 48,002.4 samples per second while the receiver consumes 48,000.
+
+```text title="drift accumulates without bound"
+  50 ppm  =  50 microseconds per second
+          =  180 ms per hour
+```
+
+Three minutes into the call the buffer has grown by 9ms; an hour in, the receiver is either 180ms behind or has run out of audio 180ms early. **Neither endpoint has lost a packet or made a mistake.** The fix is continuous and invisible: the receiver measures the long-term trend of its buffer level and slowly **resamples** the audio — stretching or compressing it by a fraction of a percent, far below the threshold of hearing — to hold the buffer steady. Video is easier, since a frame can be shown for one refresh longer or dropped without anyone noticing.
+
+<Callout type="info" title="Why this section earns its place">
+Clock handling is where "the call was fine for twenty minutes and then went strange" comes from. Progressive audio/video drift, audio that gradually gains or loses latency, a buffer that grows all call: none of these are loss or congestion problems, and looking at loss and RTT dashboards will show you nothing. They are clock problems, and they show up in `getStats()` as a steadily climbing `jitterBufferDelay` with flat `packetsLost` (sec 34).
+</Callout>
+
+## Codecs and What Negotiation Really Decides
+
+Constraint 4 established the job: 200:1 or better. This section is about who does it and what negotiation actually settles.
+
+WebRTC mandates a floor so that any two endpoints can always talk: **Opus and G.711 for audio** (RFC 7874), **VP8 and H.264 for video** (RFC 7742). Beyond the floor, browsers offer VP9 and AV1, and negotiation picks the best both sides support.
+
+For audio there is effectively one answer. **Opus** covers 6 kbps of intelligible speech through 128 kbps of stereo music in one codec, changes bitrate on the fly without renegotiating, and ships two features that matter enormously on bad networks. **In-band FEC** piggybacks a low-quality copy of the previous frame onto the next packet, so a single loss is repaired with no retransmission and no added latency — which, by the inequality in sec 18, is the only repair that works when the round trip is long. **DTX**, discontinuous transmission, stops sending during silence and drops a quiet participant's bitrate to near zero, which is what makes a fifty-person meeting affordable when only one person is talking.
+
+For video the choice is a real trade-off:
+
+| Codec      | Efficiency        | Hardware support         | Choose it when                                           |
+| ---------- | ----------------- | ------------------------ | -------------------------------------------------------- |
+| **H.264**  | baseline          | near universal, hardware | Mobile fleets and battery life; interop with SIP and older devices |
+| **VP8**    | similar to H.264  | mostly software          | The safe default, no licensing questions, universal in browsers |
+| **VP9**    | ~30% better       | patchy                   | You want SVC (sec 30) and can afford the CPU              |
+| **AV1**    | ~30% better again | improving, newer devices | Low-bitrate quality matters most; screen sharing; SVC     |
+
+Two practical facts about codecs cost people days.
+
+**Profiles must match, not just names.** Two endpoints can both "support H.264" and still fail, because one offers constrained baseline and the other only high profile, or because the hardware decoder refuses a level it advertised. The negotiated line is `a=fmtp:98 profile-level-id=42e01f`, and a mismatch there is a black video rectangle with a perfectly healthy connection.
+
+**Keyframes are expensive and load-bearing** — this is constraint 5 arriving in your bug tracker. A keyframe is 10 to 20 times a delta frame, and by constraint 3 it is fifty packets rather than three. Three consequences follow, and all three are things you will observe:
+
+- A **PLI is not free.** Requesting a keyframe means asking the publisher to emit a 60 KB burst into a link that congestion control had carefully budgeted for 5 KB frames. Ask too often and you cause the congestion you were recovering from.
+- **A participant joining a call causes a visible bitrate spike**, because they need a keyframe from everyone they subscribe to. Fifty people joining at the top of the hour is a coordinated storm, which is why sec 28's coalescing exists.
+- **Loss hurts keyframes disproportionately.** At 1% independent packet loss, a 3-packet delta frame survives 97% of the time; a 50-packet keyframe survives only `0.99⁵⁰ ≈ 60%`. The frame that repairs the stream is the frame most likely to be destroyed in transit — which is why a badly degraded video call gets *stuck* rather than merely blurry, and why sec 18's repair ordering matters so much.
+
+<Callout type="info" title="The screen-share special case">
+Screen content breaks every assumption above. It is mostly static, then changes completely when you switch windows; it has hard edges and text where camera codecs assume smooth gradients; and legibility matters more than frame rate. So treat it as a different medium: prefer a content hint of `detail` or `text`, accept a low frame rate for a high resolution (5fps of readable text beats 30fps of mush), and prefer VP9 or AV1, whose screen-content tools are markedly better. Sending a shared screen through camera-tuned settings is one of the most common quality complaints in production.
+</Callout>
+
+## Loss, Jitter and the Repair Toolbox
+
+The network delivers packets late, out of order and not at all. A receiver that played whatever arrived, the instant it arrived, would produce unwatchable video and unlistenable audio. Every WebRTC endpoint therefore runs repair mechanisms whose entire purpose is to **trade latency for quality** — and since sec 2 showed the latency budget is nearly exhausted before you start, knowing exactly what each mechanism costs is the difference between tuning and guessing.
+
+The centrepiece is the **jitter buffer**. Packets arrive with varying delay (that variance _is_ jitter); the buffer holds them briefly, reorders them by sequence number, and releases them on a smooth clock. Its depth is the tuning knob, and it is a **pure latency tax**: every millisecond of buffer is a millisecond added to the mouth-to-ear budget. Modern implementations adapt the depth continuously to measured jitter, which is why a call gets subtly laggier when Wi-Fi degrades and tightens again when it recovers.
+
+For audio the adaptation is cleverer than simply "hold more packets". Growing the buffer means the receiver must consume audio slightly slower than it arrives, and shrinking it means consuming faster — both of which would change pitch if done naively. So the buffer **time-stretches** the waveform instead: it finds a pitch period and repeats or removes one, lengthening or shortening a 20ms frame by a few milliseconds with no audible pitch change. This is the same machinery that fixes clock drift in sec 16, and it is why an audio call can silently absorb a network hiccup that would visibly freeze the video.
+
+<Diagram caption="The repair toolbox, from cheapest to most expensive">
+<svg viewBox="0 0 720 270" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Four repair mechanisms ordered by cost: forward error correction, retransmission, concealment, and keyframe request">
+  <rect x="20" y="26" width="330" height="70" rx="10" fill="var(--dg-ok-surface)" stroke="var(--dg-ok-border)" />
+  <text x="36" y="48" font-size="11" font-weight="700" fill="var(--dg-ok)">FEC · send redundancy up front</text>
+  <text x="36" y="68" font-size="9.5" fill="var(--dg-ink-2)">Opus in-band FEC, flexfec for video.</text>
+  <text x="36" y="84" class="mono" font-size="8.5" fill="var(--dg-ink-2)">costs bandwidth always · repairs instantly · no RTT</text>
+
+  <rect x="370" y="26" width="330" height="70" rx="10" fill="var(--dg-info-surface)" stroke="var(--dg-info-border)" />
+  <text x="386" y="48" font-size="11" font-weight="700" fill="var(--dg-info)">NACK + RTX · ask for it again</text>
+  <text x="386" y="68" font-size="9.5" fill="var(--dg-ink-2)">Receiver names the missing sequence number.</text>
+  <text x="386" y="84" class="mono" font-size="8.5" fill="var(--dg-ink-2)">costs one RTT · only worth it if RTT fits in the buffer</text>
+
+  <rect x="20" y="110" width="330" height="70" rx="10" fill="var(--dg-warn-surface)" stroke="var(--dg-warn-border)" />
+  <text x="36" y="132" font-size="11" font-weight="700" fill="var(--dg-warn)">Concealment · fake it</text>
+  <text x="36" y="152" font-size="9.5" fill="var(--dg-ink-2)">Audio PLC invents a plausible 20ms; video freezes.</text>
+  <text x="36" y="168" class="mono" font-size="8.5" fill="var(--dg-ink-2)">free · always available · quality degrades gracefully</text>
+
+  <rect x="370" y="110" width="330" height="70" rx="10" fill="var(--dg-accent-surface)" stroke="var(--dg-accent-border)" />
+  <text x="386" y="132" font-size="11" font-weight="700" fill="var(--dg-accent-2)">PLI · start over with a keyframe</text>
+  <text x="386" y="152" font-size="9.5" fill="var(--dg-ink-2)">The decoder gives up and asks for a fresh reference.</text>
+  <text x="386" y="168" class="mono" font-size="8.5" fill="var(--dg-accent-2)">costs a bitrate spike · visible stutter · last resort</text>
+
+  <rect x="20" y="196" width="680" height="52" rx="10" fill="var(--dg-inverse)" />
+  <text x="360" y="218" font-size="11" font-weight="700" fill="var(--dg-on-inverse)" text-anchor="middle">The jitter buffer is what buys time for all of them</text>
+  <text x="360" y="238" class="mono" font-size="8.5" fill="var(--dg-on-inverse-2)" text-anchor="middle">deeper buffer = more repair possible = more latency. That single trade-off defines your product.</text>
+</svg>
+</Diagram>
+
+#### When is a retransmission worth asking for?
+
+This is the one piece of arithmetic in the repair toolbox, and it decides which mechanism you should be spending bandwidth on.
+
+A NACK is useful only if the replacement packet arrives **before the moment that packet was going to be played**. So:
+
+```text title="the NACK inequality"
+   detect the gap      ≈  one packet interval after the loss
+ + send the NACK       ≈  RTT / 2
+ + sender responds     ≈  a few ms
+ + replacement arrives ≈  RTT / 2
+   ------------------------------------------
+   total  ≈  RTT + a few ms      must be  <  time left in the jitter buffer
+
+   Local network,   RTT  20ms, buffer  60ms  ->  20 < 60   ✓ retransmit, easily twice
+   Cross-country,   RTT 120ms, buffer 100ms  ->  120 > 100 ✗ too late; use FEC instead
+   Satellite,       RTT 600ms, buffer 200ms  ->  hopeless; FEC or nothing
+```
+
+That inequality is the whole design rule. **On short paths, retransmission is nearly free and strictly better than FEC**, because it costs bandwidth only when something is actually lost. **On long paths, retransmission is bandwidth spent on a packet that will arrive too late to be played**, and the same bandwidth should have gone to forward error correction, which pays a constant premium up front so that no round trip is ever needed. Opus in-band FEC and video FEC (`ulpfec`/`flexfec`) exist for exactly the long-RTT case.
+
+The ordering of the toolbox, cheapest first:
+
+| Mechanism            | Cost                                   | Latency added | Use when                              |
+| -------------------- | -------------------------------------- | ------------- | ------------------------------------- |
+| **FEC**              | constant bandwidth premium (10-30%)    | none          | RTT is large, or loss is steady        |
+| **NACK / RTX**       | bandwidth only on actual loss          | one RTT       | RTT fits in the buffer (the common case) |
+| **Concealment**      | free                                   | none          | Nothing else arrived in time; audio hides it well, video does not |
+| **PLI → keyframe**   | a 10-20× frame, and a congestion risk  | a full frame  | The decoder is stuck and nothing cheaper will unstick it |
+
+That ordering is also a product decision, not a technical one. A conversational call keeps the buffer tight and accepts occasional artifacts, because being 400ms behind is worse than a blip. A live-stream viewer with no talkback can afford a second of buffer and near-perfect quality, since nobody notices latency they cannot compare against. The `playout-delay` header extension from sec 15 exists so an application can state which of those it is.
+
+## Congestion Control: the Bitrate Negotiation You Never See
+
+Nothing tells you how much bandwidth is available. There is no field, no API, no advertisement, and the answer changes every few seconds as other traffic comes and goes. So WebRTC does the only thing possible: it **probes, watches, and adjusts continuously**. This is the most sophisticated part of the stack and the one you touch least directly, and understanding it explains most "why did the video go blurry" questions you will ever be asked.
+
+The dominant algorithm is **GCC**, Google Congestion Control, and its central insight is derivable in three lines. Consider a router with a queue:
+
+```text title="why delay is an earlier signal than loss"
+  queue length  L(t)      arrival rate  A      service rate  S
+
+  dL/dt = A - S           the queue grows exactly when you send faster than it drains
+  delay =  L / S          queueing delay IS the queue length, in time units
+  loss  =  only when  L reaches Lmax
+
+  So:  A > S   =>   delay starts rising IMMEDIATELY
+                    loss starts only after the buffer FILLS
+```
+
+Loss is therefore a strictly *later* signal than delay — later by exactly the time it takes to fill the router's buffer, which on a modern over-buffered consumer link can be **hundreds of milliseconds**. A loss-based controller learns it is sending too fast only after the user has already been experiencing a degraded call for that entire period. A delay-based one notices as the queue begins to build.
+
+How does the receiver notice a queue building without synchronised clocks? It does not need them; it needs only a **derivative**. If two packets were sent 10ms apart and arrive 14ms apart, 4ms of queueing appeared between them. Sum those inter-arrival deltas over a window and you have the trend of the queue, and the absolute clock offset cancels out entirely. GCC runs that estimator against an adaptive threshold, with a loss-based estimator as a backstop, and takes the lower of the two answers.
+
+<Diagram caption="The control loop that runs for the whole call">
+<svg viewBox="0 0 720 250" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="A loop: sender paces packets, receiver reports arrival times via transport-wide congestion control feedback, sender estimates available bandwidth and sets the encoder target bitrate">
+  <defs>
+    <marker id="cc-a" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0 0 L7 3 L0 6 Z" fill="var(--dg-accent-2)" /></marker>
+  </defs>
+  <rect x="30" y="40" width="160" height="60" rx="10" fill="var(--dg-accent-surface)" stroke="var(--dg-accent-border)" />
+  <text x="110" y="64" font-size="11" font-weight="700" fill="var(--dg-accent-2)" text-anchor="middle">Encoder</text>
+  <text x="110" y="84" class="mono" font-size="8.5" fill="var(--dg-ink-2)" text-anchor="middle">target bitrate</text>
+
+  <path fill="none" d="M194 70 H266" stroke="var(--dg-accent-2)" stroke-width="1.6" marker-end="url(#cc-a)" />
+  <text x="230" y="62" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">frames</text>
+
+  <rect x="270" y="40" width="160" height="60" rx="10" fill="var(--dg-ok-surface)" stroke="var(--dg-ok-border)" />
+  <text x="350" y="64" font-size="11" font-weight="700" fill="var(--dg-ok)" text-anchor="middle">Pacer</text>
+  <text x="350" y="84" class="mono" font-size="8.5" fill="var(--dg-ink-2)" text-anchor="middle">smooths the bursts</text>
+
+  <path fill="none" d="M434 70 H506" stroke="var(--dg-accent-2)" stroke-width="1.6" marker-end="url(#cc-a)" />
+  <text x="470" y="62" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">RTP</text>
+
+  <rect x="510" y="40" width="180" height="60" rx="10" fill="var(--dg-info-surface)" stroke="var(--dg-info-border)" />
+  <text x="600" y="64" font-size="11" font-weight="700" fill="var(--dg-info)" text-anchor="middle">Receiver</text>
+  <text x="600" y="84" class="mono" font-size="8.5" fill="var(--dg-ink-2)" text-anchor="middle">notes arrival times</text>
+
+  <path fill="none" d="M600 104 V140 H110 V104" stroke="var(--dg-accent-2)" stroke-width="1.6" stroke-dasharray="5 3" marker-end="url(#cc-a)" />
+  <text x="355" y="134" class="mono" font-size="9" fill="var(--dg-accent-2)" text-anchor="middle">RTCP transport-cc feedback: "packet 1042 arrived at T, 1043 at T+7ms..."</text>
+
+  <rect x="30" y="164" width="660" height="62" rx="10" fill="var(--dg-surface)" stroke="var(--dg-line)" />
+  <text x="46" y="186" font-size="10.5" font-weight="700" fill="var(--dg-ink)">Estimator, every ~100ms:</text>
+  <text x="46" y="206" font-size="10" fill="var(--dg-ink-2)">inter-arrival delay trending UP -> queues building -> back off multiplicatively, fast</text>
+  <text x="46" y="220" font-size="10" fill="var(--dg-ink-2)">delay flat and no loss -> headroom may exist -> increase gently, probe upward</text>
+</svg>
+</Diagram>
+
+The feedback that makes this work is **transport-wide congestion control** (sec 15's `transport-cc`): the receiver reports the arrival time of *every* packet and does no estimating at all; the sender does the work. Putting the intelligence at the sender is what allows **one estimate across audio, video and data on a bundled transport** — a single bottleneck shared by everything on that path deserves a single estimate — and lets the algorithm improve without changing receivers.
+
+#### The pacer, and why bursts are self-harm
+
+There is a second control loop that is easy to miss. Suppose congestion control has settled on 2 Mbps and the encoder produces a 60 KB keyframe. Handing all fifty packets to the socket at once puts a 480 kbit burst on a 2 Mbps link — a quarter of a second of traffic delivered instantaneously. The link cannot absorb it, so it queues, and you have just created the delay spike that your own delay-based estimator will interpret as congestion. **The sender causes the congestion it then reacts to.**
+
+So every WebRTC implementation puts a **pacer** between the encoder and the network: a queue that releases packets smoothly at the target rate, spreading that keyframe over the tens of milliseconds it actually deserves. The pacer is also where **probing** happens — to find out whether more than 2 Mbps is available, the sender deliberately paces a short burst *above* the current estimate (often padding packets, or duplicate RTX packets that cost nothing if unneeded) and watches the delay response. Bandwidth estimation cannot discover headroom passively; someone has to try.
+
+The output of all this is a single number, the **target bitrate**, spent by an allocator with strict priorities: **audio first**, because sec 2's arithmetic says 32 kbps of intelligible speech is worth more than any quantity of video; then video, which absorbs the rest by reducing quality, then frame rate, then resolution, in that order. That sequence is exactly what a user sees when their connection degrades — audio keeps working while the picture softens, goes choppy, then drops to a small blurry rectangle. **That is not a failure. It is the allocator doing precisely what constraint 5 says it should.**
+
+<Callout type="warn" title="Do not fight the bandwidth estimator">
+The instinct on seeing poor video is to raise a minimum bitrate or force a higher resolution. Almost always this makes it worse, and now you know the mechanism: you are pushing packets into a queue that is already full, which raises delay, which the estimator correctly reads as congestion — so you have converted "slightly soft video" into "growing delay, then collapse". If quality is bad, look at the estimate, the loss and the RTT first (sec 34). Override the ceiling only with evidence that the estimate itself is wrong.
+</Callout>
+
+## The Audio Pipeline: Echo, Gain and Noise
+
+Everything so far has treated audio as a stream of samples that appears from somewhere. It does not. Between the microphone and the encoder sits a signal-processing chain that is, by a wide margin, the part of WebRTC users notice most — and the reason a browser call sounds better than a naive application built on raw audio APIs.
+
+The dominant problem is **echo**, and it is a genuine consequence of the physical setup rather than a software defect. When Priya speaks, her voice reaches Sam's loudspeaker. Sam's microphone, sitting in the same room, records **Sam's voice plus a delayed, room-distorted copy of Priya's**. Send that back and Priya hears herself, several hundred milliseconds late, which is close to the most disruptive thing you can do to a speaker — delayed auditory feedback is so disorienting it has been used as an experimental speech disruptor.
+
+The insight that makes it solvable is that **the receiver already knows exactly what it played.** The far-end signal is not a mystery to be separated out; it is a reference you have a perfect copy of. What the room did to it — the delay, the reflections, the speaker and microphone response — is an unknown linear filter. So:
+
+```text title="acoustic echo cancellation, in outline"
+  mic(t)  =  near_end_speech(t)  +  ( room_response * far_end(t) )  +  noise
+                                     \_______________________/
+                                        unknown filter, but far_end is KNOWN
+
+  1. Align: find the delay between playing far_end and hearing it back.
+  2. Estimate: adaptively fit the filter (NLMS) that best maps far_end -> mic.
+  3. Subtract: mic(t) - estimate(t)  ~=  near_end_speech(t)
+  4. Suppress: whatever residual survives, attenuate non-linearly.
+```
+
+Step 1 explains most real-world echo bugs. The filter can only cancel what it can align, so **anything that makes the playback-to-capture delay unknown or variable breaks cancellation.** That is why echo appears with Bluetooth headsets (variable codec delay), with virtual audio cables and screen-recording software in the path, with an external USB interface whose buffer the browser cannot see, and above all when the user has **two devices in the same room joined to the same call** — device A's speaker feeds device B's microphone, and neither one has the other's playback signal as a reference, so no amount of processing can help. That last case is unfixable in software, and the correct response is a product one: detect it and tell the user.
+
+Two more stages complete the chain:
+
+- **Noise suppression** estimates the spectrum of the steady background — fan, traffic, air conditioning — during pauses, and subtracts it. Modern implementations use small neural models rather than spectral subtraction, which is why background suppression got dramatically better around 2020 without any protocol changing.
+- **Automatic gain control** normalises level, so a quiet speaker sitting far from a laptop and a loud one holding a headset mic arrive at comparable volume. It works against you when the "quiet" signal is actually silence, which is why AGC plus a noisy room can amplify a fan into a roar during a pause.
+
+All three are on by default and are controlled through `getUserMedia` constraints:
+
+```javascript title="the audio constraints that matter, and when to turn them off"
+const stream = await navigator.mediaDevices.getUserMedia({
+  audio: {
+    echoCancellation: true,     // leave ON unless you are certain there is no acoustic loop
+    noiseSuppression: true,     // OFF for music: it treats sustained tones as noise
+    autoGainControl: true,      // OFF for music and for anything needing true levels
+    channelCount: 1,            // speech is mono; stereo doubles bitrate for nothing
+    sampleRate: 48000,          // Opus's native rate; anything else costs a resample
+  },
+  video: true,
+});
+```
+
+<Callout type="warn" title="The music case is the classic mistake">
+Every one of those defaults is tuned for a single person speaking, and every one of them actively destroys music. Noise suppression hears a held violin note as stationary noise and removes it. AGC flattens the dynamics that are the point of the performance. Echo cancellation, which assumes only one person should be audible at a time, ducks the accompaniment. If your product involves music lessons, remote rehearsal, podcasting or any audio where fidelity matters, turn all three off, ask for stereo, and raise the Opus bitrate — otherwise users will report that your app "makes instruments sound broken", and they will be right.
+</Callout>
+
+## Data Channels: SCTP Where You Expected TCP
+
+Move 10 derived the requirement: some payloads in a real-time session want the opposite of media's guarantees. Game state, cursor positions, chat, control commands, file transfers and telemetry all want to ride the connection you have already established, with reliability chosen per message type. `RTCDataChannel` provides it, over **SCTP tunnelled in DTLS** (RFC 8831).
+
+SCTP gives you what neither TCP nor UDP does: **reliability as a per-channel setting.**
+
+| Configuration                      | Behaves like              | Use it for                                   |
+| ---------------------------------- | ------------------------- | --------------------------------------------- |
+| ordered + reliable (default)       | TCP                       | Chat, file transfer, anything that must arrive |
+| unordered + reliable               | TCP without head-of-line  | Independent events where order does not matter |
+| `maxRetransmits: 0`, unordered     | UDP                       | Player position, cursor: the next one supersedes it |
+| `maxPacketLifetime: 100`           | UDP with a deadline       | Anything worth retrying briefly, then dropping |
+
+Those middle two rows are the interesting ones, because they are unavailable anywhere else in a browser. A cursor position that is 200ms old is *worse than nothing* — the next one is already more accurate — so retransmitting it wastes bandwidth to deliver a stale answer. That is the same reasoning as move 1, applied to application data.
+
+Channels are also **multiplexed**: many share one SCTP association, so a stalled file transfer does not block cursor updates. And because it rides the peer connection, a data channel goes **directly peer to peer**, with none of the server round trip a WebSocket has — for two players on the same continent, often the difference between 20ms and 90ms.
+
+Here is a data channel on the server side of a peer connection, in Go with Pion and in Python with aiortc. Both accept a channel the browser opened, echo messages, and push periodic state.
+
+● Go● Python
+
+```go
+// github.com/pion/webrtc/v4
+pc, err := webrtc.NewPeerConnection(webrtc.Configuration{
+    ICEServers: []webrtc.ICEServer{
+        {URLs: []string{"stun:stun.example.com:3478"}},
+        {   // relay credentials are per-session and short-lived (sec 31)
+            URLs:       []string{"turn:turn.example.com:3478?transport=udp"},
+            Username:   turnUser,
+            Credential: turnPass,
+        },
+    },
+})
+if err != nil {
+    return err
+}
+
+pc.OnDataChannel(func(dc *webrtc.DataChannel) {
+    log.Printf("channel %q open, id=%d", dc.Label(), *dc.ID())
+
+    dc.OnMessage(func(msg webrtc.DataChannelMessage) {
+        // msg.Data is bytes; msg.IsString says how the peer sent it.
+        _ = dc.SendText("echo: " + string(msg.Data))
+    })
+
+    // Push state on a timer, independent of what the peer sends.
+    go func() {
+        tick := time.NewTicker(50 * time.Millisecond)
+        defer tick.Stop()
+        for range tick.C {
+            if dc.ReadyState() != webrtc.DataChannelStateOpen {
+                return // peer went away, stop the goroutine (leaks otherwise)
+            }
+            _ = dc.SendText(worldState())
+        }
+    }()
+})
+
+// Connection state is your liveness signal: ICE can fail at any time (sec 12).
+pc.OnConnectionStateChange(func(s webrtc.PeerConnectionState) {
+    if s == webrtc.PeerConnectionStateFailed || s == webrtc.PeerConnectionStateClosed {
+        _ = pc.Close() // frees the transports, the DTLS session and the ICE agent
+    }
+})
+```
+
+```python
+# aiortc
+from aiortc import RTCPeerConnection, RTCConfiguration, RTCIceServer
+
+pc = RTCPeerConnection(RTCConfiguration(iceServers=[
+    RTCIceServer(urls=["stun:stun.example.com:3478"]),
+    RTCIceServer(                                  # per-session credentials (sec 31)
+        urls=["turn:turn.example.com:3478?transport=udp"],
+        username=turn_user,
+        credential=turn_pass,
+    ),
+]))
+
+@pc.on("datachannel")
+def on_datachannel(channel):
+    log.info("channel %s open", channel.label)
+
+    @channel.on("message")
+    def on_message(message):
+        channel.send(f"echo: {message}")
+
+    async def push_state():
+        while channel.readyState == "open":
+            channel.send(world_state())
+            await asyncio.sleep(0.05)
+
+    asyncio.ensure_future(push_state())   # cancelled implicitly when the channel closes
+
+@pc.on("connectionstatechange")
+async def on_state():
+    if pc.connectionState in ("failed", "closed"):
+        await pc.close()                  # release ICE, DTLS and SCTP resources
+```
+
+<Callout type="info" title="Data channel or WebSocket?">
+Use a WebSocket when the server is a participant in the conversation: it needs to see, store, authorize or fan out the messages. Use a data channel when the server is not needed and latency matters: peer-to-peer game state, cursors, or a side channel next to media you are already sending. Note the asymmetry in setup cost too — a WebSocket is one HTTP upgrade, while a data channel needs the entire signaling, ICE and DTLS sequence first. **If you are not already establishing a peer connection for media, a data channel is rarely worth it on its own**, and a WebSocket will get you there in a tenth of the code.
+</Callout>
+Part IV / Building It
+
+## A Peer Connection, End to End
+
+Enough theory to build one. The smallest useful system is three pieces: a browser that captures media and makes an offer, a signaling server that carries it to the other side (sec 24), and a peer that answers. That third peer can be another browser, but for a backend chapter the interesting case is a **server-side peer**, because that is the foundation of recording, transcription, SIP bridging, and every SFU (sec 28).
+
+The browser side is unavoidably JavaScript, and it is short. Note the order of operations: it is fixed, and the API throws if you break it.
+
+```javascript title="the browser side, in full"
+const pc = new RTCPeerConnection({
+  iceServers: await fetchIceServers(),   // per-session TURN credentials from your API (sec 31)
+});
+
+// 1. Capture. This prompts the user; nothing works until they allow it.
+const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+for (const track of stream.getTracks()) pc.addTrack(track, stream);
+
+// 2. Trickle: send each candidate the instant it is found, do not wait (sec 12).
+pc.onicecandidate = (e) => {
+  if (e.candidate) signal.send({ type: 'candidate', candidate: e.candidate });
+};
+
+// 3. Remote media arrives here, once DTLS is up and SRTP is flowing (sec 13).
+pc.ontrack = (e) => { remoteVideo.srcObject = e.streams[0]; };
+
+// 4. Watch the state machine. This is your connection health (sec 34).
+pc.onconnectionstatechange = () => {
+  if (pc.connectionState === 'failed') pc.restartIce();   // path died, renegotiate (sec 12)
+};
+
+// 5. Offer / answer. createOffer describes what we just set up; the local
+//    description must be set BEFORE candidates can be gathered.
+const offer = await pc.createOffer();
+await pc.setLocalDescription(offer);
+signal.send({ type: 'offer', sdp: offer.sdp });
+
+signal.on('answer', async (msg) => {
+  await pc.setRemoteDescription({ type: 'answer', sdp: msg.sdp });
+});
+signal.on('candidate', (msg) => pc.addIceCandidate(msg.candidate));
+```
+
+The server-side peer answers that offer. In Go this is Pion, a pure-Go implementation of the whole stack; in Python it is aiortc, built on asyncio. Both examples accept the offer, receive the browser's video, and echo it straight back — the "hello world" of server-side WebRTC and a genuinely useful smoke test, because if you see yourself with a round-trip delay then every layer in this chapter is working at once.
+
+● Go● Python
+
+```go
+// github.com/pion/webrtc/v4
+func answer(offerSDP string) (string, error) {
+    pc, err := webrtc.NewPeerConnection(iceConfig())
+    if err != nil {
+        return "", err
+    }
+
+    // Declare up front that we will both receive and send video, otherwise the
+    // answer has no place to put the track we add below.
+    if _, err = pc.AddTransceiverFromKind(webrtc.RTPCodecTypeVideo,
+        webrtc.RTPTransceiverInit{Direction: webrtc.RTPTransceiverDirectionSendrecv}); err != nil {
+        return "", err
+    }
+
+    pc.OnTrack(func(remote *webrtc.TrackRemote, _ *webrtc.RTPReceiver) {
+        // A local track carrying the SAME codec: we forward packets, we do not
+        // decode or re-encode. That is the whole trick an SFU uses (sec 28).
+        local, err := webrtc.NewTrackLocalStaticRTP(
+            remote.Codec().RTPCodecCapability, "echo", "server")
+        if err != nil {
+            return
+        }
+        if _, err := pc.AddTrack(local); err != nil {
+            return
+        }
+
+        // Video is delta frames: a new receiver is blind until a keyframe (sec 17).
+        go func() {
+            t := time.NewTicker(3 * time.Second)
+            defer t.Stop()
+            for range t.C {
+                _ = pc.WriteRTCP([]rtcp.Packet{
+                    &rtcp.PictureLossIndication{MediaSSRC: uint32(remote.SSRC())},
+                })
+            }
+        }()
+
+        for { // the forwarding loop, one goroutine per inbound track
+            pkt, _, err := remote.ReadRTP()
+            if err != nil {
+                return // track ended or connection died
+            }
+            if err := local.WriteRTP(pkt); err != nil {
+                return
+            }
+        }
+    })
+
+    if err = pc.SetRemoteDescription(webrtc.SessionDescription{
+        Type: webrtc.SDPTypeOffer, SDP: offerSDP,
+    }); err != nil {
+        return "", err
+    }
+
+    ans, err := pc.CreateAnswer(nil)
+    if err != nil {
+        return "", err
+    }
+    // Without trickle on this side, wait for gathering so the answer carries
+    // every candidate. With trickle, send the answer immediately instead.
+    gathered := webrtc.GatheringCompletePromise(pc)
+    if err = pc.SetLocalDescription(ans); err != nil {
+        return "", err
+    }
+    <-gathered
+
+    return pc.LocalDescription().SDP, nil
+}
+```
+
+```python
+# aiortc
+from aiortc import RTCPeerConnection, RTCSessionDescription
+from aiortc.contrib.media import MediaRelay
+
+relay = MediaRelay()   # lets one inbound track be consumed by many subscribers
+
+async def answer(offer_sdp: str) -> str:
+    pc = RTCPeerConnection(ice_config())
+
+    @pc.on("track")
+    def on_track(track):
+        if track.kind == "video":
+            # relay.subscribe forwards the same encoded frames; no re-encoding,
+            # which is exactly what keeps an SFU cheap (sec 28).
+            pc.addTrack(relay.subscribe(track))
+
+        @track.on("ended")
+        async def on_ended():
+            log.info("track %s ended", track.kind)
+
+    await pc.setRemoteDescription(RTCSessionDescription(sdp=offer_sdp, type="offer"))
+
+    answer = await pc.createAnswer()
+    # aiortc completes ICE gathering inside setLocalDescription, so the SDP you
+    # read afterwards already contains every candidate.
+    await pc.setLocalDescription(answer)
+
+    return pc.localDescription.sdp
+```
+
+Go gives each inbound track a goroutine running a blocking read loop; Python gives it a coroutine and a relay object. Same structure as the WebSocket server in the previous chapter, applied to media: accept, loop reading, forward.
+
+## Renegotiation, Glare and Perfect Negotiation
+
+The code above negotiates once. Real sessions renegotiate constantly — someone enables their camera, shares a screen, a network change forces an ICE restart — and each of those needs a fresh offer/answer round trip **on a connection that is already live**. This is where more production WebRTC bugs live than in any other part of the API, so it deserves its own section rather than a warning box.
+
+The problem is **glare**: sec 7 noted that JSEP requires offers and answers to alternate. If both peers decide to renegotiate at the same instant, both send an offer, and both receive an offer while they are in the `have-local-offer` state. Neither can accept it. Hand-rolled implementations typically deadlock here, or worse, work in testing — where one side always happens to act first — and deadlock in production under real timing.
+
+The standard resolution is the **perfect negotiation** pattern, and its idea is simple: **make the situation asymmetric on purpose.** One peer is designated *polite* and the other *impolite*, by any rule both agree on. On a collision, the polite peer rolls back its own offer and accepts the incoming one; the impolite peer ignores the incoming offer and proceeds with its own. Exactly one offer survives, always, with no negotiation about who wins.
+
+```javascript title="perfect negotiation — the whole pattern, and it is worth copying verbatim"
+// One side gets polite = true. Any deterministic rule works: the callee,
+// the lower user id, whoever the server designates. Both must agree.
+let makingOffer = false;
+let ignoreOffer = false;
+
+// The browser fires this whenever something changed that needs renegotiating:
+// a track added or removed, a codec change. Never build an offer yourself.
+pc.onnegotiationneeded = async () => {
+  try {
+    makingOffer = true;
+    await pc.setLocalDescription();          // no argument: the browser builds it
+    signal.send({ description: pc.localDescription });
+  } finally {
+    makingOffer = false;
+  }
+};
+
+signal.on('message', async ({ description, candidate }) => {
+  if (description) {
+    // A collision is: an offer arrived while we are mid-offer ourselves.
+    const offerCollision =
+      description.type === 'offer' &&
+      (makingOffer || pc.signalingState !== 'stable');
+
+    ignoreOffer = !polite && offerCollision;
+    if (ignoreOffer) return;                 // impolite: our offer wins, drop theirs
+
+    // Polite peer: setRemoteDescription implicitly rolls back our own offer.
+    await pc.setRemoteDescription(description);
+    if (description.type === 'offer') {
+      await pc.setLocalDescription();        // builds the answer
+      signal.send({ description: pc.localDescription });
+    }
+  } else if (candidate) {
+    try {
+      await pc.addIceCandidate(candidate);
+    } catch (err) {
+      // A candidate for an offer we deliberately ignored is expected. Any
+      // other failure is real and should be logged.
+      if (!ignoreOffer) throw err;
+    }
+  }
+});
+```
+
+<Callout type="warn" title="Two rules that save days">
+**Never call `createOffer` yourself in a live session** — react to `onnegotiationneeded`, and use the no-argument `setLocalDescription()`, which builds the correct description for the current state. Hand-built offers desynchronise from the transceiver state and fail in ways whose error messages point somewhere else entirely.
+**Renegotiation is not free.** Each round trip is a full signaling exchange, so a UI that toggles tracks on every mute click generates a storm of them. Prefer `track.enabled = false` (which keeps the track and sends silence or black, renegotiating nothing) over removing and re-adding a track, unless you genuinely want to stop encoding to save battery.
+</Callout>
+
+## The Signaling Server
+
+The signaling server is an ordinary WebSocket application, and everything from the previous chapter applies unchanged: authenticate on connect, one goroutine or coroutine per connection, heartbeats, a registry of who is where. The WebRTC-specific part is only that it relays three message types between members of a room and never inspects the media.
+
+● Go● Python
+
+```go
+// A room-based signaling relay. gorilla/websocket, one hub, no media anywhere.
+type Room struct {
+    mu    sync.RWMutex
+    peers map[string]*Peer // peerID -> connection
+}
+
+type Envelope struct {
+    Type    string          `json:"type"`   // offer | answer | candidate | bye
+    To      string          `json:"to"`     // target peer, empty means everyone
+    From    string          `json:"from"`   // set by the SERVER, never trusted from the client
+    Payload json.RawMessage `json:"payload"`
+}
+
+func (r *Room) handle(p *Peer, raw []byte) {
+    var env Envelope
+    if err := json.Unmarshal(raw, &env); err != nil {
+        return // malformed: drop it, do not disconnect (the validation chapter)
+    }
+
+    // The server stamps identity. A client that sets `from` itself can
+    // impersonate anyone in the room, which is the classic signaling hole.
+    env.From = p.ID
+
+    switch env.Type {
+    case "offer", "answer", "candidate":
+        r.forward(env) // pure relay: we never parse the SDP
+    case "bye":
+        r.remove(p.ID)
+        r.broadcast(Envelope{Type: "bye", From: p.ID})
+    }
+}
+
+func (r *Room) forward(env Envelope) {
+    r.mu.RLock()
+    defer r.mu.RUnlock()
+    if target, ok := r.peers[env.To]; ok {
+        target.send(env) // send() writes to a buffered channel, never to the socket
+    }                    // directly: concurrent writes corrupt frames (WebSockets sec 8)
+}
+```
+
+```python
+# FastAPI signaling relay. The same shape: rooms, identity, forward.
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+
+app = FastAPI()
+rooms: dict[str, dict[str, WebSocket]] = {}
+
+@app.websocket("/rtc/{room_id}")
+async def signaling(ws: WebSocket, room_id: str):
+    peer_id = await authenticate(ws)      # verify the token BEFORE accept (sec 35)
+    if peer_id is None:
+        await ws.close(code=4401)
+        return
+    await ws.accept()
+
+    peers = rooms.setdefault(room_id, {})
+    peers[peer_id] = ws
+    await fanout(peers, {"type": "peer-joined", "from": peer_id}, skip=peer_id)
+
+    try:
+        while True:
+            env = await ws.receive_json()
+            if env.get("type") not in ("offer", "answer", "candidate", "bye"):
+                continue                   # ignore anything we did not define
+            env["from"] = peer_id          # server-stamped identity, always
+            target = peers.get(env.get("to"))
+            if target is not None:
+                await target.send_json(env)
+    except WebSocketDisconnect:
+        pass
+    finally:
+        peers.pop(peer_id, None)
+        if not peers:
+            rooms.pop(room_id, None)       # rooms are ephemeral; do not leak them
+        await fanout(peers, {"type": "bye", "from": peer_id})
+```
+
+Note what is _not_ here. **No SDP parsing**: the server is a courier, and parsing SDP on the server is a large attack surface for no benefit — an SDP arriving from a client is untrusted input in a format with decades of parser bugs behind it. **No media**: not one byte of audio or video passes through this process, which is why a single modest instance can signal for tens of thousands of concurrent calls even though it could never carry their media.
+
+<Callout type="info" title="Scaling signaling is the easy half">
+Signaling has the same shape as any WebSocket service: stateful connections, so you need sticky routing or a pub/sub backplane to fan a message out to a peer on a different instance (the WebSockets chapter, sec 15, and Redis pub/sub from the caching chapter). It is a solved problem and it is cheap. The hard scaling problem is the media plane (sec 32), where state is not a map entry but a live encrypted transport with a bitrate.
+</Callout>
+
+## Server-Side Media: Recording and Bridging
+
+A server that can terminate a peer connection can do things no browser can. Recording is the common one, and it splits into two designs whose costs differ by orders of magnitude — a distinction worth getting right before you build either.
+
+**Recording the raw tracks** means writing RTP payloads to disk as they arrive, one file per track, with no decoding: Opus into Ogg, VP8 into IVF, H.264 into MP4. It is nearly free in CPU terms, it preserves exactly what was sent, and it leaves you with N separate files that are not synchronised to each other and that no ordinary player will show side by side. (Synchronising them later means replaying the sec 16 arithmetic from the stored sender reports — so **store the RTCP too**, or you will find the recording cannot be aligned at all.) This is the right choice when you will process the media later anyway: transcription, archival, compliance.
+
+**Recording a composed view** means decoding every participant, laying them out in a grid, mixing the audio and encoding one output. It produces something a human can watch immediately, and it costs an entire transcode pipeline per room. This is by far the most expensive thing in a WebRTC deployment — it is an MCU (sec 27) bolted onto your SFU — which is why composed recording belongs in a separate autoscaled service and never on the forwarding path.
+
+● Go● Python
+
+```go
+// Recording an inbound track to disk, no transcoding (github.com/pion/webrtc/v4).
+pc.OnTrack(func(remote *webrtc.TrackRemote, _ *webrtc.RTPReceiver) {
+    var writer media.Writer
+    var err error
+
+    switch remote.Codec().MimeType {
+    case webrtc.MimeTypeOpus:
+        writer, err = oggwriter.New("audio.ogg", 48000, 2)
+    case webrtc.MimeTypeVP8:
+        writer, err = ivfwriter.New("video.ivf")
+    default:
+        return // an unhandled codec is a bug in negotiation (sec 17), not here
+    }
+    if err != nil {
+        return
+    }
+    defer writer.Close() // the container needs its trailer written, or the file is corrupt
+
+    for {
+        pkt, _, err := remote.ReadRTP()
+        if err != nil {
+            return // EOF: peer left. defer closes the file cleanly.
+        }
+        if err := writer.WriteRTP(pkt); err != nil {
+            return
+        }
+    }
+})
+```
+
+```python
+# aiortc ships a MediaRecorder that muxes with ffmpeg under the hood.
+from aiortc.contrib.media import MediaRecorder
+
+recorder = MediaRecorder(f"/recordings/{session_id}.mp4")   # decodes and re-encodes
+
+@pc.on("track")
+async def on_track(track):
+    recorder.addTrack(track)
+    await recorder.start()
+
+    @track.on("ended")
+    async def on_ended():
+        await recorder.stop()       # flushes and finalizes the container
+
+# Note the cost difference: this path DECODES every frame. For pure archival,
+# write the RTP payloads directly instead and pay nothing for CPU.
+```
+
+The same server-side peer is the foundation for live transcription (feed decoded audio to a speech model), for **telephony bridging** (transcode Opus to G.711, hand it to SIP, and accept that you are now an MCU for that leg), and for injecting media into a call from a file or another source.
+
+## WHIP and WHEP: WebRTC Without Custom Signaling
+
+Sec 7 argued that leaving signaling undefined is what lets WebRTC fit into any product. That is true for products. It is a genuine problem for **devices and tools**, because a hardware encoder, an OBS plugin or a CDN cannot each invent a bespoke WebSocket protocol and expect anything to interoperate. For the specific case of "one publisher pushes one stream to a server", the flexibility buys nothing and costs everything.
+
+**WHIP**, WebRTC-HTTP Ingestion Protocol (RFC 9725, published March 2025), fills that gap with the smallest possible answer: **POST your SDP offer to a URL and get the answer in the response body.** That is the entire protocol.
+
+```text title="WHIP, in full"
+POST /whip/live-stream-42 HTTP/1.1
+Authorization: Bearer <token>
+Content-Type: application/sdp
+
+v=0
+o=- ... (the offer)
+
+--------------------------------------------------
+HTTP/1.1 201 Created
+Location: /whip/resource/9f2a1c            <- DELETE this URL to stop publishing
+Content-Type: application/sdp
+
+v=0
+o=- ... (the answer)
+```
+
+One HTTP request replaces the whole signaling layer. Authentication is a bearer token, so it reuses everything in the auth chapter. ICE candidates can be trickled with a PATCH, or simply included in the offer for a server that has one public address anyway (ICE-lite, sec 12). Tearing down is a `DELETE` on the returned `Location`. There is no state machine, no WebSocket, no reconnection logic.
+
+Its playback counterpart, **WHEP** (WebRTC-HTTP Egress Protocol), is the same idea in reverse and is still an IETF draft, though widely implemented. Together they turn WebRTC into something a CDN can offer as a product and a `curl` command can drive.
+
+<Callout type="ok" title="Use WHIP wherever it fits">
+If your use case is one-way ingest or playback — a broadcaster pushing to your platform, a camera publishing to a server, a viewer subscribing to a stream — reach for WHIP/WHEP before building a signaling service. You get device and encoder interoperability for free, you delete an entire stateful component from your architecture, and everything in sec 24 becomes someone else's problem. Build custom signaling when you genuinely need what it buys: rooms, presence, multi-party coordination, and application state travelling alongside the call.
+</Callout>
+Part V / The Infrastructure
+
+## Topologies: Mesh, MCU, SFU
+
+Everything so far has been two peers. Add a third and the architecture question arrives, because there are only three ways to connect N participants and their costs diverge fast.
+
+<Diagram caption="Three topologies for a four-person call">
+<svg viewBox="0 0 720 300" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Mesh with every peer connected to every other peer, MCU with a mixing server sending one stream to each, and SFU with a routing server forwarding streams">
+  <text x="120" y="26" font-size="12" font-weight="700" fill="var(--dg-accent-2)" text-anchor="middle">Mesh</text>
+  <text x="360" y="26" font-size="12" font-weight="700" fill="var(--dg-warn)" text-anchor="middle">MCU</text>
+  <text x="600" y="26" font-size="12" font-weight="700" fill="var(--dg-ok)" text-anchor="middle">SFU</text>
+
+  <g stroke="var(--dg-accent-border)" stroke-width="1.3">
+    <line x1="60" y1="70" x2="180" y2="70" /><line x1="60" y1="70" x2="60" y2="170" />
+    <line x1="60" y1="70" x2="180" y2="170" /><line x1="180" y1="70" x2="60" y2="170" />
+    <line x1="180" y1="70" x2="180" y2="170" /><line x1="60" y1="170" x2="180" y2="170" />
+  </g>
+  <circle cx="60" cy="70" r="16" fill="var(--dg-accent)" /><circle cx="180" cy="70" r="16" fill="var(--dg-accent)" />
+  <circle cx="60" cy="170" r="16" fill="var(--dg-accent)" /><circle cx="180" cy="170" r="16" fill="var(--dg-accent)" />
+  <text x="120" y="212" class="mono" font-size="9" fill="var(--dg-ink-2)" text-anchor="middle">uplink: N-1 encodes</text>
+  <text x="120" y="228" class="mono" font-size="9" fill="var(--dg-ink-2)" text-anchor="middle">no server at all</text>
+  <text x="120" y="250" font-size="10" font-weight="700" fill="var(--dg-accent-2)" text-anchor="middle">dies past 4 people</text>
+
+  <g stroke="var(--dg-warn-border)" stroke-width="1.3">
+    <line x1="300" y1="70" x2="360" y2="120" /><line x1="420" y1="70" x2="360" y2="120" />
+    <line x1="300" y1="170" x2="360" y2="120" /><line x1="420" y1="170" x2="360" y2="120" />
+  </g>
+  <rect x="330" y="104" width="60" height="34" rx="8" fill="var(--dg-warn)" />
+  <text x="360" y="126" font-size="9.5" font-weight="700" fill="var(--dg-on-accent)" text-anchor="middle">mix</text>
+  <circle cx="300" cy="70" r="14" fill="var(--dg-warn-soft)" /><circle cx="420" cy="70" r="14" fill="var(--dg-warn-soft)" />
+  <circle cx="300" cy="170" r="14" fill="var(--dg-warn-soft)" /><circle cx="420" cy="170" r="14" fill="var(--dg-warn-soft)" />
+  <text x="360" y="212" class="mono" font-size="9" fill="var(--dg-ink-2)" text-anchor="middle">uplink 1, downlink 1</text>
+  <text x="360" y="228" class="mono" font-size="9" fill="var(--dg-ink-2)" text-anchor="middle">server decodes + re-encodes</text>
+  <text x="360" y="250" font-size="10" font-weight="700" fill="var(--dg-warn)" text-anchor="middle">cheap clients, expensive server</text>
+
+  <g stroke="var(--dg-ok-border)" stroke-width="1.3">
+    <line x1="540" y1="70" x2="600" y2="120" /><line x1="660" y1="70" x2="600" y2="120" />
+    <line x1="540" y1="170" x2="600" y2="120" /><line x1="660" y1="170" x2="600" y2="120" />
+  </g>
+  <rect x="570" y="104" width="60" height="34" rx="8" fill="var(--dg-ok)" />
+  <text x="600" y="126" font-size="9.5" font-weight="700" fill="var(--dg-on-accent)" text-anchor="middle">route</text>
+  <circle cx="540" cy="70" r="14" fill="var(--dg-ok-soft)" /><circle cx="660" cy="70" r="14" fill="var(--dg-ok-soft)" />
+  <circle cx="540" cy="170" r="14" fill="var(--dg-ok-soft)" /><circle cx="660" cy="170" r="14" fill="var(--dg-ok-soft)" />
+  <text x="600" y="212" class="mono" font-size="9" fill="var(--dg-ink-2)" text-anchor="middle">uplink 1, downlink N-1</text>
+  <text x="600" y="228" class="mono" font-size="9" fill="var(--dg-ink-2)" text-anchor="middle">server forwards, never decodes</text>
+  <text x="600" y="250" font-size="10" font-weight="700" fill="var(--dg-ok)" text-anchor="middle">the production answer</text>
+
+  <text x="360" y="284" font-size="11" font-style="italic" fill="var(--dg-ink-2)" text-anchor="middle">The SFU wins because forwarding an encrypted packet is cheap and encoding video is not.</text>
+</svg>
+</Diagram>
+
+**Mesh** connects everyone to everyone, with no server in the media path. It is ideal for two people and untenable beyond four, and the reason is not the one people usually give. The bandwidth is bad — each participant uploads N−1 copies — but the **encoding** is worse. Constraint 4 said compression is a 200:1 problem; that work is the single most expensive thing a client device does, and in a mesh each participant runs **N−1 encoders simultaneously**. At five participants a laptop is running four video encoders, its fan tells you about it, and a phone thermally throttles and then drops frames. Uplink is also the scarce direction on most consumer connections, typically a fifth of downlink. Mesh is the right answer for one-to-one and the wrong answer for everything else.
+
+**MCU**, a multipoint control unit, has the server decode everyone, compose one grid, and send a single stream to each participant. Clients become trivially cheap, which is why this design owned the conference-room era and still matters for telephony bridges and very weak endpoints. The cost is brutal and it lands on you: decoding and re-encoding every stream is orders of magnitude more CPU than forwarding, **and it adds a full decode-and-re-encode cycle to sec 2's latency budget** — 50 to 100ms that you cannot get back. It also destroys flexibility, since every participant receives the same layout.
+
+**SFU**, a selective forwarding unit, is what essentially every product uses today. Each participant uploads **once**; the server forwards those encrypted packets to whoever is subscribed. No decoding, no re-encoding, so the server's cost per stream is small and mostly bandwidth, and it adds almost nothing to the latency budget. It combines the cheap uplink of the MCU with the low latency and per-participant flexibility of the mesh.
+
+| Participants | Mesh: encoders / uplink | SFU: encoders / uplink | MCU: encoders / uplink |
+| ------------ | ----------------------- | ---------------------- | ---------------------- |
+| 2            | 1 / 1                   | 1 / 1                  | 1 / 1                  |
+| 4            | 3 / 3                   | 1 / 1                  | 1 / 1                  |
+| 10           | 9 / 9                   | 1 / 1                  | 1 / 1                  |
+| 50           | 49 / 49 (impossible)    | 1 / 1                  | 1 / 1                  |
+
+The encoder column is the one that decides the architecture. But the SFU has its own limit, and the table hides it: **downlink grows with N.** A 50-person grid means fifty inbound streams to decode on every client, which no phone will do. So large calls do not actually send everything to everyone — they send only what is visible, at the resolution it is displayed at, which is what sec 29's subscription policy and sec 30's simulcast exist to make possible.
+
+## Inside an SFU
+
+An SFU sounds simple — "forward packets" — and the simplicity is real: it never decodes media, so most of its work is bookkeeping. But the bookkeeping is subtle, and knowing what it does explains the failure modes you will actually meet.
+
+A packet's journey: arrive on a peer connection, be **decrypted from SRTP** (the server is a DTLS endpoint for each participant, so it holds their keys), be matched to a track by SSRC, be looked up in the subscription table, have its **sequence numbers and timestamps rewritten per subscriber**, then be re-encrypted with that subscriber's keys and sent.
+
+That rewriting is why an SFU cannot be a dumb UDP proxy, and the reason is worth deriving because it explains a whole class of glitch. **Every receiver assumes its inbound stream is one continuous sequence** — that is the assumption sec 14's loss detection rests on. A gap means loss, and a gap triggers a NACK. But the SFU legitimately does things that create gaps: it switches which simulcast layer it forwards mid-call (sec 30), and each layer is a **separate encoder with its own independent sequence and timestamp counters**; it drops packets it decides not to forward. If the subscriber saw the raw numbers, a layer switch would look like a catastrophic loss event, and it would respond by NACKing packets that will never exist. So the SFU maintains per-subscriber counters and translates every packet on the fly, presenting one seamless stream that no single publisher ever actually sent. The same applies to the sender reports of sec 16: the SFU must generate its own, because the publisher's no longer describe the timestamps the subscriber is receiving.
+
+Three more jobs sit on top:
+
+- **Per-subscriber congestion control.** Each downstream connection runs its own bandwidth estimate (sec 19), so the SFU decides independently for each subscriber which quality to send. One participant on hotel Wi-Fi does not degrade the call for anyone else — precisely what a mesh cannot do, since there the publisher has one encoder serving every peer at once.
+- **Keyframe management.** A subscriber joining or switching layers needs a keyframe, so the SFU sends a PLI upstream. It must **coalesce** these: by sec 17's arithmetic, a hundred simultaneous joins turning into a hundred keyframe requests would ask the publisher for a hundred 60 KB bursts, and congestion control would collapse the stream for everyone. One keyframe serves all hundred.
+- **Subscription policy.** Who receives whose stream (sec 29). This is where an SFU stops being infrastructure and starts being your application.
+
+<Callout type="info" title="You will not be writing an SFU">
+The open-source options are mature and each has a personality: **mediasoup** (Node control plane, C++ workers) for embedding into your own service; **LiveKit** (Go, built on Pion) for a batteries-included server with SDKs and clustering; **Janus** (C, plugin-based) for gateway work and SIP bridging; **Jitsi Videobridge** for large conferences; **Pion** itself if you want to build something specific in Go. Managed services (LiveKit Cloud, Daily, Twilio, Cloudflare Realtime, Amazon Kinesis Video Streams WebRTC) take the media plane off you entirely and charge per participant-minute or per gigabyte. Building your own SFU is a multi-year project; choose it deliberately, not by default. **Reading one, however, is the best WebRTC education available** — everything in this chapter is visible in the source.
+</Callout>
+
+## Active Speakers and Subscription Policy
+
+Sec 27 ended on the SFU's real constraint: downlink grows with N, so somebody must decide what each participant actually receives. That decision is the most product-visible piece of infrastructure in the whole stack — it is what makes a fifty-person meeting feel like a meeting rather than a wall of postage stamps — and it depends on knowing who is talking.
+
+Here is the difficulty. Determining loudness normally means decoding audio, and an SFU that decoded fifty audio streams to rank them would have thrown away the property that makes it affordable. The answer is the `ssrc-audio-level` header extension from sec 15: **the publisher measures its own loudness and writes it into the packet header**, where the SFU reads it without touching the encrypted payload. One byte, negotiated in the SDP, and speaker detection becomes free.
+
+```text title="what the SFU actually does, per audio packet"
+  read hdrext ssrc-audio-level  ->  loudness in -dBov (0 = loudest, 127 = silence)
+  smooth it over ~200ms         ->  ignore door slams and keyboard clicks
+  rank participants             ->  active speaker, plus recent speakers
+  publish the ranking           ->  over the data channel or signaling
+
+  Cost: reading one byte. No decode, no decrypt of media, no per-stream DSP.
+```
+
+From that ranking, the subscription policy follows, and it is your product logic rather than a protocol:
+
+| Policy                     | What each client receives                                     | Fits                              |
+| -------------------------- | ------------------------------------------------------------- | --------------------------------- |
+| **Subscribe to all**       | Every stream, every layer                                      | Under 6 people, nothing else      |
+| **Last-N**                 | The N most recent speakers in high quality, the rest audio-only | The standard grid meeting          |
+| **Speaker + thumbnails**   | Active speaker large, a handful of small layers                | Webinars, classrooms              |
+| **Client-driven**          | The client requests exactly the tracks and layers it is rendering | Large calls with custom layouts |
+
+The last one is where mature products end up, and the reasoning is worth stating: **the client is the only party that knows what is on screen.** A participant scrolled out of view, a tab in the background, a window the user shrank — the server cannot see any of that, and sending full-resolution video to a 90-pixel thumbnail wastes the subscriber's bandwidth and the publisher's encoder. So the client tells the server which tracks it wants and at which layer, and updates that as the layout changes.
+
+<Callout type="ok" title="This is the single highest-leverage optimisation in a large call">
+Audio is roughly 32 kbps and video roughly 1 Mbps — a factor of thirty. In a fifty-person meeting where one person is speaking, subscribing to fifty video streams costs about 50 Mbps of downlink; subscribing to one speaker's video plus forty-nine audio streams costs about 2.5 Mbps. **That is a twentyfold reduction from a policy decision alone, with no protocol change and no quality loss anyone can perceive.** Get this right before you tune anything else about a large call.
+</Callout>
+
+## Simulcast and SVC
+
+Here is the problem the SFU cannot solve by routing alone. One publisher, ten subscribers: one on fibre with a 27-inch monitor, one on a phone on a train, one with the video in a thumbnail. A single encoded stream cannot suit all of them. Send at the fibre user's quality and the phone drowns; send at the phone's quality and the monitor gets mush. And the SFU cannot transcode — that was the whole point of sec 27.
+
+If the server may not change the bitrate and one bitrate cannot serve everyone, the only remaining move is to **have the publisher send more than one version in the first place.**
+
+**Simulcast** does that directly: the publisher encodes and sends several versions of the same video at once, typically three, at different resolutions and bitrates, tagged with the `rid` extension from sec 15. The SFU forwards, to each subscriber independently, whichever layer fits that subscriber's estimated bandwidth and display size.
+
+<Diagram caption="One publisher, three layers, per-subscriber selection">
+<svg viewBox="0 0 720 280" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="A publisher sends high medium and low quality layers to an SFU, which forwards the high layer to a desktop, medium to a laptop and low to a phone on a weak network">
+  <defs>
+    <marker id="sc-a" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0 0 L7 3 L0 6 Z" fill="var(--dg-ink-2)" /></marker>
+  </defs>
+  <rect x="20" y="90" width="130" height="80" rx="10" fill="var(--dg-accent)" />
+  <text x="85" y="120" font-size="11.5" font-weight="700" fill="var(--dg-on-accent)" text-anchor="middle">Publisher</text>
+  <text x="85" y="140" class="mono" font-size="8" fill="var(--dg-on-accent)" text-anchor="middle">encodes 3x,</text>
+  <text x="85" y="154" class="mono" font-size="8" fill="var(--dg-on-accent)" text-anchor="middle">uploads ~3.1 Mbps</text>
+
+  <g class="mono" font-size="8.5">
+    <path fill="none" d="M154 108 H246" stroke="var(--dg-ok)" stroke-width="1.6" marker-end="url(#sc-a)" />
+    <text x="200" y="102" fill="var(--dg-ok)" text-anchor="middle">720p 2.5M</text>
+    <path fill="none" d="M154 130 H246" stroke="var(--dg-warn)" stroke-width="1.6" marker-end="url(#sc-a)" />
+    <text x="200" y="124" fill="var(--dg-warn)" text-anchor="middle">360p 500k</text>
+    <path fill="none" d="M154 152 H246" stroke="var(--dg-info)" stroke-width="1.6" marker-end="url(#sc-a)" />
+    <text x="200" y="146" fill="var(--dg-info)" text-anchor="middle">180p 150k</text>
+  </g>
+
+  <rect x="250" y="86" width="150" height="88" rx="10" fill="var(--dg-inverse)" />
+  <text x="325" y="118" font-size="12" font-weight="700" fill="var(--dg-on-inverse)" text-anchor="middle">SFU</text>
+  <text x="325" y="138" class="mono" font-size="8" fill="var(--dg-on-inverse-2)" text-anchor="middle">picks a layer per</text>
+  <text x="325" y="152" class="mono" font-size="8" fill="var(--dg-on-inverse-2)" text-anchor="middle">subscriber, no decode</text>
+
+  <path fill="none" d="M404 106 H556" stroke="var(--dg-ok)" stroke-width="1.6" marker-end="url(#sc-a)" />
+  <rect x="560" y="82" width="140" height="46" rx="9" fill="var(--dg-ok-surface)" stroke="var(--dg-ok-border)" />
+  <text x="630" y="100" font-size="10" font-weight="700" fill="var(--dg-ok)" text-anchor="middle">Desktop, fibre</text>
+  <text x="630" y="117" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">gets 720p</text>
+
+  <path fill="none" d="M404 138 H556" stroke="var(--dg-warn)" stroke-width="1.6" marker-end="url(#sc-a)" />
+  <rect x="560" y="136" width="140" height="46" rx="9" fill="var(--dg-warn-surface)" stroke="var(--dg-warn-border)" />
+  <text x="630" y="154" font-size="10" font-weight="700" fill="var(--dg-warn)" text-anchor="middle">Laptop, in a grid</text>
+  <text x="630" y="171" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">gets 360p</text>
+
+  <path fill="none" d="M404 170 H556" stroke="var(--dg-info)" stroke-width="1.6" marker-end="url(#sc-a)" />
+  <rect x="560" y="190" width="140" height="46" rx="9" fill="var(--dg-info-surface)" stroke="var(--dg-info-border)" />
+  <text x="630" y="208" font-size="10" font-weight="700" fill="var(--dg-info)" text-anchor="middle">Phone, 3 bars</text>
+  <text x="630" y="225" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">gets 180p</text>
+
+  <text x="360" y="264" font-size="11" font-style="italic" fill="var(--dg-ink-2)" text-anchor="middle">The publisher pays ~25% extra uplink so that every subscriber gets a stream matched to their link.</text>
+</svg>
+</Diagram>
+
+The cost lands on the publisher: three encodes instead of one, and roughly 20 to 30 percent more uplink than the top layer alone (the lower layers are small — a quarter-resolution layer is about a sixteenth of the pixels). In exchange the SFU gains per-subscriber adaptation without ever decoding, which is the property the entire architecture depends on.
+
+**SVC**, scalable video coding, achieves the same end more elegantly. Instead of independent streams, one bitstream is encoded in **layers that build on each other**: a base layer that stands alone, plus enhancement layers adding resolution or frame rate. The SFU forwards a *prefix* of the layers, so dropping quality means simply not forwarding some packets — with **no switch point and no keyframe required**, which by sec 17's arithmetic is a large saving, since simulcast layer switches need a keyframe and keyframes are what congestion cannot afford. VP9 and AV1 support SVC well, and where the codec is available it is the better mechanism: lower publisher cost and instant, seamless adaptation. **Temporal layers alone** — same resolution, half the frame rate, achieved by dropping every other frame — are the cheapest useful form, widely supported, and often enough on their own.
+
+<Callout type="warn" title="Simulcast interacts badly with things you might turn on">
+Simulcast only helps if the publisher is actually sending all its layers, and several common conditions silently kill the top one: a CPU-constrained laptop drops it to protect the encoder, a bandwidth estimate below the sum of the layers causes the publisher to stop sending it, and some codec and hardware combinations produce only one layer at all. The symptom is always the same — "everyone sees this one person in low quality, even on a fast network" — and it is invisible from the subscriber side, because the SFU is faithfully forwarding the best layer that exists. **Check the publisher's outbound stats for the layers before you look anywhere else** (sec 34).
+</Callout>
+
+## Running TURN in Production
+
+TURN is the infrastructure you cannot avoid and the one most teams get wrong, so it is worth being concrete. **coturn** is the standard open-source server and handles both STUN and TURN in one process.
+
+```text title="turnserver.conf / the parts that matter"
+listening-port=3478                 # plain STUN/TURN
+tls-listening-port=5349             # TURN over TLS
+# Also run a listener on 443: a restrictive firewall that blocks everything
+# else almost always allows outbound TCP 443, which is your last-resort path
+# for sec 9's row four.
+
+fingerprint
+use-auth-secret                     # ephemeral credentials, NOT a user database
+static-auth-secret=<long-random-secret-shared-with-your-api>
+realm=turn.example.com
+
+# The relay port range. Each allocation takes one; size it for peak concurrency
+# and open exactly this range in the firewall, nothing wider.
+min-port=49160
+max-port=49500
+
+# On a cloud VM the NIC has a private IP and the world sees an elastic IP.
+# Without this mapping, coturn advertises the private address and every
+# relay candidate is unreachable. This is the single most common TURN bug.
+external-ip=203.0.113.9/10.0.0.9
+
+# An open relay gets abused within days. Deny the RFC1918 space so a
+# stranger cannot use your TURN server to reach into your own VPC.
+no-multicast-peers
+denied-peer-ip=10.0.0.0-10.255.255.255
+denied-peer-ip=172.16.0.0-172.31.255.255
+denied-peer-ip=192.168.0.0-192.168.255.255
+user-quota=12
+total-quota=1200
+```
+
+The credential model deserves the most attention. coturn's `use-auth-secret` mode implements the **REST API for TURN credentials**: your backend and the TURN server share one secret, and your backend mints a username that is an expiry timestamp and a password that is an HMAC of it. The TURN server validates the HMAC itself, so it needs no database, no synchronisation and no user list — and a leaked credential is worthless within minutes. It is a neat piece of design: authentication with zero shared state.
+
+● Go● Python
+
+```go
+// Mint short-lived TURN credentials. Your API returns these to an authenticated
+// client just before it starts a call; they expire on their own.
+func turnCredentials(userID string, ttl time.Duration) (user, pass string) {
+    // coturn's contract: username = "<unix expiry>:<anything>"
+    user = fmt.Sprintf("%d:%s", time.Now().Add(ttl).Unix(), userID)
+
+    mac := hmac.New(sha1.New, []byte(os.Getenv("TURN_STATIC_AUTH_SECRET")))
+    mac.Write([]byte(user))
+    pass = base64.StdEncoding.EncodeToString(mac.Sum(nil))
+    return user, pass
+}
+
+// GET /api/ice-servers  (authenticated: this is the endpoint attackers want)
+func iceServersHandler(w http.ResponseWriter, r *http.Request) {
+    uid := auth.UserFromContext(r.Context()).ID
+    user, pass := turnCredentials(uid, 10*time.Minute) // long enough to connect, not to abuse
+
+    respondJSON(w, map[string]any{
+        "iceServers": []map[string]any{
+            {"urls": []string{"stun:turn.example.com:3478"}},
+            {
+                "urls": []string{
+                    "turn:turn.example.com:3478?transport=udp",
+                    "turn:turn.example.com:443?transport=tcp", // firewall fallback
+                    "turns:turn.example.com:5349?transport=tcp",
+                },
+                "username":   user,
+                "credential": pass,
+            },
+        },
+    })
+}
+```
+
+```python
+import base64, hashlib, hmac, os, time
+
+def turn_credentials(user_id: str, ttl: int = 600) -> tuple[str, str]:
+    """coturn use-auth-secret: username is '<expiry>:<id>', password is its HMAC."""
+    username = f"{int(time.time()) + ttl}:{user_id}"
+    digest = hmac.new(
+        os.environ["TURN_STATIC_AUTH_SECRET"].encode(),
+        username.encode(),
+        hashlib.sha1,
+    ).digest()
+    return username, base64.b64encode(digest).decode()
+
+@app.get("/api/ice-servers")
+async def ice_servers(user=Depends(current_user)):     # authenticated, always
+    username, credential = turn_credentials(user.id)
+    return {"iceServers": [
+        {"urls": "stun:turn.example.com:3478"},
+        {
+            "urls": [
+                "turn:turn.example.com:3478?transport=udp",
+                "turn:turn.example.com:443?transport=tcp",   # gets through hostile firewalls
+                "turns:turn.example.com:5349?transport=tcp",
+            ],
+            "username": username,
+            "credential": credential,
+        },
+    ]}
+```
+
+Sizing TURN is arithmetic, not guesswork, and it follows directly from sec 11's topology — the relay is a full participant in the byte stream, so it pays the bitrate **twice**, once in and once out:
+
+```text title="TURN capacity, computed"
+  1,000 concurrent 2-party calls at 1 Mbps each
+  x 15% needing a relay        =   150 relayed calls
+  x 1 Mbps x 2 directions x 2 (in + out at the relay)
+                              =   600 Mbps sustained
+
+  At typical cloud egress pricing, that bandwidth bill dwarfs the instances.
+  Halving the relay rate halves the bill. Nothing else you tune comes close.
+```
+
+Two consequences. **Put TURN servers in every region where you have users** — sec 2's table says a relay on the wrong continent adds a hundred milliseconds and doubles the distance the media travels, turning a comfortable call into an awkward one. And **treat "percentage of sessions relayed" as a first-class metric** (sec 34), because it is the dial your costs hang from and it moves without warning when a large customer's network changes.
+
+## Scaling the Media Plane
+
+Signaling scales like any web service. The media plane does not, and the reason is worth stating precisely: **a media server holds live, encrypted, per-participant state that cannot be moved.** A peer connection is an ICE agent with a nominated path, a DTLS session with negotiated keys, SRTP counters, per-subscriber sequence-number translations and a bandwidth estimate built up over the call. None of that serialises and hands over the way a session cookie does. You cannot drain a media server the way you drain an HTTP one; you can only stop sending it new rooms and wait.
+
+That single fact drives the architecture.
+
+**Rooms are the unit of placement, not participants.** Everyone in a room must be on the same media server, or it cannot forward between them. So allocation happens once, at room creation: a service picks the least-loaded server in the right region, records the choice in a registry (Redis is the usual home), and every later joiner is routed there.
+
+**Load is bandwidth and packet rate, not CPU.** An SFU forwarding a thousand streams may sit at 30 percent CPU while saturating its NIC — it does almost no computation per packet, by design. Autoscaling on CPU therefore scales far too late, after quality has already collapsed. Track concurrent streams, egress bitrate and packets per second, and set your ceiling well below the hardware limit, because the last 20 percent of a NIC is exactly where queueing appears, and queueing is what sec 19's estimators on every client will read as congestion.
+
+**Scaling out is slow, so scale early.** A new instance must boot, warm up and register before it can take rooms, and rooms already in progress cannot be moved to it. Provision headroom ahead of your daily peak rather than reacting to it.
+
+<Diagram caption="Room placement, and cascading between regions">
+<svg viewBox="0 0 720 280" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="A room allocator backed by Redis assigns rooms to regional SFUs, and two SFUs in different regions are linked so participants on each continent connect locally">
+  <defs>
+    <marker id="sf-a" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0 0 L7 3 L0 6 Z" fill="var(--dg-ink-2)" /></marker>
+  </defs>
+  <rect x="250" y="16" width="220" height="46" rx="9" fill="var(--dg-info-surface)" stroke="var(--dg-info-border)" />
+  <text x="360" y="36" font-size="11" font-weight="700" fill="var(--dg-info)" text-anchor="middle">Room allocator + registry</text>
+  <text x="360" y="53" class="mono" font-size="8.5" fill="var(--dg-ink-2)" text-anchor="middle">room -> server, in Redis</text>
+
+  <path fill="none" d="M300 66 L170 108" stroke="var(--dg-ink-2)" stroke-width="1.3" stroke-dasharray="4 3" marker-end="url(#sf-a)" />
+  <path fill="none" d="M420 66 L550 108" stroke="var(--dg-ink-2)" stroke-width="1.3" stroke-dasharray="4 3" marker-end="url(#sf-a)" />
+
+  <rect x="60" y="112" width="220" height="60" rx="10" fill="var(--dg-inverse)" />
+  <text x="170" y="136" font-size="11.5" font-weight="700" fill="var(--dg-on-inverse)" text-anchor="middle">SFU · eu-west</text>
+  <text x="170" y="156" class="mono" font-size="8.5" fill="var(--dg-on-inverse-2)" text-anchor="middle">rooms: 34 · egress 2.1 Gbps</text>
+
+  <rect x="440" y="112" width="220" height="60" rx="10" fill="var(--dg-inverse)" />
+  <text x="550" y="136" font-size="11.5" font-weight="700" fill="var(--dg-on-inverse)" text-anchor="middle">SFU · ap-south</text>
+  <text x="550" y="156" class="mono" font-size="8.5" fill="var(--dg-on-inverse-2)" text-anchor="middle">rooms: 29 · egress 1.8 Gbps</text>
+
+  <path fill="none" d="M284 142 H436" stroke="var(--dg-ok)" stroke-width="2.2" stroke-dasharray="7 4" />
+  <text x="360" y="134" class="mono" font-size="9" font-weight="700" fill="var(--dg-ok)" text-anchor="middle">cascade link</text>
+  <text x="360" y="164" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">one copy per stream, not per user</text>
+
+  <g fill="var(--dg-accent)">
+    <circle cx="90" cy="216" r="13" /><circle cx="130" cy="216" r="13" /><circle cx="170" cy="216" r="13" />
+    <circle cx="510" cy="216" r="13" /><circle cx="550" cy="216" r="13" /><circle cx="590" cy="216" r="13" />
+  </g>
+  <g stroke="var(--dg-accent-border)" stroke-width="1.2">
+    <line x1="90" y1="203" x2="150" y2="174" /><line x1="130" y1="203" x2="160" y2="174" /><line x1="170" y1="203" x2="175" y2="174" />
+    <line x1="510" y1="203" x2="540" y2="174" /><line x1="550" y1="203" x2="550" y2="174" /><line x1="590" y1="203" x2="565" y2="174" />
+  </g>
+  <text x="130" y="248" font-size="10" fill="var(--dg-ink-2)" text-anchor="middle">European participants</text>
+  <text x="550" y="248" font-size="10" fill="var(--dg-ink-2)" text-anchor="middle">Indian participants</text>
+  <text x="360" y="272" font-size="11" font-style="italic" fill="var(--dg-ink-2)" text-anchor="middle">Everyone connects to a nearby server; the long haul happens once, between servers, on good networks.</text>
+</svg>
+</Diagram>
+
+**Cascading** is how a room outgrows one server or spans continents. Two or more SFUs join the same room and forward between themselves, so a participant in Mumbai connects to the Mumbai server and one in Dublin to the Dublin server, and each stream crosses the ocean **exactly once** rather than once per viewer. That is the same insight as a CDN, applied to live media, and sec 2's table shows why it matters: the ocean crossing is unavoidable, but paying for it fifty times is not. It also raises the ceiling on room size, since a broadcast to fifty thousand viewers becomes a tree of forwarding servers each fanning out to a manageable number. The costs are inter-server bandwidth, one extra hop of latency, and considerably harder failure handling — so it is a tool you reach for when geography or size demands it, not a default.
+
+## Deploying Media Servers: the UDP Problem
+
+Everything you know about deploying HTTP services is close to useless here, and this section exists because that surprise costs teams weeks.
+
+**Your load balancer cannot help you.** An application load balancer terminates TCP and speaks HTTP. Media is UDP carrying DTLS and SRTP: there is nothing to terminate, no path or header to route on, and no way to move a connection between backends mid-call — the state described in sec 32 lives in the server, not the request. So media servers are addressed **directly, by public IP**, and the "load balancing" is the room allocator handing out an address at join time.
+
+**The container must not be NATed.** ICE works by advertising addresses the far peer will send to. A media server inside a container with a bridge network advertises the container's private IP, which is unreachable, so every relay-free connection fails — and by sec 12, an ICE-lite server has no second candidate to fall back on. The fixes are `hostNetwork: true` on Kubernetes, `--network host` on Docker, or explicitly configuring the server with its public address. This is the same class of bug as coturn's `external-ip` in sec 31, and it appears the moment you containerise something that worked on a VM.
+
+**Ports are a range, and it must be open.** Each connection takes a UDP port from a configured range, and both the cloud security group and any host firewall must allow the whole range. Some servers can multiplex every connection onto a single port, which makes firewall rules trivial and is worth choosing when available.
+
+```yaml title="sfu.yaml / the parts that differ from a normal Deployment"
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      hostNetwork: true          # no CNI NAT: the pod must see and advertise the node IP
+      dnsPolicy: ClusterFirstWithHostNet
+      containers:
+        - name: sfu
+          ports:
+            - containerPort: 7880          # signaling, ordinary HTTP/WebSocket
+            - containerPort: 7881          # TCP fallback for ICE
+          env:
+            - name: NODE_IP                # advertise the PUBLIC address, or ICE fails
+              valueFrom:
+                fieldRef: { fieldPath: status.hostIP }
+          # UDP media uses a host port range opened in the security group,
+          # e.g. 50000-60000/udp. Never route it through a Service or Ingress.
+      terminationGracePeriodSeconds: 1800  # you cannot drain a call; you wait for it to end
+```
+
+That last line is the deployment model in one field. **A media server cannot be rolled like a stateless service.** The pattern that works is: stop assigning new rooms to an instance, let its existing calls finish naturally, then terminate it — which means your grace period is measured in the length of your longest call, not in seconds. Plan releases around that, or accept that every deploy drops calls. Teams that discover this after launch usually end up doing releases at 4am, which is a scheduling solution to an architecture problem.
+
+## Observability for Real-Time Media
+
+A media call has no status code. It fails by **getting worse**, and "worse" is a distribution across users that is invisible from the server, so observability here means collecting client-side quality signals as diligently as server metrics (the logging and observability chapter's principles, applied to a stream).
+
+The browser exposes everything through `getStats()`, and a small number of fields carry most of the signal.
+
+```javascript title="the client-side stats worth shipping, once every few seconds"
+const stats = await pc.getStats();
+for (const r of stats.values()) {
+  if (r.type === 'inbound-rtp' && r.kind === 'video') {
+    report({
+      // The single best proxy for "is this call good": time spent frozen.
+      freezeMs: r.totalFreezesDuration, freezeCount: r.freezeCount,
+      // Loss and jitter explain WHY it froze.
+      lost: r.packetsLost, jitter: r.jitter,
+      // What the user is actually seeing, versus what was published (sec 30).
+      width: r.frameWidth, height: r.frameHeight, fps: r.framesPerSecond,
+      nacks: r.nackCount, plis: r.pliCount,
+      // Rising steadily with flat packetsLost means a clock problem (sec 16),
+      // not a network one. They have completely different fixes.
+      jitterBufferDelay: r.jitterBufferDelay, jitterBufferEmitted: r.jitterBufferEmittedCount,
+    });
+  }
+  if (r.type === 'candidate-pair' && r.state === 'succeeded' && r.nominated) {
+    report({
+      rtt: r.currentRoundTripTime,
+      availableOutgoing: r.availableOutgoingBitrate,
+      // Did this session end up on a relay? This is your cost metric (sec 31).
+      relayed: r.localCandidateId,
+    });
+  }
+}
+```
+
+| Signal                          | Healthy            | What it means when it is not                       |
+| ------------------------------- | ------------------ | --------------------------------------------------- |
+| Round-trip time                 | under 150ms        | Wrong region, or a relay on the wrong continent (sec 31) |
+| Packet loss                     | under 1%           | Above 5% and video degrades visibly whatever you do  |
+| Jitter                          | under 30ms         | Buffer deepens, latency grows (sec 18)               |
+| Freeze duration                 | near zero          | The user-visible symptom; alert on this, not on loss |
+| Available outgoing bitrate      | stable             | Collapsing means congestion control is backing off (sec 19) |
+| Jitter buffer delay             | stable             | Climbing with flat loss is clock drift, not congestion (sec 16) |
+| ICE connection failure rate     | under 1% of joins  | TURN misconfigured, credentials expiring, UDP blocked |
+| **Relay rate**                  | 10-20% of sessions | Rising means networks got worse or STUN is failing; your bill follows it |
+
+Two service-level indicators are worth defining up front, because they are what users actually experience: **join success rate** (of attempted joins, how many reached `connected` within, say, five seconds) and **good-minutes ratio** (of all media minutes delivered, how many had freeze time and loss below your thresholds). Both are computed from client reports, and both catch regressions that server dashboards will happily show as green.
+
+<Callout type="warn" title="Server-side dashboards systematically lie about call quality">
+An SFU's own metrics describe what it sent, not what anyone received. A server can report perfect health — low CPU, no errors, packets forwarded — while every user on one ISP is watching frozen video, because the loss is happening on the last mile and the server never learns about it except through RTCP it does not aggregate. **If you take one operational thing from this chapter, make it this: instrument the client.** The call quality you can measure from your own infrastructure is not the call quality your users have.
+</Callout>
+
+## Security Specific to WebRTC
+
+The general rules from the security chapter all apply. What follows is what is different when media is involved.
+
+**Media encryption is handled; access control is not.** DTLS-SRTP is mandatory and automatic, so nobody sniffs your call off the wire. But "may this person join this room" is answered entirely by your signaling server (sec 7), which is also — per move 6 — the root of trust for the encryption itself. Sign short-lived, room-scoped join tokens, verify them before accepting the WebSocket, re-check on every action, and never accept a room identity the client asserts.
+
+**TURN credentials are a bandwidth wallet.** Static credentials in client code will be extracted and used to relay someone else's traffic on your bill. Mint ephemeral HMAC-derived credentials per session (sec 31), keep the TTL short, and deny private ranges so your relay cannot be used to reach into your own network.
+
+**IP addresses leak by design.** ICE candidates contain local and public addresses, so a peer-to-peer call reveals each participant's IP to the other — inherent to a direct connection, not a bug. Browsers mitigate the local-address half with **mDNS candidates** (a random `.local` name instead of the real private IP), but the public address is unavoidable. If your product connects strangers — dating, marketplaces, support, anything where one party should not learn where the other lives — force media through TURN with `iceTransportPolicy: 'relay'`, and accept that every session now pays relay bandwidth. **This is a case where the right privacy answer costs real money, and it should be a deliberate decision rather than a default nobody examined.**
+
+**Media ports are an attack surface.** They accept UDP from anywhere, so rate-limit allocations, cap per-user quotas in coturn, and keep media servers off the network path to anything else you care about.
+
+#### End-to-end encryption, and what it costs
+
+Sec 14 established that an SFU terminates SRTP per hop: it decrypts and re-encrypts, and therefore **can see every frame of every call it routes**. For most products that is fine — it is the same trust you place in any server holding your data. For some it is unacceptable.
+
+The fix is a second encryption layer applied to the payload *before* it reaches the transport, using keys the server never receives. **SFrame** is the standard; browsers expose it through **insertable streams** (`RTCRtpScriptTransform`), which hand your code each encoded frame on its way in or out.
+
+```text title="the two layers, and who can read what"
+  publisher                      SFU                        subscriber
+  ---------                      ---                        ----------
+  encode                                                    render
+  encrypt with GROUP key   ->    cannot decrypt        ->    decrypt with GROUP key
+  encrypt with SRTP key    ->    DECRYPTS, routes,     ->    decrypt with SRTP key
+                                 re-encrypts per hop
+
+  The SFU still reads: SSRC, sequence number, timestamp, header extensions
+  (sec 15) -- exactly enough to route, rewrite and select layers.
+  The SFU never reads: a single pixel or sample.
+```
+
+The design works precisely because of move 5: **the readable header that made a routable media plane possible is also what makes E2EE possible through it.** The server keeps the metadata it needs and loses the content it never needed.
+
+What it costs you is substantial and worth stating plainly. Server-side recording, transcription, composed layouts and telephony bridging all become impossible without a client that shares keys — which is usually a contradiction of the reason you wanted E2EE. Key distribution and rotation as people join and leave is a genuinely hard distributed-systems problem (the standard answer is MLS, RFC 9420). And some SFU optimisations degrade, since a few decisions that would benefit from frame contents now have to be made from headers alone. **Choose E2EE because your threat model requires it, not because it sounds like the more secure default.**
+
+<Callout type="warn" title="Recording is a legal surface, not just a technical one">
+Recording consent rules differ by jurisdiction and several require every participant to be informed. Make recording state visible in the UI, log who started it and when, encrypt artifacts at rest, and set a retention policy. This is one of the few places where an engineering shortcut turns directly into legal exposure.
+</Callout>
+Part VI / Practice and Comparison
+
+## WebRTC vs WebSockets vs HLS vs MoQ
+
+The previous chapter's spectrum had four points and all of them carried events. Add media and the spectrum extends, with WebRTC at one end and CDN streaming at the other.
+
+| Technology            | Latency     | Direction             | Scales to               | Reach for it when                                              |
+| --------------------- | ----------- | --------------------- | ----------------------- | --------------------------------------------------------------- |
+| **WebSocket**         | 20-100ms    | bidirectional, events | 100k+ per cluster       | Events, state, chat, cursors. No media.                          |
+| **WebRTC, mesh**      | 50-150ms    | bidirectional, media  | 2-4 people              | One-to-one calls. No server in the media path at all.            |
+| **WebRTC, SFU**       | 100-300ms   | bidirectional, media  | 50-1000 per room, more with cascading | Group calls, interactive rooms, anything conversational |
+| **LL-HLS / LL-DASH**  | 1-5s        | one-way               | millions, on any CDN    | Live broadcast with a chat, sport, events                        |
+| **HLS / DASH**        | 15-30s      | one-way               | millions, cheaply       | Anything with no feedback loop at all                            |
+| **MoQ** (draft)       | sub-second  | one-way, evolving     | CDN-shaped              | Watch this space: QUIC-based, aims at CDN scale with WebRTC-ish latency |
+
+The decision is genuinely simple once framed correctly, and sec 6 already framed it: **does a human need to react to what they just saw, within their own reaction time?** If yes, you need WebRTC and you accept the infrastructure. If no, use HTTP streaming, ride a CDN, and spend the saved months on your product.
+
+The middle ground — sub-second, one-way, at CDN scale — is exactly the gap **Media over QUIC** is being designed to fill, and it is worth understanding why it is a plausible answer rather than another acronym. QUIC already provides what move 1 needed (independent streams with no head-of-line blocking across them) and what move 4 needed (mandatory encryption), over UDP, with NAT traversal that works because the client always initiates. MoQ adds a publish/subscribe relay model on top, so intermediaries can cache and fan out the way a CDN does — the thing WebRTC fundamentally cannot do, because an SFU must hold per-subscriber cryptographic state. As of 2026 the drafts are still moving at the IETF, so it belongs on your roadmap and not in production.
+
+One combination is worth naming because it is what most real products actually build: **WebSocket for signaling and application state, WebRTC for media, HLS for the audience.** A live show has presenters on an SFU, chat and reactions over WebSockets, and ten thousand viewers on LL-HLS, with the SFU output re-published into the streaming pipeline. Each layer does the job it is cheapest at, and the boundary between them is exactly the line where "someone has to react" stops being true.
+
+## Debugging From First Principles
+
+The point of deriving the stack in sec 3 was not elegance; it was that a derived system can be **diagnosed by working backwards**. Almost every WebRTC failure you will meet is one of the six constraints from sec 2 asserting itself, and identifying which one narrows the search from "the whole stack" to one section.
+
+| Symptom                                          | Which constraint is biting                                   | Where to look                     |
+| ------------------------------------------------ | ------------------------------------------------------------- | --------------------------------- |
+| Call never connects; state goes `checking` → `failed` | **6** — no usable address exists between these two peers  | ICE candidates, TURN creds (sec 12, 31) |
+| Works at home, fails at the office               | **6** — symmetric NAT or UDP blocked entirely                 | Ship TURN on TCP 443 (sec 9, 31)  |
+| Connects, then dies after ~30s                   | **6** — the NAT mapping expired; consent checks stopped        | Consent freshness, keepalives (sec 12) |
+| Connects, but total silence both ways            | Not a constraint — a state-machine bug                        | `a=setup` roles in the SDP (sec 13) |
+| Audio fine, video black                          | **The contract** — no common codec profile survived negotiation | `a=fmtp` lines in the answer (sec 17) |
+| Video freezes for a second at a time             | **5** — loss broke the dependency chain, waiting on a keyframe | Loss rate, PLI count (sec 17, 18) |
+| Video permanently soft, network is fast          | **4** — the publisher is not producing the layers you expect   | Publisher outbound layers (sec 30) |
+| Quality collapses under mild load                | **3 + 4** — bursts causing self-inflicted queueing             | Pacer, keyframe size (sec 19)     |
+| Delay grows steadily through the call            | **1 vs 5** — buffer growing to absorb jitter, or clock drift   | `jitterBufferDelay` vs loss (sec 16, 18) |
+| Audio and video drift apart over minutes         | Clock — RTCP sender reports missing or wrong                   | Is RTCP reaching you? (sec 16)    |
+| Everyone sounds echoey to one participant        | Physical — the AEC reference is misaligned                     | Bluetooth, two devices in a room (sec 20) |
+| Fine transatlantic, awful for two people in Sydney | **1** — media is detouring through the wrong continent       | Which region relayed (sec 31, 32) |
+| Server dashboards green, users complaining       | Measurement — you are watching the wrong side                  | Client-side stats (sec 34)        |
+
+Two habits make this work in practice. **Reproduce on a hostile network before you debug anything** — a mobile hotspot and a corporate VPN cover most of the failure surface, and a bug that only appears there is almost always constraint 6. And **read the ICE state and candidate list first, always**, because sec 12's four phases partition connection failures completely: if you know which phase stopped, you know which of five things to check, and if ICE succeeded then the problem is not connectivity and you can stop looking there.
+
+<Callout type="ok" title="The question to ask before opening a library's source">
+"Which of the six numbers is this violating?" Latency complaints are constraint 1 or 2 — geography or budget. Freezes and blockiness are 4 and 5 — compression meeting loss. Connection failures are 6, essentially always. Mysterious packet loss on large frames is 3. It is a crude filter and it is right often enough to save you hours, because it points at a section instead of a stack trace.
+</Callout>
+
+## Common Pitfalls
+
+Most WebRTC production failures are not exotic. They are the same dozen mistakes, and nearly all live in ICE, TURN and deployment rather than in media.
+
+| Pitfall                            | What happens                                                                                      | Fix                                                                                       |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| **STUN only, no TURN**             | Works everywhere you tested, fails for 10-20% of real users, mostly corporate and mobile           | Always ship TURN with UDP, TCP and TLS-on-443 URLs (sec 11, 31)                             |
+| **`external-ip` not set**          | Relay candidates advertise a private cloud IP; every relayed connection fails                      | Map public to private in coturn; same for any media server behind NAT (sec 31, 33)          |
+| **Static TURN credentials**        | Extracted from your JS within days, relay bandwidth billed to you                                  | Ephemeral HMAC credentials, short TTL, minted by an authenticated endpoint (sec 31)         |
+| **No trickle ICE**                 | Call setup waits for the slowest TURN allocation; seconds of dead air                              | Trickle candidates as they are gathered (sec 12)                                            |
+| **Container NAT on a media server**| ICE advertises the pod IP, connections fail with no obvious error                                  | `hostNetwork`, or explicitly configure the public address (sec 33)                          |
+| **Media through a load balancer**  | UDP is not routable by an L7 LB; connections never establish                                       | Address media servers directly; balance at room-allocation time (sec 32, 33)                |
+| **Rolling deploys on the SFU**     | Every release drops every live call                                                                | Stop assigning new rooms, drain by waiting, long grace period (sec 33)                      |
+| **Autoscaling on CPU**             | The NIC saturates at 30% CPU; quality collapses before anything scales                             | Scale on streams, egress bitrate and packets per second (sec 32)                            |
+| **Overriding the bitrate estimate**| Forcing a floor turns soft video into unbounded delay, then collapse                               | Trust the estimator; fix loss and RTT instead (sec 19)                                      |
+| **Ignoring simulcast layer health**| Everyone sees one participant in low quality, on a fast network                                    | Check the publisher's outbound layers before anything else (sec 30)                         |
+| **Subscribing to every stream**    | A 50-person call needs 50 Mbps of downlink and melts phones                                        | Last-N or client-driven subscription; audio is 30× cheaper than video (sec 29)              |
+| **Renegotiating on every mute**    | A storm of offer/answer round trips, and eventually glare deadlock                                 | `track.enabled = false`; perfect negotiation when you must renegotiate (sec 23)             |
+| **Blocking or ignoring RTCP**      | Lip sync drifts, congestion control goes blind, nothing looks broken                               | RTCP is load-bearing, not optional telemetry (sec 14, 16)                                   |
+| **Audio defaults on for music**    | Instruments sound broken; sustained notes are removed as "noise"                                   | Disable AEC, AGC and noise suppression for music (sec 20)                                   |
+| **Alerting on loss, not freezes**  | Dashboards green while users stare at frozen video                                                 | Freeze duration and join success are the user-visible SLIs (sec 34)                         |
+| **Composed recording on the SFU**  | One transcode pipeline per room starves the forwarding path                                        | Recording is a separate, separately scaled service (sec 25)                                 |
+
+<Callout type="warn" title="The pattern: connectivity and placement, not media">
+Look down that list. Almost none of these are about codecs, jitter or encryption — the parts of WebRTC that feel hardest to learn. They are about **getting a path** and **putting servers in the right place with the right addresses**, which is to say constraints 1 and 6. Budget your attention accordingly: the media stack mostly works if you leave it alone, while ICE, TURN and deployment topology are where your users' failures actually come from.
+</Callout>
+
+## Designing a Real-Time Media System
+
+Pulling the manual into design judgment.
+
+#### Design principles
+
+- **Prove you need sub-second latency.** If nobody has to react, use HTTP streaming and skip this chapter's entire operational burden (sec 6, 36).
+- **Do the geography before the architecture.** Sec 2's table sets a floor no engineering removes. If your users are on opposite sides of the planet, decide what that means for the product before you pick a stack.
+- **Start with a managed SFU.** Building a media plane is a multi-year commitment; renting one is a config file. Move in-house when unit economics or data requirements demand it, not before (sec 28).
+- **Own your TURN.** Even on a managed SFU, relay behaviour and its cost are yours to understand. Ephemeral credentials, regional placement, a TLS-on-443 fallback, and relay rate as a tracked metric (sec 31).
+- **Design signaling as an ordinary authenticated service.** It is a WebSocket app with rooms, every rule from the previous chapter applies — and it is the root of trust for the media encryption too (sec 7, 35).
+- **Place rooms, do not balance connections.** Media state cannot move, so decide once, at room creation, in the right region, and record it (sec 32).
+- **Treat capacity as bandwidth.** Size by egress and stream count, keep headroom below the NIC limit, and provision ahead of peak because scaling out cannot rescue calls already in progress (sec 32).
+- **Adapt, do not force.** Simulcast or SVC so each subscriber gets a stream matched to their link, and let congestion control set the bitrate (sec 19, 30).
+- **Send less before you send better.** Subscription policy beats every encoder tweak in a large call, by an order of magnitude (sec 29).
+- **Measure what the user sees.** Freeze time, join success rate, relay rate. Server CPU tells you almost nothing about call quality (sec 34).
+- **Plan the deploy story before the launch story.** Long grace periods, room draining, and a client that reconnects and renegotiates cleanly (sec 23, 33).
+
+<Callout type="ok" title="A worked sizing example, from the constraints">
+A thousand concurrent 4-person calls, 720p simulcast, on an SFU. By sec 30, each participant publishes about 1.7 Mbps across three layers. By sec 29, they subscribe to three others at roughly 1 Mbps each. So the server receives 1.7 Mbps and sends about 3 Mbps per participant — times four thousand participants, about **7 Gbps in and 12 Gbps out**. At a conservative 3 Gbps of usable egress per instance (sec 32: stay well below the NIC), that is five or six SFU instances plus headroom, spread across your user regions, and **your dominant cost line is egress, not compute**. Now add TURN: at a 15 percent relay rate, 150 of those calls also pay relay bandwidth twice (sec 31). Run this arithmetic before you choose an architecture — it is what actually decides between self-hosting and a managed service, and it takes ten minutes.
+</Callout>
+
+## Cheat-Sheet
+
+The whole manual compressed to what you reach for under pressure.
+
+| Concept             | One-liner                                                                                            |
+| ------------------- | ------------------------------------------------------------------------------------------------------ |
+| The six numbers     | Light 5ms/1000km · 150ms budget · 1200-byte packets · 332 Mbps raw · loss propagates · not enough IPs (sec 2). |
+| Why WebRTC          | TCP retransmits and blocks; media must drop late packets and keep going (sec 1).                        |
+| Why the stack looks like that | Ten forced moves from those six numbers. Nothing in it was a preference (sec 3).              |
+| What it is          | ICE + STUN/TURN + DTLS + SRTP + RTP + SCTP behind one browser API. Not one protocol (sec 4).             |
+| Not included        | Signaling. You build it, usually a WebSocket to your own backend (sec 7).                               |
+| SDP                 | Line-oriented session contract; offer lists options, answer picks the subset (sec 8).                   |
+| BUNDLE + rtcp-mux   | Everything on one transport, one port. Do not turn these off (sec 8).                                   |
+| NAT, in one line    | A table keyed on who you contacted. Mapping decides if your address is real; filtering opens when you send first (sec 9). |
+| Candidate types     | host (same LAN) / srflx (via STUN) / relay (via TURN) / prflx (discovered mid-check) (sec 10-12).        |
+| STUN                | Two packets: "what is my public address". Cheap, self-host it (sec 10).                                 |
+| TURN                | A relay for when hole punching fails. Always ship it. 10-20% of sessions need it (sec 11).              |
+| ICE                 | Gather, exchange, check pairs with STUN, nominate the best working pair (sec 12).                        |
+| Trickle ICE         | Send candidates as found instead of waiting. Saves a second of setup (sec 12).                           |
+| ICE restart         | Renegotiate the path without dropping the call, for network changes (sec 12).                            |
+| ICE-lite            | The server-side role: answer checks, never initiate. Needs a correct public IP (sec 12, 33).             |
+| Encryption          | DTLS-SRTP, mandatory, no plaintext mode. Trust comes from the SDP fingerprint (sec 13).                  |
+| RTP header          | seq (loss), timestamp (playout), SSRC (which stream), marker (frame end) (sec 14).                       |
+| RTCP feedback       | SR (lip sync!), RR, NACK (resend), PLI (keyframe), TWCC (arrival times) (sec 14).                        |
+| Header extensions   | The metadata an SFU may read without decrypting: transport-cc, mid, rid, audio-level (sec 15).           |
+| Lip sync            | RTCP sender reports map each stream's clock to wall clock. No SR, no sync (sec 16).                      |
+| Clock drift         | 50 ppm = 180ms/hour. The receiver resamples continuously to absorb it (sec 16).                          |
+| Codecs              | Opus for audio, always with FEC and DTX. VP8 safe, H.264 for hardware, AV1/VP9 for SVC (sec 17).         |
+| Keyframes           | 10-20× a delta frame, ~50 packets, and the frame most likely to be lost. Ask sparingly (sec 17).         |
+| NACK inequality     | Retransmit only if RTT < time left in the buffer. Otherwise spend it on FEC (sec 18).                    |
+| Repair order        | FEC (no latency) → NACK (one RTT) → concealment → PLI (most expensive) (sec 18).                          |
+| Jitter buffer       | Trades latency for smoothness; time-stretches audio rather than changing pitch (sec 18).                 |
+| Congestion control  | Queue grows before it overflows, so delay precedes loss. GCC watches the delay trend (sec 19).           |
+| The pacer           | Smooths bursts so you do not cause the congestion you then react to (sec 19).                            |
+| Bitrate allocation  | Audio first, then video quality, then frame rate, then resolution (sec 19).                              |
+| Audio pipeline      | AEC subtracts a known reference; breaks on variable delay (Bluetooth, two devices in a room) (sec 20).    |
+| Music mode          | Turn AEC, AGC and noise suppression OFF, or instruments sound broken (sec 20).                           |
+| Data channels       | SCTP over DTLS; per-channel ordering and reliability, from TCP-like to UDP-like (sec 21).                 |
+| Perfect negotiation | One polite peer rolls back on collision. Never hand-roll glare handling (sec 23).                        |
+| WHIP / WHEP         | POST an offer, get an answer. Signaling deleted, for one-way ingest and playback (sec 26).                |
+| Topologies          | Mesh under 4 (N−1 encoders!), SFU for everything else, MCU only for weak endpoints (sec 27).             |
+| SFU                 | Forwards encrypted packets, rewrites sequence numbers per subscriber, never decodes (sec 28).            |
+| Active speaker      | Read the audio-level header extension. No decoding required (sec 29).                                    |
+| Subscription policy | Last-N or client-driven. The biggest win available in a large call (sec 29).                             |
+| Simulcast / SVC     | Publish several qualities; the SFU picks one per subscriber. SVC needs no keyframe to switch (sec 30).    |
+| TURN config         | `use-auth-secret`, `external-ip`, port range, deny RFC1918, 443 fallback (sec 31).                        |
+| TURN cost           | Relayed bitrate × 2 directions × 2 (in and out). Relay rate is your bill (sec 31).                        |
+| Media scaling       | Rooms are the placement unit; state cannot move; scale on bandwidth, not CPU (sec 32).                    |
+| Cascading           | SFUs peer so a stream crosses the ocean once, not once per viewer (sec 32).                              |
+| Deployment          | No LB for UDP, no container NAT, host networking, drain by waiting (sec 33).                             |
+| Metrics that matter | Freeze duration, join success rate, RTT, relay rate. Not CPU (sec 34).                                   |
+| E2EE                | SFrame via insertable streams; the readable header is what makes it possible, and it costs you recording (sec 35). |
+| Decision rule       | Human must react in under 500ms → WebRTC. Otherwise HLS, and save yourself the year (sec 6, 36).          |
+
+**The whole topic in one breath:** Six measurable facts decide everything — light needs 5ms per 1000 km, conversation collapses past a 150ms budget, a packet must stay under about 1200 bytes, raw 720p is 332 Mbps and so must be compressed 200:1, that compression makes every frame depend on the last so one lost packet corrupts the future, and there are not enough IPv4 addresses for anyone to be reachable (sec 2). From those, the entire stack is forced: a transport willing to lose data (UDP), the sequence numbers and timestamps UDP left out (RTP), a feedback channel so the sender can adapt (RTCP), encryption over datagrams that still leaves the header readable so a server can route without decrypting (DTLS-SRTP), trust anchored in the signaling channel because no CA will vouch for a laptop (the SDP fingerprint), address discovery and relay and exhaustive probing because neither peer can be addressed (STUN, TURN, ICE), an offer/answer contract for what is being sent (SDP), and per-channel reliability for everything that is not media (SCTP) — which is exactly WebRTC, with nothing left over (sec 3-4). You supply the signaling yourself (sec 7). NAT is a table whose filtering rule opens when you send first, which is why hole punching works and why symmetric NAT — where the address itself is wrong — needs a relay instead (sec 9-12). Media rides RTP with header extensions carrying the metadata infrastructure is allowed to read (sec 14-15), RTCP sender reports supply the only clock both streams share and therefore lip sync itself (sec 16), and a jitter buffer plus FEC, NACK and keyframe requests trade latency for quality according to whether the round trip fits inside the buffer (sec 17-18), while congestion control watches queueing delay — which rises before loss appears — and a pacer keeps the sender from causing its own congestion (sec 19). Audio gets a processing chain that cancels echo by subtracting a reference it already has (sec 20). Past two participants, mesh dies on encoder count and an SFU forwards without decoding, rewriting sequence numbers so subscribers never see the seam (sec 27-28), choosing what to send from audio-level headers and subscription policy (sec 29) and which quality from simulcast or SVC layers (sec 30). In production, TURN needs ephemeral credentials and a public-address mapping (sec 31), rooms are placed once because media state cannot move (sec 32), media servers refuse load balancers and container NAT and cannot be rolled like stateless services (sec 33), quality is measured on the client in freeze time and join success rather than on the server in CPU (sec 34), and the security work is access control and credentials, with a second encryption layer if your threat model truly needs it (sec 35). And the first decision is still the biggest: if nobody has to react in under half a second, do not use any of this (sec 6).
+
+Grounded in the W3C WebRTC 1.0 specification and MDN (developer.mozilla.org/en-US/docs/Web/API/WebRTC\_API) & RFC 8445 (ICE), 8489 (STUN), 8656 (TURN), 8829 (JSEP), 8866 (SDP), 3550 (RTP), 3711 (SRTP), 5764 (DTLS-SRTP), 8285 (header extensions), 9335 (Cryptex), 8831 (data channels), 9725 (WHIP), 9420 (MLS), ITU-T G.114 (delay) / pion/webrtc v4 & aiortc / coturn / Go 1.22+ and Python 3.11+ examples.
+
+Backend from First Principles / Chapter 26 / WebRTC. Code targets Go 1.22+ and Python 3.11+.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,7 +13,7 @@ const PARTS = [
   { from: 1,  to: 7,  label: 'The Request Path',  blurb: 'How bytes on a socket become a handled request.' },
   { from: 8,  to: 14, label: 'State & Machinery',  blurb: 'Where data lives, and the moving parts around it.' },
   { from: 15, to: 20, label: 'Running in Production', blurb: 'Keeping it observable, secure and fast under load.' },
-  { from: 21, to: 24, label: 'Distribution & Scale', blurb: 'Shipping it, testing it, and connecting services.' },
+  { from: 21, to: 26, label: 'Distribution & Scale', blurb: 'Shipping it, testing it, and connecting services in real time.' },
 ];
 const grouped = PARTS.map((p) => ({
   ...p,
@@ -21,15 +21,15 @@ const grouped = PARTS.map((p) => ({
 })).filter((p) => p.chapters.length > 0);
 ---
 <Base
-  title="Backend from First Principles — a 24-chapter engineering reference"
-  description="A 24-chapter reference on backend engineering, from HTTP and routing through databases, caching and Kafka to production deployment. Notes, diagrams and runnable Go and Python examples."
+  title="Backend from First Principles — a 25-chapter engineering reference"
+  description="A 25-chapter reference on backend engineering, from HTTP and routing through databases, caching and Kafka to production deployment and real-time media. Notes, diagrams and runnable Go and Python examples."
   path="/"
 >
   <SiteHeader />
 
   <main class="home" id="main">
     <section class="hero">
-      <p class="eyebrow">A 24-chapter engineering reference</p>
+      <p class="eyebrow">A 25-chapter engineering reference</p>
       <h1 class="hero-title">Backend, from <em>first principles</em>.</h1>
       <p class="hero-lede">
         Most backend material teaches a framework. This teaches the machinery underneath it —


### PR DESCRIPTION
Adds WebRTC to the series, built as a **derivation** rather than a tour of acronyms.

Numbered **26** rather than 25 to leave that slot for #14 (GraphQL), which claimed it first. Happy to renumber if that lands elsewhere — it's a one-line change.

## Why this is a chapter and not a subtopic

You asked whether WebRTC could sit inside an existing chapter. I looked into it, and I don't think it can:

- The only plausible parent is Chapter 24 (WebSockets & Real-Time). Merging produces a ~31,000-word chapter, over twice the size of the largest chapter today.
- **About a third of the material is backend infrastructure** — running a TURN fleet, how an SFU forwards video without decoding it, placing rooms across media servers, why a load balancer can't sit in front of UDP media, why a rolling deploy drops every live call. That's the part a browser-side tutorial never covers, and it's what makes WebRTC a *backend* topic. Shrinking to a subtopic means deleting exactly that.
- gRPC, Kafka and WebSockets each get a full chapter at ~7,000 words. WebRTC is a protocol family of comparable size that additionally carries a media plane and its own server infrastructure.
- MDN scopes it the same way — roughly nine separate guides plus a reference tree, framed as *"several interrelated APIs and protocols which work together."*

## The approach

Most WebRTC material lists acronyms and explains each one. You finish able to recite the names and still unable to say *why any of them exist*.

This chapter refuses to introduce an acronym until the reader has been forced to invent it. It opens with **six measurable facts, computed on the page**:

| # | Fact | Computed | Forces |
|---|------|----------|--------|
| 1 | Light in fibre: 200,000 km/s | Sydney→London is 110ms minimum | Regional servers |
| 2 | Turn-taking gap ~200ms | 150ms mouth-to-ear budget (ITU-T G.114) | Every buffer is a tax |
| 3 | Path MTU 1500 | ~1200 usable; splitting **triples** loss | App-layer fragmentation |
| 4 | Raw 720p30 = 332 Mbps | Target 1.5 Mbps → 200:1 | Can't send whole frames |
| 5 | 200:1 needs temporal prediction | Frames depend on each other | **One lost packet corrupts the future** |
| 6 | 4.3bn IPv4 vs 20bn devices | NAT is arithmetic | Nobody has an address |

Section 3 then derives the whole stack from them in ten forced moves — a transport willing to drop data (UDP), the sequence numbers and timestamps UDP omits (RTP), a feedback channel (RTCP), encryption over datagrams that still leaves the header readable so a server can route without decrypting (DTLS-SRTP), trust anchored in signaling because no CA vouches for a laptop (the SDP fingerprint), address discovery and relay and exhaustive probing (STUN/TURN/ICE), and per-channel reliability (SCTP) — arriving at WebRTC with nothing left over.

The same method runs throughout: NAT derived from its translation table so the type taxonomy falls out instead of being memorised; congestion control derived from queue mechanics, so delay *necessarily* precedes loss; retransmission as an inequality against the jitter buffer.

## Contents

40 sections in 6 parts · 16 diagrams · 32 callouts · 14 runnable examples (Go, Python, JavaScript) · 47 protocol traces · 20 RFCs cited.

Includes several topics most WebRTC material omits: **RTP header extensions** (how an SFU routes media it may not decrypt), **clock drift and lip sync** (RTCP sender reports are the only shared clock; 50ppm drifts 180ms in an hour), **the audio pipeline** (echo cancellation derived from having a copy of the signal you played), **active-speaker detection** (a 20× bandwidth win from subscription policy alone), and **the UDP deployment problem**.

## Conventions followed

- `Diagram` and `Callout` components; all artwork uses `--dg-*` tokens so it follows the theme
- Paired Go/Python snippets carry the `Go`/`Python` labels so the new `rehype-code-tabs` plugin groups them — verified rendering as 5 tab groups
- Frontmatter matches the collection schema; prev/next and the homepage grid pick it up automatically

## Verification

- `npm run build` clean; `npm test` **12/12** (same as a clean `main`)
- All ~26 numerical derivations recomputed; all 200+ internal cross-references checked
- Claims checked against **MDN** (its ICE/STUN/TURN/NAT/SDP definitions match; on symmetric NAT this follows RFC 4787's mapping/filtering distinction)
- The 150ms figure verified against **ITU-T G.114** ("below 150 ms… essentially transparent interactivity", "above 400 ms are unacceptable")
- Rendering checked in both light and dark mode

## A note on length

It's the longest chapter in the series (~24k words, 5-6 hours) against a norm of 2-4 hours. If you'd prefer it match the house size, it splits cleanly at the Part III/IV seam — *how the protocol works* vs *how you build and run it* — giving two chapters of ~12,900 and ~11,300 words at 21 and 19 sections, both inside the current range, with precedent in Chapters 18/19. Happy to do that; I'd just rather split than cut, since the infrastructure half is what makes it a backend chapter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116nXymCEajo7YQatHdRwSg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a Table of Contents entry covering WebRTC and real-time media, including peer-to-peer audio/video, NAT traversal, security, congestion control, and SFU infrastructure.

- **Content Updates**
  - Updated the site’s chapter count and related page title, description, and hero text to reference the 25-chapter reference.
  - Expanded the “Distribution & Scale” section description to include real-time systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->