### PR TITLE
fix: render numbered step flows as styled components instead of raw text

### DIFF
--- a/src/components/Step.astro
+++ b/src/components/Step.astro
@@ -1,0 +1,47 @@
+---
+---
+<li class="step"><slot /></li>
+
+<style>
+  .step {
+    position: relative;
+    counter-increment: step;
+    padding-left: calc(var(--space-6) + var(--space-3));
+    padding-bottom: var(--space-5);
+    margin-top: 0;
+  }
+  .step:last-child { padding-bottom: 0; }
+
+  .step::before {
+    content: counter(step);
+    position: absolute;
+    left: 0;
+    top: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--space-6);
+    height: var(--space-6);
+    border-radius: 50%;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    color: var(--ink);
+    font-family: var(--font-ui);
+    font-size: var(--text-xs);
+    font-weight: 640;
+    z-index: 1;
+  }
+  .step:not(:last-child)::after {
+    content: '';
+    position: absolute;
+    left: calc(var(--space-6) / 2 - 0.5px);
+    top: var(--space-6);
+    bottom: 0;
+    width: 1px;
+    background: var(--line-2);
+  }
+
+  .step > :global(* + *) { margin-top: var(--space-3); }
+  .step > :global(:first-child) { margin-top: 0; }
+  .step > :global(:last-child) { margin-bottom: 0; }
+</style>

--- a/src/components/StepBranch.astro
+++ b/src/components/StepBranch.astro
@@ -1,0 +1,49 @@
+---
+interface Props {
+  labelA?: string;
+  labelB?: string;
+}
+const { labelA = 'A', labelB = 'B' } = Astro.props;
+---
+<div class="step-branch">
+  <div class="branch-box">
+    <p class="branch-label">{labelA}</p>
+    <div class="branch-body"><slot name="a" /></div>
+  </div>
+  <div class="branch-box">
+    <p class="branch-label">{labelB}</p>
+    <div class="branch-body"><slot name="b" /></div>
+  </div>
+</div>
+
+<style>
+  .step-branch {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-4);
+    margin-left: calc(var(--space-6) + var(--space-3));
+  }
+  .branch-box {
+    padding: var(--space-4);
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    background: var(--surface);
+  }
+  .branch-label {
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+    font-weight: 640;
+    color: var(--ink-2);
+    text-transform: uppercase;
+    letter-spacing: var(--tracking-wide);
+    margin: 0 0 var(--space-2);
+  }
+  .branch-body { font-size: var(--text-base); }
+  .branch-body :global(> * + *) { margin-top: var(--space-3); }
+  .branch-body :global(> :first-child) { margin-top: 0; }
+  .branch-body :global(> :last-child) { margin-bottom: 0; }
+
+  @media (max-width: 640px) {
+    .step-branch { grid-template-columns: 1fr; }
+  }
+</style>

--- a/src/components/Steps.astro
+++ b/src/components/Steps.astro
@@ -1,0 +1,14 @@
+---
+---
+<ol class="steps">
+  <slot />
+</ol>
+
+<style>
+  .steps {
+    list-style: none;
+    padding-left: 0;
+    margin-bottom: 0;
+    counter-reset: step;
+  }
+</style>

--- a/src/content/chapters/01-http-and-cors.mdx
+++ b/src/content/chapters/01-http-and-cors.mdx
@@ -527,27 +527,20 @@ The fix: idempotency keys
 
 The client generates a unique key (typically a UUID) for the _logical operation_ and sends it as an `Idempotency-Key` header. The server stores the key alongside the result of the first successful execution. If the same key ever arrives again, because the client retried, the server recognizes it and returns the **stored result** without re-running the work. The operation thus executes _at most once_ regardless of how many times it's submitted. (MDN now documents `Idempotency-Key` as a standardizing header, and payment APIs like Stripe popularized the pattern.)
 
-1
-
+<Steps>
+<Step>
 Client sends `POST /payments` with `Idempotency-Key: 9f8c-...`.
-
-v
-
-2
-
+</Step>
+<Step>
 Server checks its key store. Key unseen -> run the charge, persist `key -> result`, return 201.
-
-v
-
-3
-
+</Step>
+<Step>
 The network drops the response. The client, unsure, retries with the _same_ key.
-
-v
-
-4
-
+</Step>
+<Step>
 Server sees the key already exists -> returns the stored result. **No second charge.**
+</Step>
+</Steps>
 
 #### Implementation considerations
 
@@ -780,21 +773,17 @@ CORS is enforced entirely by the **browser**, not the server. The server only _a
 
 For requests the spec deems "simple", GET, POST, or HEAD using only standard headers and a common content type, the browser doesn't bother asking permission in advance. It just sends the request (with an `Origin` header) and checks the response afterward.
 
-1
-
+<Steps>
+<Step>
 Browser automatically adds `Origin: https://example.com` and sends the request.
-
-v
-
-2
-
+</Step>
+<Step>
 Server checks the origin against its policy; if allowed, it includes `Access-Control-Allow-Origin` echoing that origin (or `*`) in the response.
-
-v
-
-3
-
+</Step>
+<Step>
 Browser sees a matching header -> hands the response to the page. Header missing -> browser **blocks the response** and logs a CORS error, even though the server processed the request.
+</Step>
+</Steps>
 
 ### Flow 2: the preflighted request
 
@@ -808,21 +797,17 @@ Why you see OPTIONS everywhere
 
 Since a typical authenticated JSON API request hits _all three_ triggers (JSON body, Authorization header, often a non-GET method), **nearly every real API call is preflighted**. That's why your Network tab shows a paired `OPTIONS` request immediately before each actual call, it's not a bug, it's the browser asking permission.
 
-1
-
+<Steps>
+<Step>
 Browser sends `OPTIONS /resource` with `Access-Control-Request-Method` and `-Request-Headers`, asking "may I send this method with these headers from my origin?", no body.
-
-v
-
-2
-
+</Step>
+<Step>
 Server replies 204 No Content with `Access-Control-Allow-Origin / -Methods / -Headers`, plus `-Max-Age` telling the browser how long it may cache this approval (e.g. 24h) so it can skip the preflight on future identical calls.
-
-v
-
-3
-
+</Step>
+<Step>
 Approval granted -> the browser sends the actual request and returns the real response to the page.
+</Step>
+</Steps>
 
 One extra wrinkle for **credentialed** requests (those carrying cookies): the server must also send `Access-Control-Allow-Credentials: true`, and in that mode it may _not_ use the `*` wildcard for the origin, it has to name the exact origin. This prevents a server from accidentally exposing authenticated data to any site.
 
@@ -1098,25 +1083,22 @@ The server stamps a response with how long it stays usable, so the client can re
 
 When freshness lapses, the client doesn't blindly re-download, it revalidates. The original response carried an `ETag` (a fingerprint/hash of the content) and/or a `Last-Modified` timestamp. The client sends these back as _conditional_ headers, and if nothing changed the server returns a tiny 304 with no body, saving the entire payload.
 
-1
-
+<Steps>
+<Step>
 First GET -> 200 + body + `ETag: "abc"` + `Cache-Control: max-age=10`.
-
-v
-
-2
-
+</Step>
+<Step>
 After freshness expires, the next GET sends `If-None-Match: "abc"` (and/or `If-Modified-Since`).
-
-v
-
-3a
-
+</Step>
+</Steps>
+<StepBranch labelA="3a" labelB="3b">
+<Fragment slot="a">
 Unchanged -> 304 Not Modified with an empty body. The client reuses its copy; the payload bytes are saved.
-
-3b
-
+</Fragment>
+<Fragment slot="b">
 Changed -> 200 with the new body and a fresh ETag.
+</Fragment>
+</StepBranch>
 
 ETags come in two flavors: a **strong** ETag (`"abc"`) guarantees byte-for-byte identity, while a **weak** one (`W/"abc"`) only promises semantic equivalence, useful when, say, a timestamp in the response differs but the meaningful content doesn't.
 
@@ -1198,25 +1180,22 @@ Each says "proceed only if a condition about the resource's current version hold
 
 ### The optimistic-locking flow
 
-1
-
+<Steps>
+<Step>
 Client GETs `/doc/7` -> receives the body plus `ETag: "v1"`.
-
-v
-
-2
-
+</Step>
+<Step>
 After editing, client sends `PUT /doc/7` with `If-Match: "v1"`, "only save if it's _still_ v1, i.e. nobody changed it under me."
-
-v
-
-3a
-
+</Step>
+</Steps>
+<StepBranch labelA="3a" labelB="3b">
+<Fragment slot="a">
 Still v1 -> apply the update, return 200 + the new `ETag: "v2"`.
-
-3b
-
+</Fragment>
+<Fragment slot="b">
 Someone already bumped it to v2 -> reject with 412 Precondition Failed. No lost update, the client refetches v2, reapplies its change, and retries.
+</Fragment>
+</StepBranch>
 
 Why this beats a database lock
 

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -3,10 +3,13 @@ import { getCollection, render } from 'astro:content';
 import Chapter from '../layouts/Chapter.astro';
 import Callout from '../components/Callout.astro';
 import Diagram from '../components/Diagram.astro';
+import Steps from '../components/Steps.astro';
+import Step from '../components/Step.astro';
+import StepBranch from '../components/StepBranch.astro';
 
 // Chapters use <Callout> and <Diagram> without importing them, so a chapter
 // file stays plain content. Register them once, here.
-const mdxComponents = { Callout, Diagram };
+const mdxComponents = { Callout, Diagram, Steps, Step, StepBranch };
 
 export async function getStaticPaths() {
   const all = (await getCollection('chapters'))


### PR DESCRIPTION
Chapter 1 had step-by-step flows written as literal plain-text markers
(`1`, `v`, `2`, `v`, `3a`, `3b`), which rendered as ugly raw lines in the
browser instead of a visual flow.

**Before:**
<img width="1366" height="694" alt="old" src="https://github.com/user-attachments/assets/835b3fb7-7b9e-4eea-acf5-5273ea69a0bf" />

**After:**
<img width="1366" height="693" alt="new" src="https://github.com/user-attachments/assets/cfc9add4-7f21-4a4c-918f-60e1182605bd" />


## Changes

- Add `<Steps>` / `<Step>` / `<StepBranch>` Astro components:
  - `Steps.astro` — an `<ol>` wrapper that renders numbered circles + a
    connector line for each `<Step>`, using CSS counters.
  - `Step.astro` — a single step (`<li>`).
  - `StepBranch.astro` — side-by-side boxes for a flow that splits into
    two outcomes (e.g. `3a` / `3b`), with custom labels via props.
- Register the new components in `[...slug].astro`'s `mdxComponents`.
- Convert all 5 raw-text step flows in `01-http-and-cors.mdx` to the new
  JSX syntax. Only the wrapping markup changed — prose content and inline
  code are untouched.

Styling reuses existing design tokens only (`--line`, `--space-*`,
`--font-ui`, `--text-sm`, `--radius`, etc.) — no new colors or dependencies,
and dark mode works automatically since it's all CSS custom properties.

Closes #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added numbered step layouts with connecting lines for clearer procedural content.
  - Added responsive two-branch layouts with configurable labels and content panels.
  - Enabled these components in chapter pages.

- **Documentation**
  - Updated HTTP and CORS explanations with structured, visual step-by-step presentations.
  - Preserved existing guidance on idempotency keys, CORS, cache validation, and optimistic locking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->