### PR TITLE
feat(chapter): add a Back link above the table of contents

### DIFF
--- a/src/layouts/Chapter.astro
+++ b/src/layouts/Chapter.astro
@@ -27,7 +27,13 @@ const num = String(order).padStart(2, '0');
 
   <div class="shell">
     <aside class="rail">
-      <div class="rail-inner"><Toc headings={headings} /></div>
+      <div class="rail-inner">
+        <a class="rail-back" href="/">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="13.5" y1="8" x2="3.5" y2="8" /><polyline points="7.5,4 3.5,8 7.5,12" /></svg>
+          <span>Back</span>
+        </a>
+        <Toc headings={headings} />
+      </div>
     </aside>
 
     <main class="main" id="main">
@@ -174,6 +180,35 @@ const num = String(order).padStart(2, '0');
     padding-block: var(--space-6);
     padding-right: var(--space-3);
   }
+
+  /* Sits above the outline rather than inside <Toc>: it is a way out of the
+     chapter, not one of its sections, so it must not be announced as part of
+     the "On this page" nav. Padding plus the matching negative margin is the
+     .toc-link idiom -- it buys a hover target wider than the text while
+     keeping the label flush with "On this page" below it. */
+  .rail-back {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    margin-left: calc(-1 * var(--space-3));
+    margin-bottom: var(--space-4);
+    border-radius: var(--radius-sm);
+    font-family: var(--font-ui);
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--ink-3);
+    text-decoration: none;
+    transition: color 120ms ease, background-color 120ms ease;
+  }
+  .rail-back:hover { color: var(--accent); background: var(--accent-bg); }
+  .rail-back svg {
+    width: 15px;
+    height: 15px;
+    flex: none;
+    transition: transform 120ms ease;
+  }
+  .rail-back:hover svg { transform: translateX(-2px); }
 
   .main { min-width: 0; padding-block: var(--space-8) var(--space-9); }
 


### PR DESCRIPTION
The chapter rail offered no way back to the index. The wordmark links home, but it reads as branding rather than navigation, so the only obvious route back was the browser button.

Adds a "Back" link at the top of the rail, above the outline.

It sits in the layout rather than inside <Toc> on purpose: it is a way out of the chapter, not one of its sections, so it must not be announced as part of the "On this page" nav. Styling reuses the .toc-link idiom (padding plus a matching negative margin) so the hover target is wider than the text while the label stays flush with the heading below it, and every value is a token, so it follows both themes without new colours.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Back” link with a left-arrow icon above the chapter table of contents.
  * The link returns visitors to the site home page and includes hover styling with subtle icon movement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->