### PR TITLE
feat(chapters): add TypeScript and Java code tabs to chapters 01-03

### DIFF
--- a/src/content/chapters/01-http-and-cors.mdx
+++ b/src/content/chapters/01-http-and-cors.mdx
@@ -2,7 +2,7 @@
 order: 1
 title: "HTTP & CORS"
 navTitle: "HTTP & CORS"
-summary: "A first-principles walkthrough of the application-layer protocol every backend touches, from statelessness and method semantics to caching, conditional requests, proxies, and TLS. Written to explain not just what each piece does but why it exists and how it works underneath. Implementations in Go, Python and JavaScript, grounded in MDN and RFC 9110."
+summary: "A first-principles walkthrough of the application-layer protocol every backend touches, from statelessness and method semantics to caching, conditional requests, proxies, and TLS. Written to explain not just what each piece does but why it exists and how it works underneath. Implementations in Go, Python, JavaScript, TypeScript and Java, grounded in MDN and RFC 9110."
 readingTime: "3-4 hours"
 keywords:
   - "http"
@@ -161,7 +161,7 @@ Headers go on the wire **before** the status line and body, the receiver reads t
 
 ______
 
-Go Python JavaScript
+Go Python JavaScript TypeScript Java
 
 ```go
 package main
@@ -237,6 +237,67 @@ app.post('/api/v1/notes', (req, res) => {
 app.listen(8080)
 ```
 
+```ts
+import express from 'express'
+
+interface Note {
+  id: number
+  title: string
+  done: boolean
+}
+
+const app = express()
+app.use(express.json())            // parses the body; malformed JSON -> 400 automatically
+
+app.post('/api/v1/notes', (req, res) => {
+  // req.body is `any`: the annotation is only a claim, the typeof check proves it
+  const { title, done = false }: Partial<Note> = req.body ?? {}
+  if (typeof title !== 'string') {
+    return res.status(400).json({ error: 'invalid JSON' })
+  }
+  const note: Note = { id: 42, title, done }
+  res.set('Content-Type', 'application/json')  // 1. headers FIRST
+  res.status(201)                              // 2. status
+  res.json(note)                               // 3. body LAST
+})
+
+app.listen(8080)
+```
+
+```java
+import java.util.Map;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+record NoteInput(String title, Boolean done) {}
+record Note(long id, String title, boolean done) {}
+
+@SpringBootApplication
+@RestController
+class NotesApp {
+
+    // Spring parses the JSON body into NoteInput; malformed JSON -> 400 automatically.
+    @PostMapping("/api/v1/notes")
+    ResponseEntity<?> createNote(@RequestBody NoteInput in) {
+        if (in.title() == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "invalid JSON"));
+        }
+        Note note = new Note(42, in.title(), Boolean.TRUE.equals(in.done()));
+        // ResponseEntity collects headers, status and body up front, so Spring
+        // can put them on the wire in the right order for you.
+        return ResponseEntity.status(HttpStatus.CREATED)      // status
+                .contentType(MediaType.APPLICATION_JSON)      // headers
+                .body(note);                                  // body
+    }
+
+    public static void main(String[] args) {
+        SpringApplication.run(NotesApp.class, args);          // listens on :8080 by default
+    }
+}
+```
+
 ## Why Headers Exist
 
 Headers are **key-value pairs of metadata** attached to a request or response, sitting between the start line and the body. The natural question is: why a separate section at all? Why not put this information in the URL, or inside the body?
@@ -283,7 +344,7 @@ Because these should apply to _every_ response, you set them once in middleware 
 
 ______
 
-Go Python JavaScript
+Go Python JavaScript TypeScript Java
 
 ```go
 func securityHeaders(next http.Handler) http.Handler {
@@ -325,6 +386,44 @@ function securityHeaders(req, res, next) {
 
 app.use(securityHeaders)
 // In production `helmet()` sets these, and more, for you.
+```
+
+```ts
+import type { NextFunction, Request, Response } from 'express'
+
+function securityHeaders(req: Request, res: Response, next: NextFunction): void {
+  res.set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains')
+  res.set('Content-Security-Policy', "default-src 'self'")
+  res.set('X-Frame-Options', 'DENY')
+  res.set('X-Content-Type-Options', 'nosniff')
+  next() // headers MUST be set before the handler writes the body (see sec 3)
+}
+
+app.use(securityHeaders)
+// In production `helmet()` sets these, and more, for you.
+```
+
+```java
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.*;
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component // Spring Boot registers every Filter bean for all requests
+class SecurityHeadersFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
+            throws ServletException, IOException {
+        res.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains");
+        res.setHeader("Content-Security-Policy", "default-src 'self'");
+        res.setHeader("X-Frame-Options", "DENY");
+        res.setHeader("X-Content-Type-Options", "nosniff");
+        chain.doFilter(req, res); // headers MUST be set before this call (see sec 3)
+    }
+}
+// In production Spring Security's http.headers(...) sets these, and more, for you.
 ```
 
 Part II / Methods & Semantics
@@ -442,7 +541,7 @@ TRACE asks the server to echo the request it received, so the client can see exa
 
 ______
 
-Go Python JavaScript
+Go Python JavaScript TypeScript Java
 
 ```go
 mux := http.NewServeMux()
@@ -513,6 +612,82 @@ function getNote(req, res) {
 }
 ```
 
+```ts
+import express, { type Request, type Response } from 'express'
+
+const app = express()
+
+// Express matches method + path. An unmatched method falls through to the 404
+// handler; add an `app.all` catch-all per route to answer 405 Method Not Allowed.
+app.get('/notes', listNotes)          // safe, cacheable read
+app.get('/notes/:id', getNote)        // GET also serves HEAD automatically
+app.post('/notes', createNote)        // create (server assigns id)
+app.put('/notes/:id', putNote)        // full replace (idempotent)
+app.patch('/notes/:id', patchNote)    // partial update
+app.delete('/notes/:id', deleteNote)  // remove (idempotent)
+
+function getNote(req: Request<{ id: string }>, res: Response) {
+  const { id } = req.params           // typed path params: { id: string }
+  const note = db.find(id)            // Note | undefined, so the 404 check can't be skipped
+  if (!note) return res.status(404).json({ error: 'not found' }) // 404
+  res.set('Content-Type', 'application/json')
+  res.json(note)                                                 // 200
+}
+```
+
+```java
+import java.util.*;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/notes")
+class NotesController {
+    private final NoteRepository notes;
+
+    NotesController(NoteRepository notes) {
+        this.notes = notes;
+    }
+
+    // Spring matches method + path. The right path with the wrong method gets
+    // 405 Method Not Allowed (plus an Allow header) automatically.
+    @GetMapping                      // safe, cacheable read (list)
+    List<Note> list(@RequestParam(required = false) Boolean done,
+                    @RequestParam(defaultValue = "20") int limit) {
+        return notes.list(done, limit);
+    }
+
+    @GetMapping("/{id}")             // GET also serves HEAD automatically
+    ResponseEntity<Note> get(@PathVariable long id) {
+        return notes.findById(id)
+                .map(ResponseEntity::ok)                    // 200
+                .orElse(ResponseEntity.notFound().build()); // 404
+    }
+
+    @PostMapping                     // create (server assigns id)
+    @ResponseStatus(HttpStatus.CREATED)
+    Note create(@RequestBody Note note) {
+        return notes.insert(note);
+    }
+
+    @PutMapping("/{id}")             // full replace (idempotent)
+    Note put(@PathVariable long id, @RequestBody Note note) {
+        return notes.replace(id, note);
+    }
+
+    @PatchMapping("/{id}")           // partial update
+    Note patch(@PathVariable long id, @RequestBody Map<String, Object> changes) {
+        return notes.update(id, changes);
+    }
+
+    @DeleteMapping("/{id}")          // remove (idempotent)
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    void delete(@PathVariable long id) {
+        notes.delete(id);
+    }
+}
+```
+
 ## Idempotency in Practice
 
 Idempotency is the property that makes a request **safe to retry**: and retries are not optional in a distributed system, they're inevitable. Networks drop packets, a client times out without knowing whether the request reached the server, a user impatiently double-clicks, a mobile app re-sends when the radio reconnects. GET, PUT, and DELETE are idempotent by design, so retrying them is harmless. POST is not, which is the root cause of duplicate-record and double-charge bugs.
@@ -550,7 +725,7 @@ Server sees the key already exists -> returns the stored result. **No second cha
 
 ______
 
-Go Python JavaScript
+Go Python JavaScript TypeScript Java
 
 ```go
 var seen sync.Map // key -> []byte result. Use Redis with a TTL in production.
@@ -602,6 +777,62 @@ app.post('/payments', async (req, res) => {
   seen.set(key, result)                    // remember it BEFORE responding
   res.status(201).json(result)
 })
+```
+
+```ts
+interface PaymentResult {
+  id: string
+  status: 'succeeded' | 'failed'
+}
+
+const seen = new Map<string, PaymentResult>() // key -> stored result. Use Redis with a TTL in production.
+
+app.post('/payments', async (req, res) => {
+  const key = req.get('Idempotency-Key')   // string | undefined
+  if (!key) {
+    return res.status(400).json({ error: 'missing Idempotency-Key' })
+  }
+  const stored = seen.get(key)             // one lookup that narrows; has() + get() wouldn't
+  if (stored) {                            // replay: return the stored result
+    return res.status(200).json(stored)
+  }
+  const result = await charge(req.body)    // the real, non-idempotent work
+  seen.set(key, result)                    // remember it BEFORE responding
+  res.status(201).json(result)
+})
+```
+
+```java
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+class PaymentsController {
+    // key -> stored result. Use Redis with a TTL in production.
+    private final Map<String, PaymentResult> seen = new ConcurrentHashMap<>();
+    private final PaymentGateway gateway;
+
+    PaymentsController(PaymentGateway gateway) {
+        this.gateway = gateway;
+    }
+
+    @PostMapping("/payments")
+    ResponseEntity<?> pay(@RequestHeader(name = "Idempotency-Key", required = false) String key,
+                          @RequestBody PaymentRequest body) {
+        if (key == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "missing Idempotency-Key"));
+        }
+        PaymentResult stored = seen.get(key);
+        if (stored != null) {                         // replay: return the stored result
+            return ResponseEntity.ok(stored);
+        }
+        PaymentResult result = gateway.charge(body);  // the real, non-idempotent work
+        seen.put(key, result);                        // remember it BEFORE responding
+        return ResponseEntity.status(HttpStatus.CREATED).body(result);
+    }
+}
 ```
 
 Idempotency keys protect against _duplicate execution_. A different but related hazard, two clients overwriting each other's edits (the "lost update"), needs a complementary tool: optimistic concurrency with `If-Match` and ETags, covered in sec 13.
@@ -663,7 +894,7 @@ On the protocol side, the `WWW-Authenticate` response header (paired with a 401)
 
 ______
 
-Go Python JavaScript
+Go Python JavaScript TypeScript Java
 
 ```go
 // Set a secure session cookie after login (stateful)
@@ -757,6 +988,106 @@ function requireToken(req, res, next) {
 app.get('/me', requireToken, (req, res) => res.json({ ok: true }))
 ```
 
+```ts
+import cookieParser from 'cookie-parser'
+import type { NextFunction, Request, Response } from 'express'
+
+app.use(cookieParser())
+
+// Set a secure session cookie after login (stateful)
+app.post('/login', (req, res) => {
+  const sid = newSessionID()
+  sessions.set(sid, userId)          // server-side session store (use Redis)
+  res.cookie('session', sid, {
+    httpOnly: true,                  // JS can't read it
+    secure: true,                    // HTTPS only
+    sameSite: 'strict',              // CSRF defense, typed: 'strict' | 'lax' | 'none'
+    maxAge: 3600 * 1000,             // Express takes milliseconds
+    path: '/',
+  })
+  res.sendStatus(204)
+})
+
+// Bearer-token auth middleware (stateless)
+function requireToken(req: Request, res: Response, next: NextFunction) {
+  const auth = req.get('Authorization') ?? ''
+  if (!auth.startsWith('Bearer ') || !validJWT(auth.slice(7))) {
+    res.set('WWW-Authenticate', 'Bearer')
+    return res.status(401).json({ error: 'unauthorized' }) // 401
+  }
+  next()
+}
+
+app.get('/me', requireToken, (req, res) => res.json({ ok: true }))
+```
+
+```java
+import jakarta.servlet.http.*;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.*;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.config.annotation.*;
+
+@RestController
+class AuthController {
+    private final UserService users;
+    private final SessionStore sessions;
+
+    AuthController(UserService users, SessionStore sessions) {
+        this.users = users;
+        this.sessions = sessions;
+    }
+
+    // Set a secure session cookie after login (stateful)
+    @PostMapping("/login")
+    ResponseEntity<Void> login(@RequestBody Credentials creds) {
+        String userId = users.authenticate(creds);
+        String sid = UUID.randomUUID().toString();
+        sessions.put(sid, userId);               // server-side session store (use Redis)
+        ResponseCookie cookie = ResponseCookie.from("session", sid)
+                .httpOnly(true)                  // JS can't read it
+                .secure(true)                    // HTTPS only
+                .sameSite("Strict")              // CSRF defense
+                .maxAge(Duration.ofHours(1))
+                .path("/")
+                .build();
+        return ResponseEntity.noContent().header(HttpHeaders.SET_COOKIE, cookie.toString()).build();
+    }
+
+    @GetMapping("/me")
+    Map<String, Boolean> me() {
+        return Map.of("ok", true);
+    }
+}
+
+// Bearer-token auth (stateless): an interceptor runs before the handler
+class RequireToken implements HandlerInterceptor {
+    @Override
+    public boolean preHandle(HttpServletRequest req, HttpServletResponse res, Object handler)
+            throws IOException {
+        String auth = Objects.requireNonNullElse(req.getHeader("Authorization"), "");
+        if (!auth.startsWith("Bearer ") || !Jwt.isValid(auth.substring(7))) {
+            res.setHeader("WWW-Authenticate", "Bearer");
+            res.sendError(HttpServletResponse.SC_UNAUTHORIZED, "unauthorized"); // 401
+            return false;                        // the handler never runs
+        }
+        return true;
+    }
+}
+
+@Configuration
+class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new RequireToken()).addPathPatterns("/me");
+    }
+}
+```
+
 ## CORS & the Preflight Workflow
 
 To understand CORS you first have to understand the rule it relaxes. Browsers enforce the **Same-Origin Policy**: JavaScript on a page from one origin may not read responses from a _different_ origin. An "origin" is the triple of **scheme + host + port**: `https://example.com` and `https://example.com:8443` and `http://example.com` are all different origins. This policy exists because browsers automatically attach your cookies to requests (sec 8); without it, a malicious site you visit could silently fire authenticated requests at your bank's API and read the responses. **CORS** (Cross-Origin Resource Sharing) is the controlled mechanism by which a server _opts in_ to letting specific other origins read its responses.
@@ -813,7 +1144,7 @@ One extra wrinkle for **credentialed** requests (those carrying cookies): the se
 
 ______
 
-Go Python JavaScript
+Go Python JavaScript TypeScript Java
 
 ```go
 func cors(next http.Handler) http.Handler {
@@ -858,6 +1189,43 @@ app.use(cors({
   credentials: true,
   maxAge: 86400,                   // cache the approval for 24h
 }))
+```
+
+```ts
+import cors, { type CorsOptions } from 'cors'
+
+// Typed options: a misspelled key like `allowHeaders` fails to compile
+// instead of silently doing nothing.
+const corsOptions: CorsOptions = {
+  origin: 'https://example.com',   // exact origin, not *, when credentials are on
+  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
+  allowedHeaders: ['Content-Type', 'Authorization'],
+  credentials: true,
+  maxAge: 86400,                   // cache the approval for 24h
+}
+
+// Handles the OPTIONS preflight and all the headers for you.
+app.use(cors(corsOptions))
+```
+
+```java
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+class CorsConfig implements WebMvcConfigurer {
+    // Handles the OPTIONS preflight and all the headers for you.
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("https://example.com")  // exact origin; Spring rejects * with credentials
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE")
+                .allowedHeaders("Content-Type", "Authorization")
+                .allowCredentials(true)
+                .maxAge(86400);                         // cache the approval for 24h
+    }
+}
 ```
 
 ### Common misconception: does CORS protect the server?
@@ -939,7 +1307,7 @@ A three-digit status code is a **standardized, machine-readable verdict** on a r
 
 ______
 
-Go Python JavaScript
+Go Python JavaScript TypeScript Java
 
 ```go
 func getUser(w http.ResponseWriter, r *http.Request) {
@@ -991,6 +1359,57 @@ app.get('/users/:id', (req, res) => {
 })
 ```
 
+```ts
+app.get('/users/:id', (req, res) => {
+  if (!req.get('Authorization')) {
+    return res.status(401).json({ error: 'login required' })  // 401: who are you?
+  }
+  const user = db.find(req.params.id)  // User | undefined, so the 404 branch is enforced
+  if (!user) {
+    return res.status(404).json({ error: 'no such user' })     // 404
+  }
+  if (!user.visibleTo(req)) {
+    return res.status(403).json({ error: 'forbidden' })         // 403: not allowed
+  }
+  res.json(user)                                                // 200
+})
+```
+
+```java
+import java.util.Map;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+class UsersController {
+    private final UserRepository users;
+
+    UsersController(UserRepository users) {
+        this.users = users;
+    }
+
+    @GetMapping("/users/{id}")
+    ResponseEntity<?> getUser(@PathVariable long id,
+                              @RequestHeader(name = "Authorization", required = false) String auth) {
+        if (auth == null) {
+            return error(HttpStatus.UNAUTHORIZED, "login required"); // 401: who are you?
+        }
+        User user = users.findById(id).orElse(null);
+        if (user == null) {
+            return error(HttpStatus.NOT_FOUND, "no such user");      // 404
+        }
+        if (!user.visibleTo(auth)) {
+            return error(HttpStatus.FORBIDDEN, "forbidden");         // 403: not allowed
+        }
+        return ResponseEntity.ok(user);                              // 200
+    }
+
+    private static ResponseEntity<Map<String, String>> error(HttpStatus status, String message) {
+        return ResponseEntity.status(status).body(Map.of("error", message));
+    }
+}
+```
+
 ## Redirections
 
 A redirect lets one resource live at more than one URL: the server responds with a `3xx` status and a `Location` header naming where to go, and the client (a browser following automatically, or your HTTP library) re-issues the request to that new URL. Redirects power URL migrations, canonical-URL enforcement, HTTP->HTTPS upgrades, and the Post/Redirect/Get pattern. The detail that trips up backends is **whether the original method and body survive the redirect**: because historically they often didn't.
@@ -1013,7 +1432,7 @@ Early clients, faced with a 301 or 302 on a POST, would silently re-issue it as 
 
 ______
 
-Go Python JavaScript
+Go Python JavaScript TypeScript Java
 
 ```go
 // Permanent move that must keep the method/body -> 308
@@ -1054,6 +1473,53 @@ app.post('/submit', (req, res) => {
   const id = save(req.body)
   res.redirect(303, `/results/${id}`)  // 303 forces the follow-up to be a GET
 })
+```
+
+```ts
+// Permanent move that must keep the method/body -> 308
+app.all('/user/:id', (req, res) => {
+  // req.params.id is typed as string, inferred from the '/user/:id' literal
+  res.redirect(308, `/person/${req.params.id}`)
+})
+
+// Post/Redirect/Get -> 303 so a browser refresh won't re-POST the form
+app.post('/submit', (req, res) => {
+  const id: string = save(req.body)
+  res.redirect(303, `/results/${id}`)  // 303 forces the follow-up to be a GET
+})
+```
+
+```java
+import java.net.URI;
+import java.util.Map;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+class RedirectsController {
+    private final ResultStore results;
+
+    RedirectsController(ResultStore results) {
+        this.results = results;
+    }
+
+    // Permanent move that must keep the method/body -> 308
+    @RequestMapping("/user/{id}")            // no method listed = every method
+    ResponseEntity<Void> moved(@PathVariable String id) {
+        return redirect(HttpStatus.PERMANENT_REDIRECT, "/person/" + id);
+    }
+
+    // Post/Redirect/Get -> 303 so a browser refresh won't re-POST the form
+    @PostMapping("/submit")
+    ResponseEntity<Void> submit(@RequestBody Map<String, Object> form) {
+        String id = results.save(form);
+        return redirect(HttpStatus.SEE_OTHER, "/results/" + id); // 303 forces the follow-up to be a GET
+    }
+
+    private static ResponseEntity<Void> redirect(HttpStatus status, String location) {
+        return ResponseEntity.status(status).location(URI.create(location)).build();
+    }
+}
 ```
 
 ## HTTP Caching
@@ -1104,7 +1570,7 @@ ETags come in two flavors: a **strong** ETag (`"abc"`) guarantees byte-for-byte 
 
 ______
 
-Go Python JavaScript
+Go Python JavaScript TypeScript Java
 
 ```go
 func getResource(w http.ResponseWriter, r *http.Request) {
@@ -1152,6 +1618,58 @@ app.get('/resource', (req, res) => {
   res.set('Cache-Control', 'max-age=10')
   res.send(body)                            // 200 + body
 })
+```
+
+```ts
+import { createHash } from 'node:crypto'
+
+app.get('/resource', (req, res) => {
+  const body: string = loadResource()
+  const etag = `"${createHash('sha256').update(body).digest('hex').slice(0, 16)}"`
+
+  if (req.get('If-None-Match') === etag) {  // client already has this exact version
+    return res.status(304).end()            // 304, no body, payload saved
+  }
+  res.set('ETag', etag)
+  res.set('Cache-Control', 'max-age=10')
+  res.send(body)                            // 200 + body
+})
+```
+
+```java
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.HexFormat;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+class ResourceController {
+    private final ContentService content;
+
+    ResourceController(ContentService content) {
+        this.content = content;
+    }
+
+    @GetMapping("/resource")
+    ResponseEntity<String> resource(@RequestHeader(name = "If-None-Match", required = false) String ifNoneMatch)
+            throws NoSuchAlgorithmException {
+        String body = content.load();
+        byte[] hash = MessageDigest.getInstance("SHA-256").digest(body.getBytes(StandardCharsets.UTF_8));
+        String etag = "\"" + HexFormat.of().formatHex(hash).substring(0, 16) + "\"";
+
+        if (etag.equals(ifNoneMatch)) {              // client already has this exact version
+            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).eTag(etag).build(); // 304, no body
+        }
+        return ResponseEntity.ok()
+                .eTag(etag)
+                .cacheControl(CacheControl.maxAge(Duration.ofSeconds(10)))
+                .body(body);                         // 200 + body
+    }
+}
+// Spring's ShallowEtagHeaderFilter can do this for every response automatically.
 ```
 
 <Callout type="info" title="In practice + the Vary trap">
@@ -1203,7 +1721,7 @@ A pessimistic lock would hold a row locked the entire time a user stares at an e
 
 ______
 
-Go Python JavaScript
+Go Python JavaScript TypeScript Java
 
 ```go
 func updateDoc(w http.ResponseWriter, r *http.Request) {
@@ -1259,6 +1777,68 @@ app.put('/doc/:id', (req, res) => {
 })
 ```
 
+```ts
+interface Doc {
+  etag: string
+  apply(changes: unknown): void
+}
+
+app.put('/doc/:id', (req, res) => {
+  const doc: Doc | undefined = db.get(req.params.id)
+  if (!doc) {                            // strict null checks make this branch mandatory
+    return res.status(404).json({ error: 'not found' })
+  }
+  const want = req.get('If-Match')       // the ETag the client last saw
+  if (!want) {
+    return res.status(400).json({ error: 'If-Match required' })
+  }
+  if (want !== doc.etag) {               // someone changed it first -> conflict
+    return res.status(412).json({ error: 'version conflict' })  // 412
+  }
+  doc.apply(req.body)
+  doc.etag = newETag()                   // bump the version
+  db.save(doc)
+  res.set('ETag', doc.etag)
+  res.sendStatus(200)
+})
+```
+
+```java
+import java.util.Map;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+class DocsController {
+    private final DocRepository docs;
+
+    DocsController(DocRepository docs) {
+        this.docs = docs;
+    }
+
+    @PutMapping("/doc/{id}")
+    ResponseEntity<?> update(@PathVariable String id,
+                             @RequestHeader(name = "If-Match", required = false) String want, // the ETag the client last saw
+                             @RequestBody Map<String, Object> changes) {
+        if (want == null) {
+            return ResponseEntity.badRequest().body(Map.of("error", "If-Match required"));
+        }
+        Doc doc = docs.findById(id).orElse(null);
+        if (doc == null) {
+            return ResponseEntity.notFound().build();
+        }
+        if (!want.equals(doc.getEtag())) {           // someone changed it first -> conflict
+            return ResponseEntity.status(HttpStatus.PRECONDITION_FAILED)
+                    .body(Map.of("error", "version conflict")); // 412
+        }
+        doc.apply(changes);
+        doc.setEtag(Etags.next());                   // bump the version
+        docs.save(doc);
+        return ResponseEntity.ok().eTag(doc.getEtag()).build();
+    }
+}
+```
+
 Part V / Data Transfer & Connections
 
 ## Content Negotiation & Compression
@@ -1283,7 +1863,7 @@ Compression is just encoding negotiation. When the client advertises `Accept-Enc
 
 ______
 
-Go Python JavaScript
+Go Python JavaScript TypeScript Java
 
 ```go
 func handler(w http.ResponseWriter, r *http.Request) {
@@ -1329,6 +1909,44 @@ app.get('/greeting', (req, res) => {
 })
 ```
 
+```ts
+import compression from 'compression'
+
+// gzip responses for capable clients, but only above a size threshold
+// (compressing tiny payloads costs more CPU than it saves bytes).
+// The middleware negotiates Accept-Encoding and sets Vary: Accept-Encoding for you.
+app.use(compression({ threshold: 1000 }))
+
+type Lang = 'en' | 'es'
+const greetings: Record<Lang, string> = { en: 'Hello', es: 'Hola' } // every Lang must have one
+
+app.get('/greeting', (req, res) => {
+  const lang: Lang = (req.get('Accept-Language') ?? 'en').startsWith('es') ? 'es' : 'en'
+  res.json(greetings[lang])
+})
+```
+
+```java
+import java.util.Map;
+import org.springframework.web.bind.annotation.*;
+
+// In Spring Boot, gzip is configuration rather than code (application.properties):
+//   server.compression.enabled=true
+//   server.compression.min-response-size=1KB   # tiny payloads cost more CPU than they save
+// The embedded server negotiates Accept-Encoding and sets Vary: Accept-Encoding for you.
+
+@RestController
+class GreetingController {
+    private static final Map<String, String> GREETINGS = Map.of("en", "Hello", "es", "Hola");
+
+    @GetMapping("/greeting")
+    String greeting(@RequestHeader(name = "Accept-Language", defaultValue = "en") String acceptLanguage) {
+        String lang = acceptLanguage.startsWith("es") ? "es" : "en";
+        return GREETINGS.get(lang);
+    }
+}
+```
+
 ## Range Requests
 
 A **range request** asks for only a slice of a resource rather than the whole thing. This solves three real problems: **resuming a download** that failed at 80% without restarting from zero, **seeking** in audio/video (jumping to the 3-minute mark fetches only the bytes around it), and **parallelizing** a large download into chunks fetched simultaneously. Without ranges, every interruption means starting over and every seek means downloading everything before the target.
@@ -1361,7 +1979,7 @@ The good news for implementers: the standard file-serving helpers in both ecosys
 
 ______
 
-Go Python JavaScript
+Go Python JavaScript TypeScript Java
 
 ```go
 // http.ServeContent handles Range, 206, 416 and If-Range for you,
@@ -1394,6 +2012,36 @@ app.get('/big.zip', (req, res) => {
 })
 ```
 
+```ts
+// res.sendFile handles Range, 206, 416 and If-Range for you,
+// driven by the file's modtime and a generated ETag.
+app.get('/big.zip', (req, res) => {
+  res.sendFile('/srv/files/big.zip', {
+    acceptRanges: true,                              // options are type-checked in place
+    headers: { 'Content-Type': 'application/zip' },
+  })
+})
+```
+
+```java
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+class DownloadController {
+    // Returning a Resource lets Spring MVC answer Range requests for you:
+    // Accept-Ranges on every response, 206 for a satisfiable range, 416 otherwise.
+    @GetMapping("/big.zip")
+    ResponseEntity<Resource> download() {
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType("application/zip"))
+                .body(new FileSystemResource("/srv/files/big.zip"));
+    }
+}
+```
+
 ## Persistent Connections & Keep-Alive
 
 Establishing a TCP connection isn't free, it costs a full round trip for the handshake (and more if TLS is involved). HTTP/1.0 paid that toll on every single request, opening and tearing down a connection per resource, which made loading a page of dozens of assets painfully slow. HTTP/1.1 fixed this with **persistent connections**: one TCP connection is held open and reused for many request/response cycles, so the handshake cost is paid once and amortized across everything that follows.
@@ -1415,7 +2063,7 @@ You rarely set these headers by hand, the defaults are right for almost everythi
 
 ______
 
-Go Python JavaScript
+Go Python JavaScript TypeScript Java
 
 ```go
 srv := &http.Server{
@@ -1451,6 +2099,39 @@ server.listen(8080)
 // server.closeIdleConnections() // drop idle keep-alives, e.g. during shutdown
 ```
 
+```ts
+import http from 'node:http'
+
+const server: http.Server = http.createServer(app)
+
+server.headersTimeout = 2_000       // mitigates Slowloris (slow-header attacks)
+server.requestTimeout = 5_000       // whole request must arrive within this
+server.keepAliveTimeout = 60_000    // how long to hold an idle keep-alive conn
+server.listen(8080)
+
+// server.closeIdleConnections() // drop idle keep-alives, e.g. during shutdown
+```
+
+```java
+import org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.stereotype.Component;
+
+// Tunes the embedded Tomcat server that Spring Boot starts for you.
+@Component
+class ServerTimeouts implements WebServerFactoryCustomizer<TomcatServletWebServerFactory> {
+    @Override
+    public void customize(TomcatServletWebServerFactory factory) {
+        factory.setPort(8080);
+        factory.addConnectorCustomizers(connector -> {
+            connector.setProperty("connectionTimeout", "2000"); // max wait for request bytes (slow-client defense)
+            connector.setProperty("keepAliveTimeout", "60000"); // how long to hold an idle keep-alive conn
+        });
+    }
+}
+// Same settings as config: server.tomcat.connection-timeout=2s, server.tomcat.keep-alive-timeout=60s
+```
+
 ## Multipart Uploads & Streamed Responses
 
 JSON is a poor fit for binary data, you'd have to base64-encode it, inflating size by \~33% and forcing the whole thing into memory. Large transfers therefore use purpose-built mechanisms, and which one you reach for depends on the **direction** of the large data.
@@ -1481,7 +2162,7 @@ To send a large or open-ended response without buffering it all in memory (or ti
 
 ______
 
-Go Python JavaScript
+Go Python JavaScript TypeScript Java
 
 ```go
 // 1. Receive a multipart upload
@@ -1554,6 +2235,78 @@ app.get('/stream', async (req, res) => {
   }
   res.end()
 })
+```
+
+```ts
+import multer from 'multer'
+import { setTimeout as sleep } from 'node:timers/promises'
+
+// 1. Receive a multipart upload
+const upload = multer({ limits: { fileSize: 32 * 1024 * 1024 } }) // 32 MB cap
+
+app.post('/upload', upload.single('file'), (req, res) => {
+  // req.file is Express.Multer.File | undefined, so this check is required, not optional
+  if (!req.file) {
+    return res.status(400).json({ error: 'no file' })
+  }
+  res.json({ received: req.file.originalname, size: req.file.size })
+})
+
+// 2. Stream a response in chunks (Server-Sent Events)
+app.get('/stream', async (req, res) => {
+  res.set('Content-Type', 'text/event-stream')
+  res.set('Connection', 'keep-alive')
+  for (let i = 0; i < 5; i++) {
+    res.write(`data: chunk ${i}\n\n`) // each write is flushed to the client
+    await sleep(1000)
+  }
+  res.end()
+})
+```
+
+```java
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+class StreamingController {
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+
+    // 1. Receive a multipart upload
+    //    (cap it in application.properties: spring.servlet.multipart.max-file-size=32MB)
+    @PostMapping("/upload")
+    ResponseEntity<?> upload(@RequestParam(name = "file", required = false) MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "no file"));
+        }
+        String name = Objects.requireNonNullElse(file.getOriginalFilename(), "");
+        return ResponseEntity.ok(Map.of("received", name, "size", file.getSize()));
+    }
+
+    // 2. Stream a response in chunks (Server-Sent Events)
+    @GetMapping(path = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    SseEmitter stream() {
+        SseEmitter emitter = new SseEmitter();  // returned right away; the request thread is freed
+        executor.execute(() -> {
+            try {
+                for (int i = 0; i < 5; i++) {
+                    emitter.send("chunk " + i); // sent as "data: chunk i", flushed to the client
+                    Thread.sleep(1000);
+                }
+                emitter.complete();
+            } catch (Exception e) {
+                emitter.completeWithError(e);
+            }
+        });
+        return emitter;
+    }
+}
 ```
 
 Direction -> tool
@@ -1659,7 +2412,7 @@ You almost never implement TLS in application code. It's _terminated_ at the edg
 
 ______
 
-Go Python JavaScript
+Go Python JavaScript TypeScript Java
 
 ```go
 // Serve HTTPS directly with a certificate + private-key pair.
@@ -1688,6 +2441,45 @@ https.createServer({
   cert: readFileSync('server.crt'),
   key: readFileSync('server.key'),
 }, app).listen(443)
+
+// Production note: usually you terminate TLS at a proxy/LB and run plain HTTP behind it.
+```
+
+```ts
+import https from 'node:https'
+import { readFileSync } from 'node:fs'
+
+// Serve HTTPS directly with a certificate + private-key pair.
+const tlsOptions: https.ServerOptions = {
+  cert: readFileSync('server.crt'),
+  key: readFileSync('server.key'),
+}
+
+https.createServer(tlsOptions, app).listen(443)
+
+// Production note: usually you terminate TLS at a proxy/LB and run plain HTTP behind it.
+```
+
+```java
+import org.springframework.boot.web.server.ConfigurableWebServerFactory;
+import org.springframework.boot.web.server.Ssl;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.stereotype.Component;
+
+// Serve HTTPS directly with a certificate + private-key pair (PEM files).
+@Component
+class HttpsSetup implements WebServerFactoryCustomizer<ConfigurableWebServerFactory> {
+    @Override
+    public void customize(ConfigurableWebServerFactory factory) {
+        Ssl ssl = new Ssl();
+        ssl.setCertificate("file:server.crt");
+        ssl.setCertificatePrivateKey("file:server.key");
+        factory.setSsl(ssl);
+        factory.setPort(443);
+    }
+}
+// Same as config: server.port=443, server.ssl.certificate=file:server.crt,
+// server.ssl.certificate-private-key=file:server.key
 
 // Production note: usually you terminate TLS at a proxy/LB and run plain HTTP behind it.
 ```
@@ -1731,4 +2523,4 @@ The payoff of understanding the machinery is fast triage: map a symptom straight
 
 Grounded in MDN (developer.mozilla.org/en-US/docs/Web/HTTP) & RFC 9110 / Go 1.22+ / Python 3.11+ examples.
 
-Backend from First Principles / Chapter 01 / HTTP. Code targets Go 1.22+, Python 3.11+ and Node.js 20+.
+Backend from First Principles / Chapter 01 / HTTP. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+ (Spring Boot).

--- a/src/content/chapters/02-routing-in-backend.mdx
+++ b/src/content/chapters/02-routing-in-backend.mdx
@@ -2,7 +2,7 @@
 order: 2
 title: "Routing, the where of every request."
 navTitle: "Routing in Backend"
-summary: "HTTP methods describe the what of a request, your intent. Routing describes the where : which resource on the server your intent is aimed at. This manual covers routing end to end, static and dynamic routes, path and query parameters, nesting, versioning, and catch-alls, with worked routers in Go, Python and JavaScript."
+summary: "HTTP methods describe the what of a request, your intent. Routing describes the where : which resource on the server your intent is aimed at. This manual covers routing end to end, static and dynamic routes, path and query parameters, nesting, versioning, and catch-alls, with worked routers in Go, Python, JavaScript, TypeScript and Java."
 readingTime: "2-3 hours"
 keywords:
   - "routing"
@@ -218,11 +218,19 @@ The `*` wildcard matches anything, which is exactly why the catch-all must be re
 
 11
 
-## A Router in Go
+## Building a Router
 
-A router is, at bottom, a small object-oriented dispatch problem: a table from "method + route" to a handler. Go expresses the four OOP pillars through interfaces (abstraction + polymorphism), unexported fields (encapsulation), and struct embedding (composition, Go's form of inheritance). The comments tagged OOP point out each one.
+A router is, at bottom, a small object-oriented dispatch problem: a table from "method + route" to a handler. Below is the same router in five languages, pick a tab. Each one expresses the four OOP pillars in its own way, and the comments tagged OOP point out each one:
 
-```go title="Go 1.22+router.go"
+- **Go**: interfaces (abstraction + polymorphism), unexported fields (encapsulation), and struct embedding (composition, Go's form of inheritance).
+- **Python**: classic class syntax, an abstract base class for the contract (abstraction), real subclassing (inheritance), overridden methods (polymorphism), and a name-mangled private attribute (encapsulation).
+- **JavaScript**: no `interface` keyword to lean on, so the contract is a base class whose `handle()` throws until a subclass overrides it (abstraction + polymorphism), `extends` gives real inheritance, and a `#` field is private at runtime rather than by convention (encapsulation).
+- **TypeScript**: the JavaScript design with the compiler enforcing it, a real `interface` for the contract, an `abstract` base class so a missing `handle()` fails to compile, and a `Method` union type that rejects a misspelled verb before the code ever runs.
+- **Java**: a real `interface` for the contract (abstraction), an `abstract` base class that handlers `extend` (inheritance), `@Override` methods (polymorphism), and `private` fields enforced by both the compiler and the JVM (encapsulation).
+
+Go Python JavaScript TypeScript Java
+
+```go title="Go 1.22+ router.go"
 package main
 
 import ("fmt"; "strings")
@@ -319,13 +327,7 @@ func main() {
 }
 ```
 
-12
-
-## A Router in Python
-
-The same architecture in classic class syntax: an abstract base class for the contract (abstraction), real subclassing (inheritance), overridden methods (polymorphism), and a name-mangled private attribute (encapsulation).
-
-```python title="Python 3.11+router.py"
+```python title="Python 3.11+ router.py"
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from urllib.parse import urlsplit, parse_qs
@@ -408,12 +410,6 @@ if __name__ == "__main__":
     print(r.dispatch("GET", "/api/users/123").body)   # user id = 123
     print(r.dispatch("GET", "/api/books?page=2").body) # books page 2
 ```
-
-13
-
-## A Router in JavaScript
-
-The same architecture once more, this time with no `interface` keyword to lean on: the contract is a base class whose `handle()` throws until a subclass overrides it (abstraction + polymorphism), `extends` gives real inheritance, and a `#` field is private at runtime rather than by convention (encapsulation).
 
 ```js title="Node 20+ router.js"
 // ABSTRACTION: JavaScript has no `interface` keyword, so the contract is a
@@ -523,11 +519,264 @@ r.register("GET", "/api/books",     new ListBooks("books"));
 console.log(r.dispatch("GET", "/api/users/123").body);    // user id = 123
 console.log(r.dispatch("GET", "/api/books?page=2").body); // books page 2
 ```
-<Callout type="info" title="Same architecture, three languages">
-Go reaches it through interfaces + embedding; Python through ABCs + class inheritance; JavaScript through a base class whose method throws and `#private` fields. All three are a private dispatch table keyed on **method + route**, an abstract **handler** contract, polymorphic dispatch, and a catch-all fallback, the whole routing model from this manual, in code.
+
+```ts title="TypeScript 5+ router.ts"
+// ABSTRACTION: TypeScript has a real `interface` keyword, so the contract is
+// a type the compiler checks, not a base class that throws at runtime.
+// Anything with a matching handle() IS-A Handler. The router depends only on
+// that contract, never on a concrete type.
+interface Handler {
+  handle(req: Request): Response;
+}
+
+type Params = Record<string, string>;
+type Method = "GET" | "POST" | "PUT" | "PATCH" | "DELETE"; // a typo like "GTE" won't compile
+
+class Request {
+  readonly method: Method;
+  readonly path: string;
+  readonly params: Params; // extracted path params (:id)
+  readonly query: Params;  // query params (?page=2)
+
+  constructor(method: Method, path: string, params: Params = {}, query: Params = {}) {
+    this.method = method;
+    this.path = path;
+    this.params = params;
+    this.query = query;
+  }
+}
+
+class Response {
+  readonly status: number;
+  readonly body: string;
+
+  constructor(status: number, body: string) {
+    this.status = status;
+    this.body = body;
+  }
+}
+
+// INHERITANCE: BaseHandler is an abstract parent holding shared behaviour
+// (logging). It can't be instantiated on its own, and `abstract handle()`
+// turns a forgotten override into a compile error instead of a runtime throw.
+abstract class BaseHandler implements Handler {
+  #name: string; // ENCAPSULATION: a # field is private at runtime, not just to the compiler
+
+  constructor(name: string) {
+    this.#name = name;
+  }
+
+  protected log(req: Request): void { // subclasses may call it, outside code may not
+    console.log(`[${this.#name}] ${req.method} ${req.path}`);
+  }
+
+  abstract handle(req: Request): Response;
+}
+
+// POLYMORPHISM: each subclass OVERRIDES handle() differently, yet the
+// router calls them all identically, handler.handle(req).
+class GetUser extends BaseHandler {   // IS-A BaseHandler IS-A Handler
+  handle(req: Request): Response {
+    this.log(req);                    // inherited from the parent
+    return new Response(200, `user id = ${req.params.id}`);
+  }
+}
+
+class ListBooks extends BaseHandler {
+  handle(req: Request): Response {
+    this.log(req);
+    const page = req.query.page ?? "1"; // query param drives pagination
+    return new Response(200, `books page ${page}`);
+  }
+}
+
+// ENCAPSULATION: #routes is unreachable from outside the class, so the
+// table stays hidden. The public surface is register() and dispatch().
+class Router {
+  #routes = new Map<string, Handler>(); // key = "METHOD /route"
+
+  register(method: Method, pattern: string, handler: Handler): void {
+    this.#routes.set(`${method} ${pattern}`, handler); // method + path = the key
+  }
+
+  dispatch(method: Method, url: string): Response {
+    const { pathname, searchParams } = new URL(url, "http://localhost");
+    const query: Params = Object.fromEntries(searchParams.entries()); // ?a=1&b=2 -> object
+
+    for (const [key, handler] of this.#routes) {
+      const [m, pattern] = key.split(" ");
+      const params = Router.#match(pattern, pathname);
+      if (m === method && params !== null) {
+        // polymorphic dispatch: the router never asks which class this is
+        return handler.handle(new Request(method, pathname, params, query));
+      }
+    }
+    return new Response(404, "route not found"); // catch-all fallback
+  }
+
+  // #match compares "/users/:id" against "/users/123", returning the params.
+  static #match(pattern: string, path: string): Params | null {
+    const p = pattern.replace(/^\/|\/$/g, "").split("/");
+    const q = path.replace(/^\/|\/$/g, "").split("/");
+    if (p.length !== q.length) return null;
+
+    const params: Params = {};
+    for (const [i, seg] of p.entries()) {
+      if (seg.startsWith(":")) {   // dynamic segment
+        params[seg.slice(1)] = q[i]; // bind :id -> "123"
+      } else if (seg !== q[i]) {   // static segment must match exactly
+        return null;
+      }
+    }
+    return params;
+  }
+}
+
+const r = new Router();
+r.register("GET", "/api/users/:id", new GetUser("users"));
+r.register("GET", "/api/books",     new ListBooks("books"));
+
+console.log(r.dispatch("GET", "/api/users/123").body);    // user id = 123
+console.log(r.dispatch("GET", "/api/books?page=2").body); // books page 2
+
+// Exporting makes this file a module, so the local Request/Response classes
+// shadow the global fetch types instead of clashing with them.
+export { Router, type Handler };
+```
+
+```java title="Java 17+ Router.java"
+// run: javac Router.java && java Router
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+// ABSTRACTION: Handler is a real Java interface, a pure contract. Anything
+// that implements handle() IS-A Handler. The router depends only on that
+// contract, never on a concrete type.
+interface Handler {
+    Response handle(Request req);
+}
+
+// Records are immutable data carriers: Java generates the constructor,
+// accessors (req.path()), equals, hashCode and toString.
+record Request(String method, String path, Map<String, String> params, Map<String, String> query) {}
+
+record Response(int status, String body) {}
+
+// INHERITANCE: BaseHandler is an abstract parent holding shared behaviour
+// (logging). It can't be instantiated on its own, and any concrete subclass
+// that forgets to implement handle() fails to compile.
+abstract class BaseHandler implements Handler {
+    private final String name; // ENCAPSULATION: private is enforced by the compiler and the JVM
+
+    protected BaseHandler(String name) {
+        this.name = name;
+    }
+
+    protected void log(Request req) { // subclasses may call it, outside code may not
+        System.out.printf("[%s] %s %s%n", name, req.method(), req.path());
+    }
+}
+
+// POLYMORPHISM: each subclass OVERRIDES handle() differently, yet the
+// router calls them all identically, handler.handle(req).
+class GetUser extends BaseHandler {   // IS-A BaseHandler IS-A Handler
+    GetUser(String name) {
+        super(name);
+    }
+
+    @Override
+    public Response handle(Request req) {
+        log(req);                     // inherited from the parent
+        return new Response(200, "user id = " + req.params().get("id"));
+    }
+}
+
+class ListBooks extends BaseHandler {
+    ListBooks(String name) {
+        super(name);
+    }
+
+    @Override
+    public Response handle(Request req) {
+        log(req);
+        String page = req.query().getOrDefault("page", "1"); // query param drives pagination
+        return new Response(200, "books page " + page);
+    }
+}
+
+// ENCAPSULATION: routes is private, so the table stays hidden.
+// The public surface is register() and dispatch().
+public class Router {
+    private final Map<String, Handler> routes = new LinkedHashMap<>(); // key = "METHOD /route"
+
+    public void register(String method, String pattern, Handler handler) {
+        routes.put(method + " " + pattern, handler); // method + path = the key
+    }
+
+    public Response dispatch(String method, String url) {
+        URI uri = URI.create(url);
+        String path = uri.getPath();
+        Map<String, String> query = parseQuery(uri.getRawQuery()); // ?a=1&b=2 -> map
+
+        for (Map.Entry<String, Handler> route : routes.entrySet()) {
+            String[] key = route.getKey().split(" ", 2);
+            Map<String, String> params = match(key[1], path);
+            if (key[0].equals(method) && params != null) {
+                // polymorphic dispatch: the router never asks which class this is
+                return route.getValue().handle(new Request(method, path, params, query));
+            }
+        }
+        return new Response(404, "route not found"); // catch-all fallback
+    }
+
+    // match compares "/users/:id" against "/users/123", returning the params.
+    private static Map<String, String> match(String pattern, String path) {
+        String[] p = pattern.replaceAll("^/|/$", "").split("/");
+        String[] q = path.replaceAll("^/|/$", "").split("/");
+        if (p.length != q.length) return null;
+
+        Map<String, String> params = new HashMap<>();
+        for (int i = 0; i < p.length; i++) {
+            if (p[i].startsWith(":")) {              // dynamic segment
+                params.put(p[i].substring(1), q[i]); // bind :id -> "123"
+            } else if (!p[i].equals(q[i])) {         // static segment must match exactly
+                return null;
+            }
+        }
+        return params;
+    }
+
+    private static Map<String, String> parseQuery(String raw) {
+        Map<String, String> query = new HashMap<>();
+        if (raw == null) return query;
+        for (String pair : raw.split("&")) {
+            String[] kv = pair.split("=", 2);
+            String value = kv.length > 1 ? kv[1] : "";
+            query.put(URLDecoder.decode(kv[0], StandardCharsets.UTF_8),
+                      URLDecoder.decode(value, StandardCharsets.UTF_8));
+        }
+        return query;
+    }
+
+    public static void main(String[] args) {
+        Router r = new Router();
+        r.register("GET", "/api/users/:id", new GetUser("users"));
+        r.register("GET", "/api/books",     new ListBooks("books"));
+
+        System.out.println(r.dispatch("GET", "/api/users/123").body());    // user id = 123
+        System.out.println(r.dispatch("GET", "/api/books?page=2").body()); // books page 2
+    }
+}
+```
+<Callout type="info" title="Same architecture, five languages">
+Go reaches it through interfaces + embedding; Python through ABCs + class inheritance; JavaScript through a base class whose method throws and `#private` fields; TypeScript through a real `interface`, an `abstract` base class and the same `#private` fields; Java through an `interface`, an `abstract` base class and `private` fields. All five are a private dispatch table keyed on **method + route**, an abstract **handler** contract, polymorphic dispatch, and a catch-all fallback, the whole routing model from this manual, in code.
 </Callout>
 
-14
+12
 
 ## Routing Glossary
 
@@ -557,4 +806,4 @@ Every routing term used above, in one place.
 A request bundles a **method** (the what) and a **route** (the where). The server joins them into a unique key, matches it against its table, static routes first, dynamic next, catch-all last, extracts any **path params** from the route and **query params** from the query string, then calls the matched **handler**. Version the route to evolve, deprecate to retire, and catch-all to fail gracefully.
 </Callout>
 
-Backend from First Principles / Chapter 02 / Routing. Code targets Go 1.22+, Python 3.11+ and Node.js 20+.
+Backend from First Principles / Chapter 02 / Routing. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+.

--- a/src/content/chapters/03-serialization-and-deserialization.mdx
+++ b/src/content/chapters/03-serialization-and-deserialization.mdx
@@ -2,7 +2,7 @@
 order: 3
 title: "Serialization, the shared language of machines."
 navTitle: "Serialization & Deserialization"
-summary: "A JavaScript client and a Rust server have nothing in common at the level of data types. Serialization is how they talk anyway: both convert their native data to and from one agreed format for the trip across the network. This manual covers the whole idea, the language barrier, the common standard, text vs binary formats, JSON in depth, the OSI mental model, and the full client<->server round-trip, with worked code in Go, Python and JavaScript."
+summary: "A JavaScript client and a Rust server have nothing in common at the level of data types. Serialization is how they talk anyway: both convert their native data to and from one agreed format for the trip across the network. This manual covers the whole idea, the language barrier, the common standard, text vs binary formats, JSON in depth, the OSI mental model, and the full client<->server round-trip, with worked code in Go, Python, JavaScript, TypeScript and Java."
 readingTime: "2-3 hours"
 keywords:
   - "serialization"
@@ -165,11 +165,19 @@ In words: the client gathers input, **serializes** it to a JSON string in the re
 
 09
 
-## Serialization in Go
+## Serialization in Code
 
-Go serializes to/from JSON with the standard `encoding/json` package: `Marshal` = serialize, `Unmarshal` = deserialize. The pillars show up through interfaces (abstraction + polymorphism), unexported fields + struct tags (encapsulation), and embedding (composition, Go's inheritance). Pillars are tagged OOP.
+Every language has a JSON codec, and each one expresses the same OOP architecture in its own way. Below is the same serializer in five languages, pick a tab. The pillars are tagged OOP in the comments:
 
-```go title="Go 1.22+serialize.go"
+- **Go**: the standard `encoding/json` package, `Marshal` = serialize, `Unmarshal` = deserialize. Interfaces (abstraction + polymorphism), unexported fields + struct tags (encapsulation), and embedding (composition, Go's inheritance).
+- **Python**: the built-in `json` module, `json.dumps` = serialize (dump to string), `json.loads` = deserialize (load from string). An ABC contract, inheritance, polymorphism, and a private attribute.
+- **JavaScript**: the built-in `JSON` object, `JSON.stringify` = serialize, `JSON.parse` = deserialize. One twist worth noticing: a `#private` field is invisible to `JSON.stringify`, so the language itself keeps the secret off the wire, and `toJSON()` is the hook that decides which keys leave the object, JavaScript's answer to Go's struct tags.
+- **TypeScript**: the same `JSON` object with types on both sides of the wire: `toJSON()` returns a declared `UserJSON` shape, so a misspelled key fails to compile, and `deserialize()` returns `unknown`, so incoming data has to pass a type guard before you can touch it.
+- **Java**: no JSON in the standard library, so the de facto standard Jackson, `writeValueAsString` = serialize, `readValue` = deserialize. An `interface` contract, an abstract base class, `private` fields, and annotations (`@JsonProperty`, `@JsonIgnore`) that play the role of Go's struct tags.
+
+Go Python JavaScript TypeScript Java
+
+```go title="Go 1.22+ serialize.go"
 package main
 
 import ("encoding/json"; "fmt"; "time")
@@ -241,13 +249,7 @@ func main() {
 }
 ```
 
-10
-
-## Serialization in Python
-
-Python uses the built-in `json` module: `json.dumps` = serialize (dump to string), `json.loads` = deserialize (load from string). The same OOP architecture: an ABC contract, inheritance, polymorphism, and a private attribute.
-
-```python title="Python 3.11+serialize.py"
+```python title="Python 3.11+ serialize.py"
 import json
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, asdict, field
@@ -312,12 +314,6 @@ if __name__ == "__main__":
     data = codec.deserialize(incoming)
     print(data["name"], data["address"]["country"])  # Lin IN
 ```
-
-11
-
-## Serialization in JavaScript
-
-JavaScript uses the built-in `JSON` object: `JSON.stringify` = serialize, `JSON.parse` = deserialize. The same OOP architecture, with one twist worth noticing: a `#private` field is invisible to `JSON.stringify`, so the language itself keeps the secret off the wire, and `toJSON()` is the hook that decides which keys leave the object, JavaScript's answer to Go's struct tags.
 
 ```js title="Node 20+ serialize.js"
 // ABSTRACTION: JavaScript has no interface keyword, so the contract is a base
@@ -396,11 +392,221 @@ const incoming = '{"name":"Lin","address":{"country":"IN","phone":42}}';
 const data = codec.deserialize(incoming);
 console.log(data.name, data.address.country); // Lin IN
 ```
-<Callout type="info" title="Same shape, three languages">
-All three define a **Serializer** contract (abstraction), implement it for JSON (polymorphism), share fields through a base model (inheritance / composition), and keep secrets out of the wire format (encapsulation). The verbs are universal: **serialize** = native -> JSON (Go `Marshal`, Python `dumps`, JavaScript `JSON.stringify`); **deserialize** = JSON -> native (Go `Unmarshal`, Python `loads`, JavaScript `JSON.parse`).
+
+```ts title="TypeScript 5+ serialize.ts"
+// ABSTRACTION: TypeScript has a real interface keyword, so the contract is a
+// type the compiler checks. Callers depend only on this shape, so JSON could
+// be swapped for another format without touching them.
+interface Serializer {
+  serialize(value: unknown): string;  // native -> common
+  deserialize(data: string): unknown; // common -> native, untrusted until checked
+}
+
+// POLYMORPHISM: JsonSerializer implements the contract. Any other format
+// (YAML, Protobuf) can implement the same interface and be swapped in unchanged.
+class JsonSerializer implements Serializer {
+  serialize(value: unknown): string {
+    return JSON.stringify(value);  // SERIALIZE: object -> JSON text
+  }
+  deserialize(data: string): unknown {
+    return JSON.parse(data);       // DESERIALIZE: JSON text -> unknown
+  }
+}
+
+// "INHERITANCE": BaseModel holds the shared fields; User extends it and
+// reuses them, the counterpart of Go's struct embedding.
+class BaseModel {
+  id: number;
+  createdAt: Date;
+
+  constructor(id = 0, createdAt = new Date()) {
+    this.id = id;
+    this.createdAt = createdAt;
+  }
+}
+
+interface Address {
+  country: string;
+  phone: number; // nested object
+}
+
+// The exact keys that leave a User. With the wire shape declared as a type,
+// a misspelled or forgotten key in toJSON() is a compile error.
+interface UserJSON {
+  id: number;
+  created_at: Date; // rename on the way out, like a json tag
+  name: string;
+  active: boolean;
+  address: Address | null;
+}
+
+interface UserInit {
+  id: number;
+  name: string;
+  active?: boolean;
+  address?: Address | null;
+  password?: string;
+}
+
+// ENCAPSULATION: #password is private at RUNTIME, so it is both unreachable
+// from outside AND invisible to JSON.stringify. TypeScript's `private` keyword
+// is not enough on its own: it only hides the field from the compiler, and
+// JSON.stringify would still write it out. toJSON() decides which keys leave.
+class User extends BaseModel {
+  name: string;
+  active: boolean;
+  address: Address | null;
+  #password: string;
+
+  constructor({ id, name, active = true, address = null, password = "" }: UserInit) {
+    super(id);
+    this.name = name;
+    this.active = active;
+    this.address = address;
+    this.#password = password;
+  }
+
+  toJSON(): UserJSON {
+    return {
+      id: this.id,
+      created_at: this.createdAt,
+      name: this.name,
+      active: this.active,
+      address: this.address,
+    };
+  }
+}
+
+// What we EXPECT a client to send. JSON.parse can't promise that shape, so a
+// type guard checks it at runtime before the compiler lets us use the data.
+interface IncomingUser {
+  name: string;
+  address: Address;
+}
+
+function isIncomingUser(value: unknown): value is IncomingUser {
+  const v = value as Partial<IncomingUser> | null;
+  return typeof v?.name === "string"
+    && typeof v.address?.country === "string"
+    && typeof v.address?.phone === "number";
+}
+
+const codec: Serializer = new JsonSerializer(); // program to the contract
+
+const user = new User({ id: 1, name: "Ada", address: { country: "India", phone: 123456 } });
+
+// SERIALIZE, native object into the common JSON format
+const payload = codec.serialize(user);
+console.log(payload);
+// {"id":1,"created_at":"...","name":"Ada","active":true,
+//  "address":{"country":"India","phone":123456}}
+
+// DESERIALIZE, JSON received over HTTP back into native data
+const incoming = '{"name":"Lin","address":{"country":"IN","phone":42}}';
+const data = codec.deserialize(incoming); // unknown: data.name won't compile yet
+if (isIncomingUser(data)) {
+  console.log(data.name, data.address.country); // Lin IN
+}
+```
+
+```java title="Java 17+ Serialize.java"
+// Java has no JSON in its standard library; Jackson is the de facto standard.
+// Dependency: tools.jackson.core:jackson-databind (Jackson 3)
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.time.Instant;
+import tools.jackson.databind.json.JsonMapper;
+
+// ABSTRACTION: Serializer is a real interface, a pure contract. Callers
+// depend only on it, so JSON could be swapped for another format without
+// touching them.
+interface Serializer {
+    String serialize(Object value);                 // native -> common
+    <T> T deserialize(String data, Class<T> type);  // common -> native
+}
+
+// POLYMORPHISM: JsonSerializer implements the contract. A YamlSerializer
+// could implement the same interface and be swapped in unchanged.
+class JsonSerializer implements Serializer {
+    private final JsonMapper mapper = new JsonMapper(); // Jackson's JSON codec
+
+    @Override
+    public String serialize(Object value) {
+        return mapper.writeValueAsString(value);    // SERIALIZE: object -> JSON text
+    }
+
+    @Override
+    public <T> T deserialize(String data, Class<T> type) {
+        return mapper.readValue(data, type);        // DESERIALIZE: JSON text -> object
+    }
+}
+
+// "INHERITANCE": BaseModel holds the shared fields; User extends it and
+// reuses them, the counterpart of Go's struct embedding.
+abstract class BaseModel {
+    @JsonProperty("id")
+    private final long id;
+    @JsonProperty("created_at")   // rename on the way out, like a json tag
+    private final Instant createdAt;
+
+    protected BaseModel(long id) {
+        this.id = id;
+        this.createdAt = Instant.now();
+    }
+}
+
+record Address(String country, int phone) {} // nested object; records map to JSON as-is
+
+// ENCAPSULATION: every field is private. Annotations are Java's answer to
+// Go's struct tags: @JsonProperty lets a field onto the wire, @JsonIgnore
+// keeps password off it for good, even if someone adds a getter later.
+@JsonPropertyOrder({"id", "created_at", "name", "active", "address"})
+class User extends BaseModel {
+    @JsonProperty private final String name;
+    @JsonProperty private final boolean active;
+    @JsonProperty private final Address address;
+    @JsonIgnore   private final String password;
+
+    User(long id, String name, Address address, String password) {
+        super(id);
+        this.name = name;
+        this.active = true;
+        this.address = address;
+        this.password = password;
+    }
+}
+
+// What we EXPECT a client to send. readValue binds the JSON straight into
+// this typed record, and a value of the wrong type (text where phone expects
+// a number) throws instead of slipping through.
+record IncomingUser(String name, Address address) {}
+
+public class Serialize {
+    public static void main(String[] args) {
+        Serializer codec = new JsonSerializer(); // program to the contract
+
+        User user = new User(1, "Ada", new Address("India", 123456), "s3cret");
+
+        // SERIALIZE, native object into the common JSON format
+        String payload = codec.serialize(user);
+        System.out.println(payload);
+        // {"id":1,"created_at":"...","name":"Ada","active":true,
+        //  "address":{"country":"India","phone":123456}}
+
+        // DESERIALIZE, JSON received over HTTP back into a typed record
+        String incoming = """
+                {"name":"Lin","address":{"country":"IN","phone":42}}""";
+        IncomingUser data = codec.deserialize(incoming, IncomingUser.class);
+        System.out.println(data.name() + " " + data.address().country()); // Lin IN
+    }
+}
+```
+<Callout type="info" title="Same shape, five languages">
+All five define a **Serializer** contract (abstraction), implement it for JSON (polymorphism), share fields through a base model (inheritance / composition), and keep secrets out of the wire format (encapsulation). The verbs are universal: **serialize** = native -> JSON (Go `Marshal`, Python `dumps`, JavaScript and TypeScript `JSON.stringify`, Java `writeValueAsString`); **deserialize** = JSON -> native (Go `Unmarshal`, Python `loads`, JavaScript and TypeScript `JSON.parse`, Java `readValue`).
 </Callout>
 
-12
+10
 
 ## Glossary
 
@@ -431,4 +637,4 @@ Every term from the source, in one place.
 Two machines with incompatible native data types agree on a **common format** (usually **JSON**). Each **serializes** its data into that format before sending and **deserializes** it back after receiving, so communication is **language- and domain-agnostic**. The network turns JSON into bits and back; at the **application layer** you only ever deal with the JSON.
 </Callout>
 
-Backend from First Principles / Chapter 03 / Serialization. Code targets Go 1.22+, Python 3.11+ and Node.js 20+.
+Backend from First Principles / Chapter 03 / Serialization. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+.

--- a/src/plugins/rehype-code-tabs.mjs
+++ b/src/plugins/rehype-code-tabs.mjs
@@ -16,6 +16,8 @@ const LANG_LABELS = new Map([
   ['python', 'Python'],
   ['sql', 'SQL'],
   ['js', 'JavaScript'],
+  ['ts', 'TypeScript'],
+  ['java', 'Java'],
 ]);
 
 // Sorted longest-first so "SQL" is tried before anything that could be a


### PR DESCRIPTION
Every language code has been added as  tabbed code block. Initially I implemented it  in the first three chapters for now with five languages, in the order Go, Python, JavaScript, TypeScript, Java. I have added Typescript and Java Implementation

Chapter 01 (HTTP & CORS)
- Add TypeScript and Java tabs to all 15 Go/Python/JavaScript groups. TypeScript builds on Express 5 typing's and Java uses Spring Boot implementation

Chapter 02 (Routing)
- Merge A Router in Go/Python/JavaScript into a single Building a Router section with one five-tab code block.
- Add TypeScript and Java routers tab and renumber the glossary to 12.

Chapter 03 (Serialization)
- Merge Serialization in Go Python JavaScript into a single Serialization in Code section with one five tab code block.
- Added TypeScript and Java serializers and renumber the glossary to 10.

Supporting changes
- Register TS and Java in rehype code tabs so those tabs are labelled  TypeScript and Java.
- Fixed the missing space in the Go and Python code titles, and list the new languages in each chapter's summary, callouts and footer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded HTTP, CORS, routing, and serialization guides with TypeScript and Java examples.
  * Added TypeScript and Java language tabs throughout relevant code samples.
  * Consolidated routing and serialization content into streamlined multi-language sections.
  * Updated chapter summaries, callouts, and closing text to reflect support for all five languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->