### PR TITLE
fix: let long search results lists scroll.

### DIFF
--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -33,10 +33,19 @@
     max-height: min(34rem, calc(100vh - 6rem));
     overflow: hidden;
   }
-  /* The query stays put; only the results scroll. */
-  #pagefind .pagefind-ui__form { flex: none; }
-  #pagefind .pagefind-ui__drawer { overflow-y: auto; }
+  /* The query stays put; only the results scroll.
+
+     Which means every ancestor of the drawer has to be able to shrink, and a
+     flex item will not shrink past its content unless it is told to. Pagefind
+     puts the results *inside* the <form>, below the input rather than beside
+     it, so pinning the form held the whole result list at its full height:
+     the panel clipped it and there was no scrollbar anywhere to recover it. */
   #pagefind { display: flex; flex-direction: column; min-height: 0; }
+  #pagefind .pagefind-ui { display: flex; flex-direction: column; min-height: 0; }
+  #pagefind .pagefind-ui__form { display: flex; flex-direction: column; flex: 1; min-height: 0; }
+  /* The clear button is absolutely positioned, so it stays put on its own. */
+  #pagefind .pagefind-ui__search-input { flex: none; }
+  #pagefind .pagefind-ui__drawer { flex: 1; min-height: 0; overflow-y: auto; }
 
   /* Pagefind ships its own markup; map it onto the design tokens. */
   #pagefind {


### PR DESCRIPTION
Search results couldn't be scrolled. Only the first two were reachable, and the
"Load more results" button was clipped out of view entirely. Searching "http"
returns 22 matches, of which 2 could be seen. No scrollbar, and the wheel did
nothing.

Pagefind puts the results inside the search `<form>`, so the `flex: none` meant
to pin the query row pinned the results too. Stuck at full height in a panel
that clips, there was nothing left to scroll.

Fixed by pinning the input instead of the form, and letting the elements
between it and the results shrink.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scrolling in the search drawer so full-height search results remain accessible.
  - Updated the layout to allow the results list to resize correctly within the panel.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->