### PR TITLE
feat(chapters): add JavaScript, TypeScript and Java code tabs to chap…

### DIFF
--- a/src/content/chapters/06-controllers-services-and-middlewares.mdx
+++ b/src/content/chapters/06-controllers-services-and-middlewares.mdx
@@ -2,7 +2,7 @@
 order: 6
 title: "Handlers, Services & Repositories."
 navTitle: "Controllers, Services & Middlewares"
-summary: "A first-principles walkthrough of how a single HTTP request travels inside your server, through routing, the three architectural layers, the middleware chain, and the request context that ties it all together. Complete implementations in Go and Python shown side by side."
+summary: "A first-principles walkthrough of how a single HTTP request travels inside your server, through routing, the three architectural layers, the middleware chain, and the request context that ties it all together. Complete implementations in Go, Python, JavaScript, TypeScript and Java shown side by side."
 readingTime: "2-3 hours"
 keywords:
   - "controllers"
@@ -108,11 +108,11 @@ With those two objects in hand, the handler runs through a precise, ordered work
 
 ### A note on Node.js vs Go & Python
 
-In a Node.js/Express app the deserialization step often happens _upstream_ in a middleware (the `json()` body parser), so JSON is already a JavaScript object by the time your handler runs. In **Go** and **Python** you typically deserialize _explicitly_ inside the handler, into a struct, a dictionary, or a class.
+In a Node.js/Express app the deserialization step often happens _upstream_ in a middleware (the `json()` body parser), so JSON is already a JavaScript object by the time your handler runs. Spring goes further still and binds the body into a record before your method is even called. In **Go** and **Python** you typically deserialize _explicitly_ inside the handler, into a struct, a dictionary, or a class. The step never disappears, it only moves: the further upstream it runs, the less of it you write yourself.
 
 #### Step 1: 2 / Extract & bind the body; 400 on failure
 
-```go title="create_book / handler Go Python"
+```go title="create_book / handler Go Python JavaScript TypeScript Java"
 // CreateBookRequest is our native format, the bind target.
 type CreateBookRequest struct {
     Title  string `json:"title"`
@@ -151,11 +151,85 @@ def create_book_handler():
     # ... validation, transformation, delegation follow ...
 ```
 
+```js
+// Express's json() body parser has already deserialized the body upstream,
+// so req.body is a JavaScript object by the time the handler runs. That
+// makes step 1 free and turns step 2 into "check the shape you expected".
+app.post('/books', (req, res) => {
+  // Step 1 + 2: extract the body and bind the fields we accept.
+  const { title, author } = req.body ?? {}
+
+  // express.json() leaves req.body empty when the payload is malformed.
+  if (typeof title !== 'string' || typeof author !== 'string') {
+    // Binding failed -> the payload is malformed.
+    return res.status(400).json({ error: 'invalid request body' }) // 400
+  }
+
+  const createBookRequest = { title, author }
+  // ... validation, transformation, delegation follow ...
+})
+```
+
+```ts
+import type { Request, Response } from 'express'
+
+// CreateBookRequest is our native format, the bind target.
+interface CreateBookRequest {
+  title: string
+  author: string
+}
+
+// A parsed body is `unknown` until something proves its shape. A type
+// guard is that proof, and it is what lets the rest of the handler treat
+// `req.body` as a CreateBookRequest without a cast.
+function isCreateBookRequest(value: unknown): value is CreateBookRequest {
+  const body = value as Partial<CreateBookRequest> | null
+  return typeof body?.title === 'string' && typeof body?.author === 'string'
+}
+
+export function createBookHandler(req: Request, res: Response): void {
+  // Step 1 + 2: extract the body and deserialize (bind) into the type.
+  if (!isCreateBookRequest(req.body)) {
+    // Deserialization failed -> the payload is malformed.
+    res.status(400).json({ error: 'invalid request body' }) // 400
+    return // terminate the request here; do not proceed.
+  }
+
+  const body: CreateBookRequest = req.body
+  // ... validation, transformation, delegation follow ...
+}
+```
+
+```java
+// CreateBookRequest is our native format, the bind target.
+public record CreateBookRequest(String title, String author) {}
+
+@RestController
+class BookController {
+
+    // Step 1 + 2 happen BEFORE this method runs: @RequestBody tells Spring
+    // to read the body and let Jackson deserialize it into the record.
+    @PostMapping("/books")
+    ResponseEntity<?> createBook(@RequestBody CreateBookRequest req) {
+        // ... validation, transformation, delegation follow ...
+        return ResponseEntity.status(HttpStatus.CREATED).build(); // 201
+    }
+
+    // A body Jackson cannot read never reaches the handler, it arrives
+    // here instead. Same outcome as the explicit `if` above: 400.
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    ResponseEntity<?> onUnreadableBody() {
+        return ResponseEntity.badRequest()
+            .body(Map.of("error", "invalid request body")); // 400
+    }
+}
+```
+
 #### Step 3: 4 / Validate, then transform (inject a default for an optional query param)
 
 A good API design rule: make query parameters **optional** wherever possible. Consider `GET /books?sort=name|date`. If the client sends nothing, validation must still pass, so the transformation step injects a sensible default.
 
-```go title="list_books / validate + transform Go Python"
+```go title="list_books / validate + transform Go Python JavaScript TypeScript Java"
 func ListBooksHandler(w http.ResponseWriter, r *http.Request) {
     sort := r.URL.Query().Get("sort") // "" if absent
 
@@ -200,6 +274,80 @@ def list_books_handler():
     return jsonify(books), 200  # array of books
 ```
 
+```js
+app.get('/books', async (req, res) => {
+  const sort = req.query.sort // undefined if absent
+
+  // VALIDATION: if present, it must be one of the allowed values.
+  if (sort !== undefined && sort !== 'name' && sort !== 'date') {
+    return res.status(400).json({ error: "sort must be 'name' or 'date'" })
+  }
+
+  // TRANSFORMATION: query params are optional -> inject a default.
+  const sortBy = sort ?? 'date' // downstream layers never see undefined
+
+  try {
+    const books = await bookService.listBooks(sortBy) // delegate
+    res.status(200).json(books) // 200 with the array of books
+  } catch {
+    res.status(500).json({ error: 'could not fetch books' }) // 500
+  }
+})
+```
+
+```ts
+import type { Request, Response } from 'express'
+
+const SORTS = ['name', 'date'] as const
+type Sort = (typeof SORTS)[number]
+
+export async function listBooksHandler(req: Request, res: Response): Promise<void> {
+  const sort = req.query.sort // string | string[] | undefined | ...
+
+  // VALIDATION: if present, it must be one of the allowed values.
+  if (sort !== undefined && !SORTS.includes(sort as Sort)) {
+    res.status(400).json({ error: "sort must be 'name' or 'date'" })
+    return
+  }
+
+  // TRANSFORMATION: optional param -> inject a default. Note what the
+  // narrowed type buys you: the service takes a `Sort`, so a typo in a
+  // future edit stops compiling instead of reaching the database.
+  const sortBy: Sort = (sort as Sort | undefined) ?? 'date'
+
+  try {
+    const books = await bookService.listBooks(sortBy) // delegate
+    res.status(200).json(books) // 200 with the array of books
+  } catch {
+    res.status(500).json({ error: 'could not fetch books' }) // 500
+  }
+}
+```
+
+```java
+@GetMapping("/books")
+ResponseEntity<?> listBooks(@RequestParam(required = false) String sort) {
+    // VALIDATION: if present, it must be one of the allowed values.
+    if (sort != null && !sort.equals("name") && !sort.equals("date")) {
+        return ResponseEntity.badRequest()
+            .body(Map.of("error", "sort must be 'name' or 'date'")); // 400
+    }
+
+    // TRANSFORMATION: query params are optional -> inject a default.
+    // (@RequestParam(defaultValue = "date") would do exactly this for you;
+    // it is spelled out here so the step stays visible.)
+    String sortBy = (sort == null) ? "date" : sort;
+
+    try {
+        List<Book> books = bookService.listBooks(sortBy); // delegate
+        return ResponseEntity.ok(books); // 200 with the array of books
+    } catch (DataAccessException e) {
+        return ResponseEntity.internalServerError()
+            .body(Map.of("error", "could not fetch books")); // 500
+    }
+}
+```
+
 ## 06The Service Layer
 
 The service layer is where the **actual processing**: the business logic, happens. The single most important rule governs it:
@@ -214,7 +362,7 @@ This isolation is what keeps the system decoupled. The service decides _what to 
 
 A single service method can do a great deal. It can call **one or several repository methods** and merge their results, make external API calls, send emails, fire notifications, anything the business operation requires. This coordinating role is called **orchestration**: the service stitches together data from multiple sources and returns a single clean result to the handler. A service that only sends an email may never touch the repository at all.
 
-```go title="book_service / pure business logic Go Python"
+```go title="book_service / pure business logic Go Python JavaScript TypeScript Java"
 // Notice: no http.Request, no ResponseWriter, no status codes.
 // You cannot tell from this signature that it serves an API.
 func (s *BookService) ListBooks(ctx context.Context, sort string) ([]Book, error) {
@@ -251,6 +399,80 @@ class BookService:
         self.mailer.send(email, "Your book was added")
 ```
 
+```js
+// Notice: no req, no res, no status codes.
+// You cannot tell from these methods that they serve an API.
+class BookService {
+  constructor(repo, mailer) {
+    this.repo = repo
+    this.mailer = mailer
+  }
+
+  async listBooks(sort) {
+    // Orchestration: call the repository for the data it needs.
+    const books = await this.repo.findAllBooks(sort)
+    // Could also: enrich, merge other repo calls, send notifications...
+    return books
+  }
+
+  // A service that needs no database at all is perfectly valid:
+  async notifyOwner(email) {
+    await this.mailer.send(email, 'Your book was added')
+  }
+}
+```
+
+```ts
+// The types tell the same story the comments do: every name in this
+// signature is a domain word (Book, Sort, Mailer). Not one of them is
+// an HTTP word, which is exactly the isolation we are after.
+export class BookService {
+  constructor(
+    private readonly repo: BookRepo,
+    private readonly mailer: Mailer,
+  ) {}
+
+  async listBooks(sort: Sort): Promise<Book[]> {
+    // Orchestration: ask the repository for what it needs.
+    const books = await this.repo.findAllBooks(sort)
+    // Could merge other repo calls, enrich, notify, etc.
+    return books
+  }
+
+  // A purely-logic service that never touches the DB:
+  async notifyOwner(email: string): Promise<void> {
+    await this.mailer.send(email, 'Your book was added')
+  }
+}
+```
+
+```java
+// No HttpServletRequest, no ResponseEntity, no status codes. Nothing here
+// says "web", this class would work unchanged behind a CLI or a queue.
+@Service
+public class BookService {
+    private final BookRepo repo;
+    private final Mailer mailer;
+
+    BookService(BookRepo repo, Mailer mailer) {
+        this.repo = repo;
+        this.mailer = mailer;
+    }
+
+    public List<Book> listBooks(String sort) {
+        // Orchestration: call the repository for the data it needs.
+        List<Book> books = repo.findAllBooks(sort);
+        // Could also: enrich, merge other repo calls, send notifications...
+        return books;
+    }
+
+    // A service that needs no database at all is perfectly valid:
+    public void notifyOwner(String email) {
+        mailer.send(email, "Your book was added");
+    }
+}
+```
+
 ## 07The Repository Layer
 
 The repository (or _database_) layer has a single concern: **talking to the database**. It receives data from the service, **constructs the database query**: for inserting, filtering, or sorting, runs it, and returns the raw result back up to the service.
@@ -259,7 +481,7 @@ The repository (or _database_) layer has a single concern: **talking to the data
 A repository method should do **one thing** and return **one kind of data**. Do _not_ write a single method that, depending on an optional parameter, returns either one book or all books. Instead write two distinct methods: `FindAllBooks()` and `FindBookByID(id)`.
 </Callout>
 
-```go title="book_repository / one job per method Go Python"
+```go title="book_repository / one job per method Go Python JavaScript TypeScript Java"
 // ONE method, ONE shape of result: all books, sorted.
 func (r *BookRepo) FindAllBooks(ctx context.Context, sort string) ([]Book, error) {
     // Build the query from the data the service handed down.
@@ -304,6 +526,92 @@ class BookRepo:
         cur = self.db.execute(
             "SELECT id, title, author FROM books WHERE id = ?", (book_id,))
         return dict(cur.fetchone())
+```
+
+```js
+class BookRepo {
+  constructor(db) {
+    this.db = db // a node-postgres Pool
+  }
+
+  // ONE method, ONE shape of result: all books, sorted.
+  async findAllBooks(sort) {
+    // A column name can never be a bound parameter, so it goes through a
+    // fixed lookup rather than into the string. Values always use $1, $2.
+    const column = { name: 'title', date: 'created_at' }[sort] ?? 'created_at'
+    const { rows } = await this.db.query(
+      `SELECT id, title, author FROM books ORDER BY ${column}`)
+    return rows
+  }
+
+  // SEPARATE method for one book. No optional toggle parameter.
+  async findBookById(id) {
+    const { rows } = await this.db.query(
+      'SELECT id, title, author FROM books WHERE id = $1', [id])
+    return rows[0] ?? null
+  }
+}
+```
+
+```ts
+import type { Pool } from 'pg'
+
+const SORT_COLUMNS: Record<Sort, string> = { name: 'title', date: 'created_at' }
+
+export class BookRepo {
+  constructor(private readonly db: Pool) {}
+
+  // ONE method, ONE shape of result: all books, sorted.
+  async findAllBooks(sort: Sort): Promise<Book[]> {
+    // Because `sort` is a `Sort` and not a `string`, the lookup is total:
+    // there is no value it could hold that produces a column we did not
+    // write ourselves. The type is the injection defence.
+    const { rows } = await this.db.query<Book>(
+      `SELECT id, title, author FROM books ORDER BY ${SORT_COLUMNS[sort]}`)
+    return rows
+  }
+
+  // SEPARATE method for one book. No optional toggle parameter.
+  // The return type says "may be missing" out loud, so the service has
+  // to decide what that means instead of tripping over undefined.
+  async findBookById(id: number): Promise<Book | null> {
+    const { rows } = await this.db.query<Book>(
+      'SELECT id, title, author FROM books WHERE id = $1', [id])
+    return rows[0] ?? null
+  }
+}
+```
+
+```java
+@Repository
+public class BookRepo {
+    // A column name can never be a bound parameter, so it goes through a
+    // fixed map rather than into the string. Values always use ?.
+    private static final Map<String, String> SORT_COLUMNS =
+        Map.of("name", "title", "date", "created_at");
+
+    private final JdbcClient db;
+
+    BookRepo(JdbcClient db) {
+        this.db = db;
+    }
+
+    // ONE method, ONE shape of result: all books, sorted.
+    public List<Book> findAllBooks(String sort) {
+        String column = SORT_COLUMNS.getOrDefault(sort, "created_at");
+        return db.sql("SELECT id, title, author FROM books ORDER BY " + column)
+                 .query(Book.class)
+                 .list();
+    }
+
+    // SEPARATE method for one book. No optional toggle parameter.
+    public Optional<Book> findBookById(long id) {
+        return db.sql("SELECT id, title, author FROM books WHERE id = ?")
+                 .param(id)
+                 .query(Book.class)
+                 .optional();
+    }
+}
 ```
 
 ## 08The Full Lifecycle, End to End
@@ -362,7 +670,7 @@ The third thing a middleware receives is **`next`**, a function. Calling `next()
 
 Because a middleware has both the request and response objects, it can read and modify the request, and it can terminate the request right where it stands by returning a response. That is the full extent of a middleware's power.
 
-```go title="middleware shape / req, res, next Go Python"
+```go title="middleware shape / req, res, next Go Python JavaScript TypeScript Java"
 // In Go, middleware wraps the "next" handler. Calling next.ServeHTTP
 // is the equivalent of next(): pass execution along the chain.
 func LoggingMiddleware(next http.Handler) http.Handler {
@@ -393,6 +701,70 @@ def logging_middleware(next):
 
         return next(request)  # === next(): continue the chain ===
     return wrapper
+```
+
+```js
+// Express middleware is the shape the whole idea is named after:
+// (req, res, next). Calling next() passes execution along the chain.
+function loggingMiddleware(req, res, next) {
+  console.log(`${req.method} ${req.path}`) // do work
+
+  // EARLY EXIT example (short-circuit, never calls next):
+  if (req.get('X-Blocked') === 'yes') {
+    return res.status(403).send('forbidden') // request stops here
+  }
+
+  next() // === next(): continue the chain ===
+}
+
+app.use(loggingMiddleware)
+```
+
+```ts
+import type { NextFunction, Request, Response } from 'express'
+
+// The three parameters, spelled out by their types: the request, the
+// response, and the `next` callable that invokes the rest of the chain.
+// The `void` return is the reminder that a middleware communicates by
+// calling next() or by writing a response, never by returning a value.
+function loggingMiddleware(req: Request, res: Response, next: NextFunction): void {
+  console.log(`${req.method} ${req.path}`) // do work
+
+  // EARLY EXIT example (short-circuit, never calls next):
+  if (req.get('X-Blocked') === 'yes') {
+    res.status(403).send('forbidden') // request stops here
+    return
+  }
+
+  next() // === next(): continue the chain ===
+}
+
+app.use(loggingMiddleware)
+```
+
+```java
+// A servlet Filter is Java's middleware. It receives the request, the
+// response, and a FilterChain, and chain.doFilter IS next(): pass
+// execution to the next filter, or on to the controller.
+@Component
+public class LoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req,
+                                    HttpServletResponse res,
+                                    FilterChain chain)
+            throws ServletException, IOException {
+        log.info("{} {}", req.getMethod(), req.getRequestURI()); // do work
+
+        // EARLY EXIT example (short-circuit, never calls the chain):
+        if ("yes".equals(req.getHeader("X-Blocked"))) {
+            res.sendError(HttpServletResponse.SC_FORBIDDEN, "forbidden");
+            return; // request stops here
+        }
+
+        chain.doFilter(req, res); // === next(): continue the chain ===
+    }
+}
 ```
 
 #### Why middleware at all?
@@ -447,7 +819,7 @@ Serialization/deserialization, and even validation/transformation, can be delega
 
 #### The CORS & Authentication middlewares in code
 
-```go title="cors + auth middleware Go Python"
+```go title="cors + auth middleware Go Python JavaScript TypeScript Java"
 var allowedOrigin = "https://app.example.com"
 
 func CORSMiddleware(next http.Handler) http.Handler {
@@ -502,12 +874,109 @@ def auth_middleware(next):
     return wrapper
 ```
 
+```js
+const ALLOWED_ORIGIN = 'https://app.example.com'
+
+function corsMiddleware(req, res, next) {
+  const origin = req.get('Origin') // runtime gives us this
+  if (origin === ALLOWED_ORIGIN) {
+    res.set('Access-Control-Allow-Origin', origin)
+  }
+  next() // pass along; browser blocks if header absent
+}
+
+function authMiddleware(req, res, next) {
+  const token = req.get('Authorization')
+  let claims
+  try {
+    claims = verifyToken(token)
+  } catch {
+    return res.status(401).send('unauthorized') // 401, stop
+  }
+  // SUCCESS: stash identity in the request context, then continue.
+  req.context = { ...req.context, userId: claims.userId, role: claims.role }
+  next()
+}
+```
+
+```ts
+import type { NextFunction, Request, Response } from 'express'
+
+const ALLOWED_ORIGIN = 'https://app.example.com'
+
+export function corsMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const origin = req.get('Origin') // runtime gives us this
+  if (origin === ALLOWED_ORIGIN) {
+    res.set('Access-Control-Allow-Origin', origin)
+  }
+  next() // pass along; browser blocks if header absent
+}
+
+export function authMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const token = req.get('Authorization')
+  let claims: TokenClaims
+  try {
+    claims = verifyToken(token)
+  } catch {
+    res.status(401).send('unauthorized') // 401, stop
+    return
+  }
+  // SUCCESS: stash identity in the request context, then continue.
+  // `req.context` is typed once via declaration merging (next section),
+  // so every handler downstream reads it without a cast.
+  req.context = { ...req.context, userId: claims.userId, role: claims.role }
+  next()
+}
+```
+
+```java
+@Component
+public class CorsFilter extends OncePerRequestFilter {
+    private static final String ALLOWED_ORIGIN = "https://app.example.com";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res,
+                                    FilterChain chain)
+            throws ServletException, IOException {
+        String origin = req.getHeader("Origin"); // runtime gives us this
+        if (ALLOWED_ORIGIN.equals(origin)) {
+            res.setHeader("Access-Control-Allow-Origin", origin);
+        }
+        chain.doFilter(req, res); // pass along; browser blocks if header absent
+    }
+}
+
+@Component
+public class AuthFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res,
+                                    FilterChain chain)
+            throws ServletException, IOException {
+        String token = req.getHeader("Authorization");
+        TokenClaims claims;
+        try {
+            claims = verifyToken(token);
+        } catch (InvalidTokenException e) {
+            res.sendError(HttpServletResponse.SC_UNAUTHORIZED, "unauthorized"); // 401, stop
+            return;
+        }
+        // SUCCESS: stash identity in the request context, then continue.
+        // Request attributes ARE the servlet request context: a key-value
+        // map that lives and dies with this one request.
+        req.setAttribute("userId", claims.userId());
+        req.setAttribute("role", claims.role());
+        chain.doFilter(req, res);
+    }
+}
+```
+
 ## 13What Request Context Is
 
 The auth middleware just did something subtle: it stored the user ID and role somewhere so that a later handler could read them. That "somewhere" is the **request context**.
 
 <Callout type="info" title="Definition / Request Context">
-A piece of **storage or state**: usually a simple key–value store, that is **scoped to a single HTTP request**. Every request gets its own context; it does not leak into other requests. Every framework in every language (Node, Go, Python) ships some implementation of this concept; the mechanics differ, the idea is the same.
+A piece of **storage or state**: usually a simple key–value store, that is **scoped to a single HTTP request**. Every request gets its own context; it does not leak into other requests. Every framework in every language ships some implementation of this concept, Go's `context.Context`, Express's `req` object, a servlet's request attributes, Python's request-scoped globals; the mechanics differ, the idea is the same.
 </Callout>
 
 Why does it exist? Because a request passes through many **isolated function boundaries**: CORS, logging, routing, auth, permission checks, the handler, the error handler. The context gives all of them a shared place to read and write state **without tightly coupling** them, without one middleware having to explicitly pass values into the next by hand.
@@ -526,7 +995,7 @@ The canonical use. The auth middleware verifies credentials, extracts the `user_
 If you took the `user_id` from the client payload, a malicious client could send _someone else's_ ID and act as them. Reading identity from the context, populated only by your verified auth middleware, closes that hole. The same context-stored role drives permission checks (is this user an admin? does it have write access?).
 </Callout>
 
-```go title="handler reads identity from context Go Python"
+```go title="handler reads identity from context Go Python JavaScript TypeScript Java"
 func CreateBookHandler(w http.ResponseWriter, r *http.Request) {
     var req CreateBookRequest
     json.NewDecoder(r.Body).Decode(&req)
@@ -565,13 +1034,80 @@ def create_book_handler(request):
     return jsonify(book), 201
 ```
 
+```js
+app.post('/books', async (req, res) => {
+  const { title, author } = req.body ?? {}
+
+  // Read the trusted user id FROM THE CONTEXT, not from the body.
+  // The auth middleware put it there after verifying the token.
+  const { userId, role } = req.context
+
+  if (role !== 'admin' && role !== 'user') {
+    return res.status(403).send('forbidden')
+  }
+
+  // Persist with the SERVER-VERIFIED owner id, never the client's.
+  const book = await bookService.create({ title, author }, userId)
+  res.status(201).json(book) // 201
+})
+```
+
+```ts
+import type { Request, Response } from 'express'
+
+// Declare the context's shape ONCE and every handler in the codebase
+// sees it. This is how you stop `req.context` from decaying into an
+// `any` bag that each handler guesses at.
+declare module 'express-serve-static-core' {
+  interface Request {
+    context: { userId: number; role: string; requestId: string }
+  }
+}
+
+export async function createBookHandler(req: Request, res: Response): Promise<void> {
+  const body = req.body as CreateBookRequest
+
+  // Read the trusted user id FROM THE CONTEXT, not from the body.
+  // The auth middleware put it there after verifying the token.
+  const { userId, role } = req.context
+
+  if (role !== 'admin' && role !== 'user') {
+    res.status(403).send('forbidden')
+    return
+  }
+
+  // Persist with the SERVER-VERIFIED owner id, never the client's.
+  const book = await bookService.create(body, userId)
+  res.status(201).json(book) // 201
+}
+```
+
+```java
+@PostMapping("/books")
+ResponseEntity<?> createBook(@RequestBody CreateBookRequest req,
+                             HttpServletRequest http) {
+    // Read the trusted user id FROM THE REQUEST CONTEXT, not from req.
+    // The auth filter put it there after verifying the token.
+    long userId = (long) http.getAttribute("userId");
+    String role = (String) http.getAttribute("role");
+
+    if (!role.equals("admin") && !role.equals("user")) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body("forbidden");
+    }
+
+    // Persist with the SERVER-VERIFIED owner id, never the client's.
+    Book book = bookService.create(req, userId);
+    return ResponseEntity.status(HttpStatus.CREATED).body(book); // 201
+}
+```
+
 ## 15Use Cases / Tracing & Cancellation
 
 ### Request tracing
 
 An early middleware can generate a unique ID (a UUID) and save it in the context. For the entire lifecycle of that request, every log line can include this ID, and any outbound calls to other microservices can forward it in a header like `X-Request-ID`. When you later audit your logs to debug a problem, that single ID lets you **trace one request across every service it touched**: where it started and everywhere it went.
 
-```go title="request-id middleware Go Python"
+```go title="request-id middleware Go Python JavaScript TypeScript Java"
 func RequestIDMiddleware(next http.Handler) http.Handler {
     return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
         id := uuid.NewString() // one unique id for this request
@@ -597,6 +1133,60 @@ def request_id_middleware(next):
     return wrapper
 ```
 
+```js
+import { randomUUID } from 'node:crypto'
+
+function requestIdMiddleware(req, res, next) {
+  const id = randomUUID() // one unique id for this request
+  req.context = { ...req.context, requestId: id }
+  res.set('X-Request-ID', id) // echo it back / forward it
+  console.log(`[${id}] ${req.method} ${req.path}`)
+  next()
+}
+```
+
+```ts
+import { randomUUID } from 'node:crypto'
+import type { NextFunction, Request, Response } from 'express'
+
+export function requestIdMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const id = randomUUID() // one unique id for this request
+  req.context = { ...req.context, requestId: id }
+  res.set('X-Request-ID', id) // echo it back / forward it
+  console.log(`[${id}] ${req.method} ${req.path}`)
+  // Node also ships AsyncLocalStorage, which carries the id through
+  // awaits into code that never sees `req` at all, the logger, the
+  // database layer, an outbound fetch. Same context, no hand-off.
+  next()
+}
+```
+
+```java
+@Component
+public class RequestIdFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res,
+                                    FilterChain chain)
+            throws ServletException, IOException {
+        String id = UUID.randomUUID().toString(); // one unique id for this request
+        req.setAttribute("requestId", id);
+        res.setHeader("X-Request-ID", id); // echo it back / forward it
+
+        // MDC is the logging framework's own per-request context. Put the
+        // id in once and EVERY log line from this request carries it, with
+        // no logging call having to pass it along by hand.
+        MDC.put("requestId", id);
+        try {
+            log.info("{} {}", req.getMethod(), req.getRequestURI());
+            chain.doFilter(req, res);
+        } finally {
+            MDC.clear(); // threads are pooled, never leak it to the next request
+        }
+    }
+}
+```
+
 ### Cancellation, abort signals & deadlines
 
 The request context is also the standard place to carry **cancellation signals** and **deadlines**. If a client disconnects or a deadline passes, those signals propagate to downstream external calls, so a service never **hangs perpetually** waiting on work that no longer matters. In Go this is the built-in `context.Context` with `WithTimeout`; in Python it surfaces as timeouts / cancellation tokens passed along the call chain.
@@ -605,4 +1195,4 @@ The request context is also the standard place to carry **cancellation signals**
 A request enters at the entry point, flows through an ordered chain of middlewares and routing, lands in a handler that validates and transforms the data, delegates to a service that orchestrates the business logic, which calls repositories for database work, all while a per-request **context** carries identity, a trace ID, and deadlines alongside it. The result climbs back up, and the handler chooses a status code and sends the response. That is the full request lifecycle.
 </Callout>
 
-Backend from First Principles / Chapter 06 / Layers. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 06 / Layers. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+ (Spring Boot).

--- a/src/content/chapters/07-api-design-rest.mdx
+++ b/src/content/chapters/07-api-design-rest.mdx
@@ -205,7 +205,7 @@ Two clients GET the same record. A changes the email and saves. B (who never saw
 
 ______
 
-GoPython
+Go Python JavaScript TypeScript Java
 
 PATCH with optimistic-concurrency guard
 
@@ -247,6 +247,72 @@ def update_organization(id: str, body: dict, if_match: str | None = Header(None)
     )                                  # 200 + updated entity
 ```
 
+```js
+app.patch('/v1/organizations/:id', async (req, res) => {
+  const org = await store.get(req.params.id)
+  if (!org) {
+    return res.status(404).json(errBody('organization not found'))
+  }
+  // optimistic concurrency: reject stale writes
+  const ifMatch = req.get('If-Match')
+  if (ifMatch && ifMatch !== org.etag) {
+    return res.status(412).json(errBody('resource changed; re-fetch and retry'))
+  }
+  const updated = await store.patch(req.params.id, req.body) // merge, don't replace
+  res.set('ETag', updated.etag)
+  res.status(200).json(updated)                              // 200 + updated entity
+})
+```
+
+```ts
+import type { Request, Response } from 'express'
+
+export async function updateOrganization(req: Request, res: Response): Promise<void> {
+  const org = await store.get(req.params.id)
+  if (org === null) {
+    res.status(404).json(errBody('organization not found'))
+    return
+  }
+  // optimistic concurrency: reject stale writes
+  const ifMatch = req.get('If-Match')
+  if (ifMatch !== undefined && ifMatch !== org.etag) {
+    res.status(412).json(errBody('resource changed; re-fetch and retry'))
+    return
+  }
+  // `Partial<Organization>` IS the PATCH contract written as a type: every
+  // field optional, and absent means "leave it alone". Typing the body as
+  // `Organization` here would quietly re-introduce the PUT trap.
+  const patch = req.body as Partial<Organization>
+  const updated = await store.patch(req.params.id, patch) // merge, don't replace
+  res.set('ETag', updated.etag)
+  res.status(200).json(updated)                           // 200 + updated entity
+}
+```
+
+```java
+@PatchMapping("/v1/organizations/{id}")
+ResponseEntity<?> updateOrganization(
+        @PathVariable String id,
+        @RequestBody Map<String, Object> patch, // only the fields to change
+        @RequestHeader(value = "If-Match", required = false) String ifMatch) {
+
+    Organization org = store.get(id);
+    if (org == null) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(errBody("organization not found"));
+    }
+    // optimistic concurrency: reject stale writes
+    if (ifMatch != null && !ifMatch.equals(org.etag())) {
+        return ResponseEntity.status(HttpStatus.PRECONDITION_FAILED)
+            .body(errBody("resource changed; re-fetch and retry")); // 412
+    }
+    Organization updated = store.patch(id, patch); // merge, don't replace
+    return ResponseEntity.ok()
+        .eTag(updated.etag())
+        .body(updated);                            // 200 + updated entity
+}
+```
+
 | Code                         | On a PUT / PATCH, this means                                                         |
 | ---------------------------- | ------------------------------------------------------------------------------------ |
 | `200 OK`                     | Updated; body holds the new state.                                                   |
@@ -277,7 +343,7 @@ Say you `POST /payments {amount: 5000}` and the network drops _after_ the server
 
 ______
 
-GoPython
+Go Python JavaScript TypeScript Java
 
 making POST retry-safe with an idempotency key
 
@@ -311,6 +377,70 @@ def create_payment(body: dict, idempotency_key: str = Header(...)):
     payment = charge(body["amount"])               # the real, non-idempotent side effect
     idem_store.save(idempotency_key, 201, payment) # remember it, keyed by the idempotency key
     return payment
+```
+
+```js
+app.post('/v1/payments', async (req, res) => {
+  const key = req.get('Idempotency-Key') // client-generated UUID
+
+  // already processed this exact request? return the SAME result, don't re-charge
+  const prior = await idemStore.get(key)
+  if (prior) {
+    return res.status(prior.status).json(prior.body)
+  }
+
+  const payment = await charge(req.body.amount) // the real, non-idempotent side effect
+  await idemStore.save(key, 201, payment)       // remember it, keyed by the idempotency key
+  res.status(201).json(payment)
+})
+```
+
+```ts
+import type { Request, Response } from 'express'
+
+interface StoredResult {
+  status: number
+  body: Payment
+}
+
+export async function createPayment(req: Request, res: Response): Promise<void> {
+  const key = req.get('Idempotency-Key') // client-generated UUID
+  if (key === undefined) {
+    res.status(400).json(errBody('Idempotency-Key header is required'))
+    return
+  }
+
+  // already processed this exact request? return the SAME result, don't re-charge
+  const prior: StoredResult | null = await idemStore.get(key)
+  if (prior !== null) {
+    res.status(prior.status).json(prior.body)
+    return
+  }
+
+  // Worth knowing: this read-then-write is itself racy if two retries land
+  // at once. In production the key is claimed with a single atomic insert
+  // (a unique index on the key), and a duplicate insert means "someone else
+  // is already charging this, wait for their result".
+  const payment = await charge(req.body.amount as number) // the non-idempotent side effect
+  await idemStore.save(key, 201, payment) // remember it, keyed by the idempotency key
+  res.status(201).json(payment)
+}
+```
+
+```java
+@PostMapping("/v1/payments")
+ResponseEntity<?> createPayment(@RequestBody PaymentRequest in,
+                                @RequestHeader("Idempotency-Key") String key) {
+    // already processed this exact request? return the SAME result, don't re-charge
+    Optional<StoredResult> prior = idemStore.get(key);
+    if (prior.isPresent()) {
+        return ResponseEntity.status(prior.get().status()).body(prior.get().body());
+    }
+
+    Payment payment = charge(in.amount()); // the real, non-idempotent side effect
+    idemStore.save(key, 201, payment);     // remember it, keyed by the idempotency key
+    return ResponseEntity.status(HttpStatus.CREATED).body(payment);
+}
 ```
 
 | Code                         | On a POST, this means                                                    |
@@ -380,7 +510,7 @@ Pass resource fields as query params to narrow the list: `?status=active`, or co
 
 ______
 
-GoPython
+Go Python JavaScript TypeScript Java
 
 list endpoint / page / sort / filter / sane defaults
 
@@ -435,6 +565,99 @@ def list_organizations(
         "page": page,
         "totalPages": total_pages,
     }
+```
+
+```js
+// GET /v1/organizations?status=active&sortBy=name&sortOrder=ascending&page=1&limit=10
+app.get('/v1/organizations', async (req, res) => {
+  const q = req.query
+
+  // --- sane defaults: never crash if the client omits params ---
+  // Note the `||` rather than `??`: a query param arrives as a string, so
+  // Number('abc') is NaN and Number('') is 0, and both must fall back too.
+  const page = Number(q.page) || 1
+  const limit = Number(q.limit) || 10
+  const sortBy = q.sortBy || 'createdAt'
+  const sortOrder = q.sortOrder || 'descending'
+
+  const filters = {}
+  if (q.status) {
+    filters.status = q.status // ?status=active
+  }
+
+  const { rows, total } = await store.query(filters, sortBy, sortOrder, page, limit)
+  const totalPages = Math.ceil(total / limit)
+
+  res.status(200).json({ data: rows, total, page, totalPages })
+})
+```
+
+```ts
+import type { Request, Response } from 'express'
+
+interface ListPage<T> {
+  data: T[]
+  total: number
+  page: number
+  totalPages: number
+}
+
+// GET /v1/organizations?status=active&sortBy=name&sortOrder=ascending&page=1&limit=10
+export async function listOrganizations(req: Request, res: Response): Promise<void> {
+  const q = req.query
+
+  // --- sane defaults: never crash if the client omits params ---
+  // Everything in `req.query` is `unknown`-ish by nature (a string, an
+  // array of strings, or missing), so each param is coerced once, here,
+  // and the rest of the function works with real numbers and strings.
+  const page = Number(q.page) || 1
+  const limit = Math.min(Number(q.limit) || 10, 100) // and cap it, see below
+  const sortBy = String(q.sortBy ?? 'createdAt')
+  const sortOrder = q.sortOrder === 'ascending' ? 'ascending' : 'descending'
+
+  const filters: Record<string, string> = {}
+  if (typeof q.status === 'string') {
+    filters.status = q.status // ?status=active
+  }
+
+  const { rows, total } = await store.query(filters, sortBy, sortOrder, page, limit)
+
+  const body: ListPage<Organization> = {
+    data: rows,
+    total,
+    page,
+    totalPages: Math.ceil(total / limit),
+  }
+  res.status(200).json(body)
+}
+```
+
+```java
+// GET /v1/organizations?status=active&sortBy=name&sortOrder=ascending&page=1&limit=10
+@GetMapping("/v1/organizations")
+ResponseEntity<?> listOrganizations(
+        // --- sane defaults: never crash if the client omits params ---
+        // defaultValue does the whole job; the param is never null here.
+        @RequestParam(defaultValue = "1")          int page,
+        @RequestParam(defaultValue = "10")         int limit,
+        @RequestParam(defaultValue = "createdAt")  String sortBy,
+        @RequestParam(defaultValue = "descending") String sortOrder,
+        @RequestParam(required = false)            String status) {
+
+    Map<String, String> filters = new HashMap<>();
+    if (status != null) {
+        filters.put("status", status); // ?status=active
+    }
+
+    QueryResult<Organization> result = store.query(filters, sortBy, sortOrder, page, limit);
+    int totalPages = (result.total() + limit - 1) / limit; // ceil division
+
+    return ResponseEntity.ok(Map.of(
+        "data",       result.rows(),
+        "total",      result.total(),
+        "page",       page,
+        "totalPages", totalPages));
+}
 ```
 
 ## Status Codes: done right
@@ -524,7 +747,7 @@ Notice the symmetry: **list** and **create** share the collection URL (`/organiz
 
 ______
 
-GoPython
+Go Python JavaScript TypeScript Java
 
 wiring the full resource / CRUD + custom action
 
@@ -607,6 +830,164 @@ def archive_organization(id: str):
     return store.archive(id)   # flips status + cascades: projects, tasks, emails...
 ```
 
+```js
+import { Router } from 'express'
+
+const router = Router()
+
+// list + create share the collection URL, split by method
+router.get('/v1/organizations', listOrganizations) // (see section 07)
+router.post('/v1/organizations', createOrganization)
+
+// get-one / update / delete share /:id, split by method
+router.get('/v1/organizations/:id', getOrganization)
+router.patch('/v1/organizations/:id', updateOrganization)
+router.delete('/v1/organizations/:id', deleteOrganization)
+
+// custom action: verb at the end of a specific resource
+router.post('/v1/organizations/:id/archive', archiveOrganization)
+
+async function createOrganization(req, res) {
+  const { name, status, description } = req.body
+  const org = await store.insert({
+    name,
+    status: status || 'active', // sane default, don't force the client to send the obvious
+    description,
+  }) // id, createdAt set server-side
+  res.status(201).json(org) // 201 Created + the new entity
+}
+
+async function getOrganization(req, res) {
+  const org = await store.get(req.params.id)
+  if (!org) {
+    return res.status(404).json(errBody('organization not found')) // single id -> 404
+  }
+  res.status(200).json(org)
+}
+
+async function updateOrganization(req, res) {
+  res.status(200).json(await store.update(req.params.id, req.body)) // partial update -> 200
+}
+
+async function deleteOrganization(req, res) {
+  await store.delete(req.params.id)
+  res.sendStatus(204) // No Content
+}
+
+async function archiveOrganization(req, res) {
+  const org = await store.archive(req.params.id) // flips status + cascades: projects, tasks, emails...
+  res.status(200).json(org) // custom action -> 200, NOT 201
+}
+```
+
+```ts
+import { Router, type Request, type Response } from 'express'
+
+const router = Router()
+
+// list + create share the collection URL, split by method
+router.get('/v1/organizations', listOrganizations) // (see section 07)
+router.post('/v1/organizations', createOrganization)
+
+// get-one / update / delete share /:id, split by method
+router.get('/v1/organizations/:id', getOrganization)
+router.patch('/v1/organizations/:id', updateOrganization)
+router.delete('/v1/organizations/:id', deleteOrganization)
+
+// custom action: verb at the end of a specific resource
+router.post('/v1/organizations/:id/archive', archiveOrganization)
+
+// The create body and the stored entity are DIFFERENT types, and saying so
+// is the point: `id` and `createdAt` are server-side, so they are absent
+// from the input type and a client cannot smuggle them in.
+interface CreateOrganization {
+  name: string
+  status?: string
+  description?: string
+}
+
+async function createOrganization(req: Request, res: Response): Promise<void> {
+  const body = req.body as CreateOrganization
+  const org: Organization = await store.insert({
+    name: body.name,
+    status: body.status ?? 'active', // sane default
+    description: body.description,
+  })
+  res.status(201).json(org) // 201 Created + the new entity
+}
+
+async function getOrganization(req: Request, res: Response): Promise<void> {
+  const org = await store.get(req.params.id)
+  if (org === null) {
+    res.status(404).json(errBody('organization not found')) // single id -> 404
+    return
+  }
+  res.status(200).json(org)
+}
+
+async function updateOrganization(req: Request, res: Response): Promise<void> {
+  const patch = req.body as Partial<Organization>
+  res.status(200).json(await store.update(req.params.id, patch)) // partial update -> 200
+}
+
+async function deleteOrganization(req: Request, res: Response): Promise<void> {
+  await store.delete(req.params.id)
+  res.sendStatus(204) // No Content
+}
+
+async function archiveOrganization(req: Request, res: Response): Promise<void> {
+  const org = await store.archive(req.params.id) // flips status + cascades
+  res.status(200).json(org) // custom action -> 200, NOT 201
+}
+```
+
+```java
+@RestController
+@RequestMapping("/v1/organizations") // the collection URL, written once
+class OrganizationController {
+
+    // list + create share the collection URL, split by method
+    @GetMapping
+    ListPage<Organization> list() { /* (see section 07) */ }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED) // 201 Created + the new entity
+    Organization create(@RequestBody CreateOrganization body) {
+        String status = (body.status() == null) ? "active" : body.status(); // sane default
+        // id, createdAt set server-side
+        return store.insert(body.name(), status, body.description());
+    }
+
+    // get-one / update / delete share /{id}, split by method
+    @GetMapping("/{id}")
+    Organization getOne(@PathVariable String id) {
+        Organization org = store.get(id);
+        if (org == null) {
+            // single id -> 404
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "organization not found");
+        }
+        return org;
+    }
+
+    @PatchMapping("/{id}") // partial update -> 200
+    Organization update(@PathVariable String id, @RequestBody Map<String, Object> body) {
+        return store.update(id, body);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT) // 204, nothing to send back
+    void delete(@PathVariable String id) {
+        store.delete(id);
+    }
+
+    // custom action: verb at the end -> POST, returns 200 (created nothing)
+    @PostMapping("/{id}/archive")
+    Organization archive(@PathVariable String id) {
+        return store.archive(id); // flips status + cascades: projects, tasks, emails...
+    }
+}
+```
+
 ## Golden Rules
 
 ### Extract nouns from the UI first
@@ -615,7 +996,7 @@ Before writing a line of business logic, look at the wireframes (Figma) or talk 
 
 ### Design the interface before coding
 
-A REST API is _designed_, not programmed-first. Lay out routes, payloads, and responses in a tool like **Insomnia** or **Postman** before touching Go, Python, or any framework. The whole point is a delightful, intuitive, unambiguous interface, so the consumer never has to read your source code or guess your behavior by trial and error.
+A REST API is _designed_, not programmed-first. Lay out routes, payloads, and responses in a tool like **Insomnia** or **Postman** before touching Go, Python, Node, Spring, or any other framework. The whole point is a delightful, intuitive, unambiguous interface, so the consumer never has to read your source code or guess your behavior by trial and error.
 
 ### Provide sane defaults
 
@@ -686,7 +1067,7 @@ Don't return stack traces, SQL errors, file paths, or framework exception dumps 
 
 ______
 
-GoPython
+Go Python JavaScript TypeScript Java
 
 one error helper, used everywhere
 
@@ -733,6 +1114,102 @@ error_response(
         {"field": "age",   "issue": "must be >= 0"},
     ],
 )
+```
+
+```js
+function writeError(res, status, code, message, details = []) {
+  res.status(status).json({
+    error: {
+      code,
+      message,
+      details,
+      requestId: res.locals.requestId, // put there by the request-id middleware
+    },
+  }) // SAME shape for every error in the whole API
+}
+
+// usage
+writeError(res, 422, 'validation_failed', 'Some fields are invalid.', [
+  { field: 'email', issue: 'must be a valid email' },
+  { field: 'age', issue: 'must be >= 0' },
+])
+```
+
+```ts
+import type { Response } from 'express'
+
+interface FieldError {
+  field: string
+  issue: string
+}
+
+// Exporting the envelope type is the quiet win here: the client imports
+// the same declaration, so `switch (err.error.code)` is checked against
+// the codes the server can actually send, on both sides of the wire.
+export interface ErrorEnvelope {
+  error: {
+    code: string
+    message: string
+    details: FieldError[]
+    requestId: string
+  }
+}
+
+export function writeError(
+  res: Response,
+  status: number,
+  code: string,
+  message: string,
+  details: FieldError[] = [],
+): void {
+  const body: ErrorEnvelope = {
+    error: { code, message, details, requestId: res.locals.requestId },
+  }
+  res.status(status).json(body) // SAME shape for every error in the whole API
+}
+
+// usage
+writeError(res, 422, 'validation_failed', 'Some fields are invalid.', [
+  { field: 'email', issue: 'must be a valid email' },
+  { field: 'age', issue: 'must be >= 0' },
+])
+```
+
+```java
+// Named ApiFieldError so it does not collide with Spring's own FieldError.
+public record ApiFieldError(String field, String issue) {}
+
+public record ErrorEnvelope(String code, String message,
+                            List<ApiFieldError> details, String requestId) {}
+
+@RestControllerAdvice
+class ApiErrors {
+
+    static ResponseEntity<Map<String, ErrorEnvelope>> writeError(
+            HttpStatus status, String code, String message, List<ApiFieldError> details) {
+        var envelope = new ErrorEnvelope(code, message, details, MDC.get("requestId"));
+        // SAME shape for every error in the whole API
+        return ResponseEntity.status(status).body(Map.of("error", envelope));
+    }
+
+    // The framework's OWN validation failures get funnelled through the same
+    // helper, so a bean-validation error and a hand-written one are
+    // indistinguishable to the client. That is what "consistent" has to mean.
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    ResponseEntity<?> onInvalid(MethodArgumentNotValidException e) {
+        List<ApiFieldError> details = e.getBindingResult().getFieldErrors().stream()
+            .map(f -> new ApiFieldError(f.getField(), f.getDefaultMessage()))
+            .toList();
+        return writeError(HttpStatus.UNPROCESSABLE_ENTITY,
+            "validation_failed", "Some fields are invalid.", details);
+    }
+}
+
+// usage
+writeError(HttpStatus.UNPROCESSABLE_ENTITY,
+    "validation_failed", "Some fields are invalid.",
+    List.of(new ApiFieldError("email", "must be a valid email"),
+            new ApiFieldError("age", "must be >= 0")));
 ```
 
 <Callout type="info" title="There's a standard for this too">
@@ -1322,4 +1799,4 @@ One resource, three layers, a method-aware router, and an in-memory store behind
 The Backend Lens / Field Manual v2, Chapter 11.\
 Further reading: [MDN / REST](https://developer.mozilla.org/en-US/docs/Glossary/REST) / [MDN / Web APIs](https://developer.mozilla.org/en-US/docs/Web/API) / Roy Fielding's 2000 dissertation on REST.
 
-Backend from First Principles / Chapter 07 / REST. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 07 / REST. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+ (Spring Boot). The complete worked program at the end is Go only.

--- a/src/content/chapters/08-databases.mdx
+++ b/src/content/chapters/08-databases.mdx
@@ -397,7 +397,7 @@ The vulnerability appears when you build queries by **concatenating strings** wi
 
 ______
 
-SQLGoPython
+SQL Go Python JavaScript TypeScript Java
 
 GET /v1/users/:id, same query, parameter-safe in each layer
 
@@ -428,6 +428,58 @@ cur.execute(
     """,
     (user_id,),  # the driver escapes it; injection is impossible
 )
+```
+
+```js
+// node-postgres: the values live in the ARRAY, never in the string.
+const { rows } = await db.query(
+  `SELECT u.*, to_jsonb(up.*) AS profile
+   FROM users u
+   LEFT JOIN user_profiles up ON u.id = up.user_id
+   WHERE u.id = $1`,
+  [userId], // userId is treated strictly as data, never SQL
+)
+
+// The JavaScript-specific trap: a template literal looks almost identical
+// and IS the injection. These two lines differ by four characters:
+//   WHERE u.id = $1`, [userId]   <- safe, the driver binds it
+//   WHERE u.id = ${userId}`      <- concatenation; you just lost the table
+```
+
+```ts
+import type { Pool } from 'pg'
+
+// The generic types the ROW, so `user.profile` is checked at compile time.
+// Worth being clear about what that does and does not buy you: it checks
+// the shape you claim to get back, not the SQL. The parameter slot is
+// still the only thing standing between you and injection.
+const { rows } = await db.query<UserWithProfile>(
+  `SELECT u.*, to_jsonb(up.*) AS profile
+   FROM users u
+   LEFT JOIN user_profiles up ON u.id = up.user_id
+   WHERE u.id = $1`,
+  [userId], // sent separately; the driver never interpolates it
+)
+const user: UserWithProfile | undefined = rows[0]
+```
+
+```java
+// Spring's JdbcClient: ? is the parameter slot, param() supplies the value.
+Optional<UserWithProfile> user = db.sql("""
+        SELECT u.*, to_jsonb(up.*) AS profile
+        FROM users u
+        LEFT JOIN user_profiles up ON u.id = up.user_id
+        WHERE u.id = ?
+        """)
+    .param(userId) // bound as data; the driver never interpolates it
+    .query(UserWithProfile.class)
+    .optional();
+
+// JPA/Hibernate is the same rule in a different spelling, a named
+// parameter instead of a positional one:
+//   em.createQuery("SELECT u FROM User u WHERE u.id = :id")
+//     .setParameter("id", userId)
+// and the same cardinal sin: never "... WHERE u.id = " + userId.
 ```
 
 ### Insert & update
@@ -579,7 +631,7 @@ Move INR 500 from account A to account B. That's two writes: subtract from A, ad
 
 ______
 
-SQLGoPython
+SQL Go Python JavaScript TypeScript Java
 
 both writes commit together, or neither does
 
@@ -615,6 +667,77 @@ try:
     # reaching here means both writes committed atomically
 finally:
     pool.putconn(conn)
+```
+
+```js
+// A transaction lives on ONE connection. `pool.query` hands out whichever
+// connection is free, so a BEGIN sent that way can easily land on a
+// different connection than the UPDATE that follows it. Check one out.
+const tx = await pool.connect()
+try {
+  await tx.query('BEGIN') // start the transaction
+  await tx.query('UPDATE accounts SET balance = balance - 500 WHERE id = $1', [a]) // debit A
+  await tx.query('UPDATE accounts SET balance = balance + 500 WHERE id = $1', [b]) // credit B
+  await tx.query('COMMIT') // only here do both writes become permanent
+} catch (err) {
+  await tx.query('ROLLBACK') // anything failed -> both reverted
+  throw err
+} finally {
+  tx.release() // the checked-out connection MUST go back to the pool
+}
+```
+
+```ts
+import type { Pool, PoolClient } from 'pg'
+
+// The release() in the finally block is the part that must never be
+// forgotten, and "must never be forgotten" is the signal to write it once.
+// The callback shape also makes the transaction's extent obvious: it is
+// exactly the body of `fn`, no more and no less.
+async function withTransaction<T>(pool: Pool, fn: (tx: PoolClient) => Promise<T>): Promise<T> {
+  const tx = await pool.connect()
+  try {
+    await tx.query('BEGIN')
+    const result = await fn(tx)
+    await tx.query('COMMIT') // only here do the writes become permanent
+    return result
+  } catch (err) {
+    await tx.query('ROLLBACK') // anything failed -> everything reverted
+    throw err
+  } finally {
+    tx.release()
+  }
+}
+
+await withTransaction(pool, async (tx) => {
+  await tx.query('UPDATE accounts SET balance = balance - 500 WHERE id = $1', [a]) // debit A
+  await tx.query('UPDATE accounts SET balance = balance + 500 WHERE id = $1', [b]) // credit B
+})
+```
+
+```java
+// @Transactional IS begin/commit/rollback: Spring opens a transaction
+// before the method body runs, commits when it returns normally, and rolls
+// back if it throws. Both writes are atomic without a BEGIN in sight.
+@Transactional
+public void transfer(long a, long b) {
+    db.sql("UPDATE accounts SET balance = balance - 500 WHERE id = ?")
+      .param(a)
+      .update(); // debit A
+
+    db.sql("UPDATE accounts SET balance = balance + 500 WHERE id = ?")
+      .param(b)
+      .update(); // credit B
+
+    // returning normally commits; any RuntimeException rolls BOTH back
+}
+
+// Two things that surprise people, both worth knowing before you trust it:
+//  1. It works through a proxy, so calling transfer() from another method
+//     of the SAME class skips the proxy and you get two auto-commits.
+//  2. By default it rolls back on RuntimeException but NOT on a checked
+//     exception, which commits the half-done work. Say so explicitly:
+//     @Transactional(rollbackFor = Exception.class)
 ```
 
 ### ACID: the four guarantees
@@ -747,4 +870,4 @@ The Backend Lens / Field Manual v2, Chapter 12.\
 Schema, constraints, trigger, joins and index usage in this chapter were executed and verified against PostgreSQL 16.\
 Companion chapter: 11 / Complete REST API Design (same project-management example).
 
-Backend from First Principles / Chapter 08 / Postgres. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 08 / Postgres. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+ (Spring Boot).

--- a/src/content/chapters/09-caching.mdx
+++ b/src/content/chapters/09-caching.mdx
@@ -563,9 +563,13 @@ That is the reason we want to separate this out, for two reasons. First, to make
 
 ## Code Examples
 
-Below are practical implementations of caching patterns using Go and Python, the two languages referenced in this course.
+Below are practical implementations of the patterns from this chapter, each one written out in Go, Python, JavaScript, TypeScript and Java. Pick a tab. What is worth noticing as you switch between them is how little changes: the Redis commands are identical in all five, because the cache has no idea what language is talking to it. The differences are all in how each language spells "wrap this", "this may be missing", and "run this before the handler".
 
-### 10.1: Lazy (Cache-Aside) Caching in Go
+### 10.1: Lazy (Cache-Aside) Caching
+
+Go Python JavaScript TypeScript Java
+
+check the cache, fall back to the database, write what you found
 
 ```go title="cache_aside.go / Go + github.com/redis/go-redis/v9"
 package main
@@ -635,7 +639,216 @@ func UpdateProduct(ctx context.Context, product *Product) error {
 }
 ```
 
-### 10.2: Rate Limiting Middleware in Go
+```python title="cache_aside.py / Python + redis-py"
+import json
+from dataclasses import dataclass, asdict
+
+import redis
+
+r = redis.Redis(host="localhost", port=6379, decode_responses=True)
+
+TTL_SECONDS = 3600  # 1 hour
+
+
+@dataclass
+class Product:
+    id: str
+    name: str
+    price: float
+
+
+def get_product(product_id: str) -> Product:
+    """Cache-Aside (Lazy) caching.
+
+    1. Check Redis first
+    2. On miss, fetch from DB, store in cache, return
+    """
+    cache_key = f"product:{product_id}"
+
+    # Step 1: Try cache first (Cache Hit path)
+    cached = r.get(cache_key)
+    if cached:
+        print("[CACHE HIT]", product_id)
+        return Product(**json.loads(cached))
+
+    # Step 2: Cache Miss, fetch from database (expensive operation)
+    print("[CACHE MISS] fetching from DB...", product_id)
+    product = fetch_from_database(product_id)
+
+    # Step 3: Store in cache with a 1-hour TTL
+    r.setex(cache_key, TTL_SECONDS, json.dumps(asdict(product)))
+
+    return product
+
+
+def update_product(product: Product) -> None:
+    """Write-Through: update DB and cache simultaneously."""
+    # Step 1: Update in database
+    update_in_database(product)
+
+    # Step 2: Write-through, update cache immediately
+    r.setex(f"product:{product.id}", TTL_SECONDS, json.dumps(asdict(product)))
+
+    print("[WRITE-THROUGH] DB + cache updated for", product.id)
+```
+
+```js title="cacheAside.js / Node 20+ + node-redis"
+import { createClient } from 'redis'
+
+const redis = createClient({ url: 'redis://localhost:6379' })
+await redis.connect()
+
+const TTL_SECONDS = 3600 // 1 hour
+
+// getProduct implements Cache-Aside (Lazy) caching.
+// 1. Check Redis first
+// 2. On miss, fetch from DB, store in cache, return
+export async function getProduct(productId) {
+  const cacheKey = `product:${productId}`
+
+  // Step 1: Try cache first (Cache Hit path)
+  const cached = await redis.get(cacheKey)
+  if (cached !== null) {
+    console.log('[CACHE HIT]', productId)
+    return JSON.parse(cached)
+  }
+
+  // Step 2: Cache Miss, fetch from database (expensive operation)
+  console.log('[CACHE MISS] fetching from DB...', productId)
+  const product = await fetchFromDatabase(productId)
+
+  // Step 3: Store in cache with a 1-hour TTL
+  await redis.set(cacheKey, JSON.stringify(product), { EX: TTL_SECONDS })
+
+  return product
+}
+
+// Write-Through: update DB and cache simultaneously
+export async function updateProduct(product) {
+  // Step 1: Update in database
+  await updateInDatabase(product)
+
+  // Step 2: Write-through, update cache immediately
+  await redis.set(`product:${product.id}`, JSON.stringify(product), { EX: TTL_SECONDS })
+
+  console.log('[WRITE-THROUGH] DB + cache updated for', product.id)
+}
+```
+
+```ts title="cacheAside.ts / TypeScript 5+ + node-redis"
+import { createClient } from 'redis'
+
+const redis = createClient({ url: 'redis://localhost:6379' })
+await redis.connect()
+
+interface Product {
+  id: string
+  name: string
+  price: number
+}
+
+const TTL_SECONDS = 3600 // 1 hour
+
+// getProduct implements Cache-Aside (Lazy) caching.
+// 1. Check Redis first
+// 2. On miss, fetch from DB, store in cache, return
+export async function getProduct(productId: string): Promise<Product> {
+  const cacheKey = `product:${productId}`
+
+  // Step 1: Try cache first (Cache Hit path)
+  const cached = await redis.get(cacheKey)
+  if (cached !== null) {
+    console.log('[CACHE HIT]', productId)
+    // Worth pausing on: this cast is a PROMISE, not a check. Redis hands
+    // back a string, and a value written by last month's deploy still has
+    // last month's shape. That is why cache keys get a version in them
+    // ("product:v2:...") the moment the stored shape changes.
+    return JSON.parse(cached) as Product
+  }
+
+  // Step 2: Cache Miss, fetch from database (expensive operation)
+  console.log('[CACHE MISS] fetching from DB...', productId)
+  const product = await fetchFromDatabase(productId)
+
+  // Step 3: Store in cache with a 1-hour TTL
+  await redis.set(cacheKey, JSON.stringify(product), { EX: TTL_SECONDS })
+
+  return product
+}
+
+// Write-Through: update DB and cache simultaneously
+export async function updateProduct(product: Product): Promise<void> {
+  // Step 1: Update in database
+  await updateInDatabase(product)
+
+  // Step 2: Write-through, update cache immediately
+  await redis.set(`product:${product.id}`, JSON.stringify(product), { EX: TTL_SECONDS })
+
+  console.log('[WRITE-THROUGH] DB + cache updated for', product.id)
+}
+```
+
+```java title="ProductService.java / Java 17+ + Spring Data Redis"
+@Service
+public class ProductService {
+    private static final Duration TTL = Duration.ofHours(1);
+
+    private final StringRedisTemplate redis;
+    private final ObjectMapper json;
+    private final ProductRepository db;
+
+    ProductService(StringRedisTemplate redis, ObjectMapper json, ProductRepository db) {
+        this.redis = redis;
+        this.json = json;
+        this.db = db;
+    }
+
+    // getProduct implements Cache-Aside (Lazy) caching.
+    // 1. Check Redis first
+    // 2. On miss, fetch from DB, store in cache, return
+    public Product getProduct(String productId) throws JsonProcessingException {
+        String cacheKey = "product:" + productId;
+
+        // Step 1: Try cache first (Cache Hit path)
+        String cached = redis.opsForValue().get(cacheKey);
+        if (cached != null) {
+            log.info("[CACHE HIT] {}", productId);
+            return json.readValue(cached, Product.class);
+        }
+
+        // Step 2: Cache Miss, fetch from database (expensive operation)
+        log.info("[CACHE MISS] fetching from DB... {}", productId);
+        Product product = db.findById(productId).orElseThrow();
+
+        // Step 3: Store in cache with a 1-hour TTL
+        redis.opsForValue().set(cacheKey, json.writeValueAsString(product), TTL);
+
+        return product;
+    }
+
+    // Write-Through: update DB and cache simultaneously
+    public void updateProduct(Product product) throws JsonProcessingException {
+        // Step 1: Update in database
+        db.save(product);
+
+        // Step 2: Write-through, update cache immediately
+        redis.opsForValue().set("product:" + product.id(),
+            json.writeValueAsString(product), TTL);
+
+        log.info("[WRITE-THROUGH] DB + cache updated for {}", product.id());
+    }
+}
+
+// Spring will also do all of the above declaratively, and the annotation
+// names map straight onto the pattern names: @Cacheable IS cache-aside,
+// @CachePut IS write-through. Section 10.3 shows that version.
+```
+
+### 10.2: Rate Limiting Middleware
+
+Go Python JavaScript TypeScript Java
+
+one atomic INCR per request, per IP, per minute window
 
 ```go title="rate_limiter.go / Go + go-redis"
 package middleware
@@ -693,7 +906,233 @@ func RateLimitMiddleware(rdb *redis.Client) http.HandlerFunc {
 }
 ```
 
-### 10.3: Caching Decorator in Python
+```python title="rate_limiter.py / Python + redis-py + FastAPI"
+import time
+
+import redis
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+r = redis.Redis(host="localhost", port=6379, decode_responses=True)
+
+MAX_REQUESTS = 50
+WINDOW_SECONDS = 60
+
+
+@app.middleware("http")
+async def rate_limit_middleware(request: Request, call_next):
+    # Extract client IP from X-Forwarded-For header
+    # (set by reverse proxy like Nginx or Caddy)
+    client_ip = request.headers.get("X-Forwarded-For") or request.client.host
+
+    # Redis key: per IP, per minute window
+    key = f"rate_limit:{client_ip}:{int(time.time()) // WINDOW_SECONDS}"
+
+    # INCR is atomic, no race condition even with concurrent requests
+    count = r.incr(key)
+
+    # Set TTL on first request of this window (key is new)
+    if count == 1:
+        r.expire(key, WINDOW_SECONDS)
+
+    # Check if limit exceeded
+    if count > MAX_REQUESTS:
+        return JSONResponse(
+            {"error": "429 Too Many Requests"},
+            status_code=429,
+            headers={"Retry-After": str(WINDOW_SECONDS)},
+        )  # short-circuit: the route handler never runs
+
+    # Proceed to actual handler
+    response = await call_next(request)
+    response.headers["X-RateLimit-Remaining"] = str(MAX_REQUESTS - count)
+    return response
+```
+
+```js title="rateLimiter.js / Node 20+ + node-redis + Express"
+const MAX_REQUESTS = 50
+const WINDOW_SECONDS = 60
+
+export async function rateLimitMiddleware(req, res, next) {
+  // Extract client IP from X-Forwarded-For header
+  // (set by reverse proxy like Nginx or Caddy)
+  const clientIp = req.get('X-Forwarded-For') ?? req.socket.remoteAddress
+
+  // Redis key: per IP, per minute window
+  const window = Math.floor(Date.now() / 1000 / WINDOW_SECONDS)
+  const key = `rate_limit:${clientIp}:${window}`
+
+  // INCR is atomic, no race condition even with concurrent requests
+  const count = await redis.incr(key)
+
+  // Set TTL on first request of this window (key is new)
+  if (count === 1) {
+    await redis.expire(key, WINDOW_SECONDS)
+  }
+
+  // Check if limit exceeded
+  if (count > MAX_REQUESTS) {
+    res.set('Retry-After', String(WINDOW_SECONDS))
+    return res.status(429).send('429 Too Many Requests') // never calls next()
+  }
+
+  // Proceed to actual handler
+  res.set('X-RateLimit-Remaining', String(MAX_REQUESTS - count))
+  next()
+}
+```
+
+```ts title="rateLimiter.ts / TypeScript 5+ + node-redis + Express"
+import type { NextFunction, Request, Response } from 'express'
+
+const MAX_REQUESTS = 50
+const WINDOW_SECONDS = 60
+
+export async function rateLimitMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  // Extract client IP from X-Forwarded-For header
+  // (set by reverse proxy like Nginx or Caddy)
+  const clientIp = req.get('X-Forwarded-For') ?? req.socket.remoteAddress ?? 'unknown'
+
+  // Redis key: per IP, per minute window
+  const window = Math.floor(Date.now() / 1000 / WINDOW_SECONDS)
+  const key = `rate_limit:${clientIp}:${window}`
+
+  // Both commands in one round trip. That is not just a speed trick: with
+  // a bare INCR followed by a separate EXPIRE, a crash in between leaves a
+  // key with NO TTL, and that IP stays rate-limited forever.
+  const [count] = (await redis
+    .multi()
+    .incr(key) // atomic; no race even with concurrent requests
+    .expire(key, WINDOW_SECONDS)
+    .exec()) as [number, boolean]
+
+  // Check if limit exceeded
+  if (count > MAX_REQUESTS) {
+    res.set('Retry-After', String(WINDOW_SECONDS))
+    res.status(429).send('429 Too Many Requests') // never calls next()
+    return
+  }
+
+  // Proceed to actual handler
+  res.set('X-RateLimit-Remaining', String(MAX_REQUESTS - count))
+  next()
+}
+```
+
+```java title="RateLimitFilter.java / Java 17+ + Spring Data Redis"
+@Component
+public class RateLimitFilter extends OncePerRequestFilter {
+    private static final int MAX_REQUESTS = 50;
+    private static final Duration WINDOW = Duration.ofMinutes(1);
+
+    private final StringRedisTemplate redis;
+
+    RateLimitFilter(StringRedisTemplate redis) {
+        this.redis = redis;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res,
+                                    FilterChain chain)
+            throws ServletException, IOException {
+        // Extract client IP from X-Forwarded-For header
+        // (set by reverse proxy like Nginx or Caddy)
+        String clientIp = req.getHeader("X-Forwarded-For");
+        if (clientIp == null) {
+            clientIp = req.getRemoteAddr();
+        }
+
+        // Redis key: per IP, per minute window
+        String key = "rate_limit:%s:%d".formatted(
+            clientIp, Instant.now().getEpochSecond() / WINDOW.toSeconds());
+
+        // INCR is atomic, no race condition even with concurrent requests
+        Long count = redis.opsForValue().increment(key);
+        if (count == null) {
+            res.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        // Set TTL on first request of this window (key is new)
+        if (count == 1L) {
+            redis.expire(key, WINDOW);
+        }
+
+        // Check if limit exceeded
+        if (count > MAX_REQUESTS) {
+            res.setHeader("Retry-After", String.valueOf(WINDOW.toSeconds()));
+            res.sendError(429, "429 Too Many Requests");
+            return; // short-circuit: the controller never runs
+        }
+
+        // Proceed to actual handler
+        res.setHeader("X-RateLimit-Remaining", String.valueOf(MAX_REQUESTS - count));
+        chain.doFilter(req, res);
+    }
+}
+```
+
+### 10.3: Wrapping a Function in a Cache
+
+Every language has some way to say "run this function, but check the cache first", and the name changes with the language: a decorator in Python, a higher-order function in Go and JavaScript, an annotation and a proxy in Java. The three steps inside are always the same ones from section 10.1.
+
+Go Python JavaScript TypeScript Java
+
+the same cache-aside logic, hoisted out of the function it wraps
+
+```go title="cached.go / Go + go-redis + generics"
+// Go has no decorator syntax, so the same idea is a higher-order
+// function: hand it a fetch func, get a cache-aside version back.
+// The generic parameter is what keeps it reusable, the wrapper never
+// needs to know what it is caching.
+func Cached[T any](rdb *redis.Client, key string, ttl time.Duration,
+    fetch func(context.Context) (T, error)) func(context.Context) (T, error) {
+
+    return func(ctx context.Context) (T, error) {
+        var zero T
+
+        // Step 1: Check cache (Cache Hit)
+        if cached, err := rdb.Get(ctx, key).Result(); err == nil {
+            var out T
+            if json.Unmarshal([]byte(cached), &out) == nil {
+                fmt.Println("[CACHE HIT]", key)
+                return out, nil
+            }
+            // Unmarshal failed: a stale shape from an older deploy.
+            // Treat it as a miss rather than failing the request.
+        }
+
+        // Step 2: Cache Miss, execute the actual function
+        fmt.Println("[CACHE MISS] fetching", key)
+        result, err := fetch(ctx)
+        if err != nil {
+            return zero, err
+        }
+
+        // Step 3: Store in Redis with TTL
+        if data, mErr := json.Marshal(result); mErr == nil {
+            rdb.Set(ctx, key, data, ttl)
+        }
+
+        return result, nil
+    }
+}
+
+// Usage: wrap any expensive call. Only runs the DB query on a miss.
+getProduct := Cached(rdb, "product:42", time.Hour,
+    func(ctx context.Context) (Product, error) {
+        return fetchFromDB(ctx, "42")
+    })
+
+// TTL-based API response caching (e.g. weather) is the SAME wrapper with
+// a different key: weather doesn't change every minute, and the upstream
+// API is rate limited and charges per call.
+getWeather := Cached(rdb, "weather:pune", time.Hour, callWeatherAPI)
+```
 
 ```python title="cache.py / Python + redis-py + FastAPI"
 import json
@@ -761,7 +1200,208 @@ async def get_weather(city: str):
     return {"source": "api", "data": weather_data}
 ```
 
-### 10.4: Session Management with Redis (Python)
+```js title="cacheResult.js / Node 20+ + node-redis + Express"
+// JavaScript's decorators aren't in plain Node yet, so the wrapper is a
+// higher-order function: pass a function in, get a cached one back.
+function cacheResult(fn, ttl = 3600) {
+  return async (...args) => {
+    // Build cache key from function name + args
+    const cacheKey = `${fn.name}:${JSON.stringify(args)}`
+
+    // Step 1: Check cache (Cache Hit)
+    const cached = await redis.get(cacheKey)
+    if (cached !== null) {
+      console.log(`[CACHE HIT] ${cacheKey}`)
+      return JSON.parse(cached)
+    }
+
+    // Step 2: Cache Miss, execute the actual function
+    console.log(`[CACHE MISS] calling ${fn.name}...`)
+    const result = await fn(...args)
+
+    // Step 3: Store in Redis with TTL
+    await redis.set(cacheKey, JSON.stringify(result), { EX: ttl })
+
+    return result
+  }
+}
+
+// Usage: wrap the expensive call, not the route. The handler never
+// learns that a cache exists, which is the whole point.
+const getProduct = cacheResult(fetchFromDb, 3600) // cache for 1 hour
+
+app.get('/products/:id', async (req, res) => {
+  res.json(await getProduct(req.params.id))
+})
+
+// TTL-based API Response Caching (e.g. weather)
+app.get('/weather/:city', async (req, res) => {
+  const cacheKey = `weather:${req.params.city}`
+
+  // Check cache (TTL = 1 hour, weather doesn't change every minute)
+  const cached = await redis.get(cacheKey)
+  if (cached !== null) {
+    return res.json({ source: 'cache', data: JSON.parse(cached) })
+  }
+
+  // Miss: call external weather API (costs money / rate limited)
+  const weatherData = await callWeatherApi(req.params.city)
+
+  // Store for 1 hour
+  await redis.set(cacheKey, JSON.stringify(weatherData), { EX: 3600 })
+
+  res.json({ source: 'api', data: weatherData })
+})
+```
+
+```ts title="cacheResult.ts / TypeScript 5+ + node-redis"
+// The two generics are the point of the TypeScript version: the wrapper
+// hands back a function with the SAME signature it was given. Adding a
+// cache to a call site therefore changes nothing about how it is called,
+// and if it did, the build would break rather than production.
+function cacheResult<A extends unknown[], R>(
+  fn: (...args: A) => Promise<R>,
+  ttl = 3600,
+): (...args: A) => Promise<R> {
+  return async (...args: A): Promise<R> => {
+    // Build cache key from function name + args
+    const cacheKey = `${fn.name}:${JSON.stringify(args)}`
+
+    // Step 1: Check cache (Cache Hit)
+    const cached = await redis.get(cacheKey)
+    if (cached !== null) {
+      console.log(`[CACHE HIT] ${cacheKey}`)
+      return JSON.parse(cached) as R
+    }
+
+    // Step 2: Cache Miss, execute the actual function
+    console.log(`[CACHE MISS] calling ${fn.name}...`)
+    const result = await fn(...args)
+
+    // Step 3: Store in Redis with TTL
+    await redis.set(cacheKey, JSON.stringify(result), { EX: ttl })
+
+    return result
+  }
+}
+
+// Usage: still (id: string) => Promise<Product>, cache or no cache.
+const getProduct: (id: string) => Promise<Product> = cacheResult(fetchFromDb, 3600)
+
+// TTL-based API response caching (e.g. weather), same wrapper, different
+// upstream: the external API costs money and is rate limited.
+const getWeather: (city: string) => Promise<WeatherData> = cacheResult(callWeatherApi, 3600)
+```
+
+```java title="ProductService.java / Java 17+ + Spring Cache + Redis"
+// Java's answer to Python's decorator is an annotation plus a proxy, and
+// Spring ships it: @Cacheable IS cache-aside. All three steps still
+// happen, they just happen in the proxy instead of in your method body.
+@Configuration
+@EnableCaching
+class CacheConfig {
+    @Bean
+    RedisCacheManager cacheManager(RedisConnectionFactory cf) {
+        return RedisCacheManager.builder(cf)
+            .cacheDefaults(RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofHours(1))) // the TTL, as in SETEX
+            .build();
+    }
+}
+
+@Service
+public class ProductService {
+
+    // Step 1 check Redis, step 2 run this body only on a miss, step 3
+    // store what it returned under "product::<id>". You write none of it.
+    @Cacheable(cacheNames = "product", key = "#productId")
+    public Product getProduct(String productId) {
+        // Expensive DB query, only runs on cache miss
+        return db.findById(productId).orElseThrow();
+    }
+
+    // TTL-based API response caching (e.g. weather). Same annotation, a
+    // different upstream: the external API is rate limited and paid-per-call.
+    @Cacheable(cacheNames = "weather", key = "#city")
+    public WeatherData getWeather(String city) {
+        return weatherApi.fetch(city);
+    }
+
+    // Write-through, the cache is updated instead of skipped, so the next
+    // read gets the new value rather than a stale one.
+    @CachePut(cacheNames = "product", key = "#product.id()")
+    public Product updateProduct(Product product) {
+        return db.save(product);
+    }
+}
+
+// The catch worth knowing: this runs through a proxy, so calling
+// getProduct() from another method of THIS class bypasses the cache
+// entirely and hits the database on every single call.
+```
+
+### 10.4: Session Management with Redis
+
+Go Python JavaScript TypeScript Java
+
+create on login, validate on every request, delete on logout
+
+```go title="session.go / Go + go-redis"
+const sessionTTL = 24 * time.Hour
+
+// CreateSession stores a session after successful login.
+func CreateSession(ctx context.Context, userID string,
+    userData map[string]any) (string, error) {
+
+    sessionID := uuid.NewString()
+    sessionKey := "session:" + sessionID
+
+    payload := map[string]any{"user_id": userID}
+    for k, v := range userData {
+        payload[k] = v
+    }
+
+    data, err := json.Marshal(payload)
+    if err != nil {
+        return "", err
+    }
+
+    // Store session data with 24-hour TTL.
+    // TTL ensures sessions auto-expire, no manual cleanup needed.
+    if err := rdb.Set(ctx, sessionKey, data, sessionTTL).Err(); err != nil {
+        return "", err
+    }
+
+    return sessionID, nil // returned to client as cookie/token
+}
+
+// GetSession validates the session on every authenticated API request.
+// Redis O(1) lookup, microseconds, not milliseconds.
+func GetSession(ctx context.Context, sessionID string) (map[string]any, error) {
+    sessionKey := "session:" + sessionID
+
+    data, err := rdb.Get(ctx, sessionKey).Result()
+    if errors.Is(err, redis.Nil) {
+        return nil, nil // session expired or invalid
+    } else if err != nil {
+        return nil, err
+    }
+
+    // Optionally: refresh TTL on activity (sliding window)
+    rdb.Expire(ctx, sessionKey, sessionTTL)
+
+    var session map[string]any
+    if err := json.Unmarshal([]byte(data), &session); err != nil {
+        return nil, err
+    }
+    return session, nil
+}
+
+// DeleteSession logs the user out, removing the session immediately.
+func DeleteSession(ctx context.Context, sessionID string) error {
+    return rdb.Del(ctx, "session:"+sessionID).Err()
+}
+```
 
 ```python title="session.py / Python + redis-py"
 import uuid
@@ -807,6 +1447,159 @@ def delete_session(session_id: str):
     r.delete(f"session:{session_id}")
 ```
 
+```js title="session.js / Node 20+ + node-redis"
+import { randomUUID } from 'node:crypto'
+
+const SESSION_TTL = 60 * 60 * 24 // 24 hours, in seconds
+
+// Create a session after successful login. Store in Redis.
+export async function createSession(userId, userData) {
+  const sessionId = randomUUID()
+
+  // Store session data with 24-hour TTL.
+  // TTL ensures sessions auto-expire, no manual cleanup needed.
+  await redis.set(
+    `session:${sessionId}`,
+    JSON.stringify({ user_id: userId, ...userData }),
+    { EX: SESSION_TTL },
+  )
+
+  return sessionId // returned to client as cookie/token
+}
+
+// Validate session on every authenticated API request.
+// Redis O(1) lookup, microseconds, not milliseconds.
+export async function getSession(sessionId) {
+  const sessionKey = `session:${sessionId}`
+  const data = await redis.get(sessionKey)
+
+  if (data === null) {
+    return null // session expired or invalid
+  }
+
+  // Optionally: refresh TTL on activity (sliding window)
+  await redis.expire(sessionKey, SESSION_TTL)
+
+  return JSON.parse(data)
+}
+
+// Logout, delete session from Redis immediately.
+export async function deleteSession(sessionId) {
+  await redis.del(`session:${sessionId}`)
+}
+```
+
+```ts title="session.ts / TypeScript 5+ + node-redis"
+import { randomUUID } from 'node:crypto'
+
+const SESSION_TTL = 60 * 60 * 24 // 24 hours, in seconds
+
+export interface Session {
+  user_id: string
+  email: string
+  role: string
+}
+
+// `Omit<Session, 'user_id'>` says the caller supplies everything EXCEPT
+// the id, which this function owns. A login handler cannot accidentally
+// pass a user_id from the request body.
+export async function createSession(
+  userId: string,
+  userData: Omit<Session, 'user_id'>,
+): Promise<string> {
+  const sessionId = randomUUID()
+  const session: Session = { user_id: userId, ...userData }
+
+  // Store session data with 24-hour TTL.
+  // TTL ensures sessions auto-expire, no manual cleanup needed.
+  await redis.set(`session:${sessionId}`, JSON.stringify(session), { EX: SESSION_TTL })
+
+  return sessionId // returned to client as cookie/token
+}
+
+// The `| null` in the return type is the part that earns its keep: every
+// caller is forced to handle "expired or invalid" before it can read
+// user_id, and that is exactly the check an auth middleware must not skip.
+export async function getSession(sessionId: string): Promise<Session | null> {
+  const sessionKey = `session:${sessionId}`
+  const data = await redis.get(sessionKey)
+
+  if (data === null) {
+    return null // session expired or invalid
+  }
+
+  // Optionally: refresh TTL on activity (sliding window)
+  await redis.expire(sessionKey, SESSION_TTL)
+
+  return JSON.parse(data) as Session
+}
+
+// Logout, delete session from Redis immediately.
+export async function deleteSession(sessionId: string): Promise<void> {
+  await redis.del(`session:${sessionId}`)
+}
+```
+
+```java title="SessionService.java / Java 17+ + Spring Data Redis"
+@Service
+public class SessionService {
+    private static final Duration SESSION_TTL = Duration.ofHours(24);
+
+    private final StringRedisTemplate redis;
+    private final ObjectMapper json;
+
+    SessionService(StringRedisTemplate redis, ObjectMapper json) {
+        this.redis = redis;
+        this.json = json;
+    }
+
+    /** Create a session after successful login. Store in Redis. */
+    public String createSession(String userId, Map<String, Object> userData)
+            throws JsonProcessingException {
+        String sessionId = UUID.randomUUID().toString();
+
+        Map<String, Object> payload = new HashMap<>(userData);
+        payload.put("user_id", userId);
+
+        // Store session data with 24-hour TTL.
+        // TTL ensures sessions auto-expire, no manual cleanup needed.
+        redis.opsForValue().set("session:" + sessionId,
+            json.writeValueAsString(payload), SESSION_TTL);
+
+        return sessionId; // returned to client as cookie/token
+    }
+
+    /**
+     * Validate session on every authenticated API request.
+     * Redis O(1) lookup, microseconds, not milliseconds.
+     */
+    public Optional<Map<String, Object>> getSession(String sessionId)
+            throws JsonProcessingException {
+        String sessionKey = "session:" + sessionId;
+        String data = redis.opsForValue().get(sessionKey);
+
+        if (data == null) {
+            return Optional.empty(); // session expired or invalid
+        }
+
+        // Optionally: refresh TTL on activity (sliding window)
+        redis.expire(sessionKey, SESSION_TTL);
+
+        return Optional.of(json.readValue(data, new TypeReference<Map<String, Object>>() {}));
+    }
+
+    /** Logout, delete session from Redis immediately. */
+    public void deleteSession(String sessionId) {
+        redis.delete("session:" + sessionId);
+    }
+}
+
+// Spring Session does the whole of the above for you: add
+// spring-session-data-redis and @EnableRedisHttpSession, and the ordinary
+// servlet HttpSession is backed by Redis with a TTL, with no session code
+// of your own at all. Worth writing it by hand once, then reaching for that.
+```
+
 ## Further Reading & Documentation
 
 #### Redis Official Docs
@@ -840,6 +1633,6 @@ def delete_session(session_id: str):
 </Callout>
 
 BACKEND ENGINEERING FIELD MANUAL / V2 / CHAPTER 12 / CACHING\
-Notes compiled from lecture transcript / Go + Python examples / MDN & Redis references inline
+Notes compiled from lecture transcript / Go, Python, JavaScript, TypeScript & Java examples / MDN & Redis references inline
 
-Backend from First Principles / Chapter 09 / Caching. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 09 / Caching. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+ (Spring Boot).

--- a/src/content/chapters/10-task-queues-and-background-jobs.mdx
+++ b/src/content/chapters/10-task-queues-and-background-jobs.mdx
@@ -2,7 +2,7 @@
 order: 10
 title: "Task Queues & Background Jobs"
 navTitle: "Task Queues & Background Jobs"
-summary: "Chapter 10 of Backend from First Principles: Task Queues & Background Jobs."
+summary: "Why slow work belongs outside the request, and how a task queue moves it there: brokers, producers and consumers, retries and backoff, visibility timeouts, idempotency, worker rate limiting, monitoring, and workflow engines. Worked implementations in Go, Python, JavaScript, TypeScript and Java."
 readingTime: "3-4 hours"
 keywords:
   - "task"
@@ -140,7 +140,6 @@ Because tasks cross process boundaries, all data must be serialized. JSON is the
   "token": "eyJhbGci...",
   "created_at": "2024-01-15T10:30:00Z"
 }
-JSON
 ```
 
 Python
@@ -151,9 +150,17 @@ JavaScript
 
 Deserializes to an `object`
 
+TypeScript
+
+Deserializes to an `object`, typed by the interface the producer and worker share
+
 Go
 
 Deserializes to a `struct` (via `json.Unmarshal`)
+
+Java
+
+Deserializes to a `record` or POJO (via Jackson's `readValue`)
 
 05
 
@@ -294,7 +301,7 @@ Amazon SQS is AWS's fully managed message queuing service. No servers to manage,
 
 SQS implements visibility timeout natively. When a worker calls `ReceiveMessage`, the message becomes invisible to all other consumers for the configured timeout (default 30s, max 12 hours). The worker must call `DeleteMessage` on success, or do nothing to let it become visible again for retry.
 
-```go
+```go title="sqs.go / Go + AWS SDK v2"
 // Go, SQS producer + consumer using AWS SDK v2
 package main
 
@@ -340,7 +347,6 @@ func PollQueue(ctx context.Context, client *sqs.Client, queueURL string) {
         }
     }
 }
-Go / AWS SDK v2
 ```
 
 <Callout type="info" title="Standard Queue + Idempotency">
@@ -476,72 +482,19 @@ Same reason as email, depends on Apple/Google external services. Rate-limited. N
 
 11
 
-## Code Examples: Go & Python
+## Code Examples
 
-### Python: Celery + Redis
+The libraries below are the de-facto choice in each ecosystem, and all five sit on Redis: [Celery](https://docs.celeryq.dev/) in Python, [Asynq](https://github.com/hibiken/asynq) in Go, [BullMQ](https://docs.bullmq.io/) in Node, and Spring Data Redis Streams in Java. They look different on the surface, and underneath they are doing the same three things: put a JSON payload in Redis, take it out in a worker process, acknowledge it when the work is done.
 
-[Celery](https://docs.celeryq.dev/) is the most popular Python task queue. Uses Redis (or RabbitMQ) as the broker.
+### The consumer: defining and handling the task
 
-```python
-# tasks.py, Define the task (consumer side)
-from celery import Celery
-import resend
+This is the code that runs in the **worker** process, not in your API. Note what every version does with errors, because it is the whole retry story: a payload that will never parse is a permanent failure and must not be retried, while a provider that timed out should be.
 
-# Connect Celery to Redis broker
-app = Celery('tasks', broker='redis://localhost:6379/0')
+Go Python JavaScript TypeScript Java
 
-# Decorate the function as a Celery task
-@app.task(bind=True, max_retries=5, default_retry_delay=60)
-def send_verification_email(self, user_id: str, email: str, token: str):
-    """
-    Called by the worker process.
-    self.retry() implements exponential backoff automatically.
-    """
-    try:
-        params = {
-            "from": "noreply@myapp.com",
-            "to": [email],
-            "subject": "Verify your email",
-            "html": build_email_template(token),
-        }
-        resend.Emails.send(params)
-    except Exception as exc:
-        # Exponential backoff: 60s, 120s, 240s, 480s, 960s
-        countdown = 60 * (2 ** self.request.retries)
-        raise self.retry(exc=exc, countdown=countdown)
-Python
-```
+the task payload and the function that processes it
 
-```python
-# signup.py, Producer side (inside your API handler)
-from fastapi import FastAPI
-from tasks import send_verification_email
-
-app = FastAPI()
-
-@app.post("/signup")
-async def signup(body: SignupRequest):
-    # 1. Validate, hash password, save user to DB
-    user = await create_user(body)
-    token = generate_verification_token(user.id)
-
-    # 2. Enqueue, returns instantly, does NOT wait for email
-    send_verification_email.delay(
-        user_id=user.id,
-        email=user.email,
-        token=token
-    )
-
-    # 3. Return 201 immediately
-    return {"message": "Account created. Check your email."}, 201
-Python / FastAPI
-```
-
-### Go: Asynq + Redis
-
-[Asynq](https://github.com/hibiken/asynq) is a simple, reliable distributed task queue library for Go, backed by Redis Streams.
-
-```go
+```go title="tasks/email.go + handlers/email_handler.go / Go + Asynq"
 // tasks/email.go, Task definitions (producer + payload)
 package tasks
 
@@ -570,21 +523,9 @@ func NewSendVerificationEmailTask(userID, email, token string) (*asynq.Task, err
     // asynq.MaxRetry, after 5 failures, moves to dead letter
     return asynq.NewTask(TypeSendVerificationEmail, payload, asynq.MaxRetry(5)), nil
 }
-Go
-```
 
-```go
 // handlers/email_handler.go, Consumer handler
 package handlers
-
-import (
-    "context"
-    "encoding/json"
-    "fmt"
-    "log/slog"
-    tasks "myapp/tasks"
-    "github.com/hibiken/asynq"
-)
 
 type EmailHandler struct {
     emailSvc EmailService // injected dependency
@@ -612,55 +553,457 @@ func (h *EmailHandler) HandleSendVerificationEmail(
     // 3. Returning nil -> ACK to queue (task done)
     return nil
 }
-Go
 ```
 
-```go
-// main.go, Wire producer and start worker server
-package main
+```python title="tasks.py / Python + Celery"
+# tasks.py, Define the task (consumer side)
+from celery import Celery
+import resend
 
-import (
-    "github.com/hibiken/asynq"
-    "myapp/handlers"
-    "myapp/tasks"
-)
+# Connect Celery to Redis broker
+app = Celery('tasks', broker='redis://localhost:6379/0')
 
-func main() {
-    redisOpt := asynq.RedisClientOpt{Addr: "localhost:6379"}
+# Decorate the function as a Celery task
+@app.task(bind=True, max_retries=5, default_retry_delay=60)
+def send_verification_email(self, user_id: str, email: str, token: str):
+    """
+    Called by the worker process.
+    self.retry() implements exponential backoff automatically.
+    """
+    try:
+        params = {
+            "from": "noreply@myapp.com",
+            "to": [email],
+            "subject": "Verify your email",
+            "html": build_email_template(token),
+        }
+        resend.Emails.send(params)
+    except Exception as exc:
+        # Exponential backoff: 60s, 120s, 240s, 480s, 960s
+        countdown = 60 * (2 ** self.request.retries)
+        raise self.retry(exc=exc, countdown=countdown)
+```
 
-    // -- PRODUCER -------------------------------------
-    client := asynq.NewClient(redisOpt)
-    defer client.Close()
+```js title="worker.js / Node 20+ + BullMQ"
+// worker.js, Consumer, BullMQ calls this for each job
+import { Worker } from 'bullmq'
+import { Resend } from 'resend'
 
-    task, _ := tasks.NewSendVerificationEmailTask(
-        "usr_01J2K", "alice@example.com", "eyJhbGci...",
-    )
-    // Enqueue, returns immediately
-    info, _ := client.Enqueue(task)
-    // info.ID, info.Queue, info.State can be used for monitoring
+const connection = { host: 'localhost', port: 6379 }
+const resend = new Resend(process.env.RESEND_API_KEY)
 
-    // -- CONSUMER (worker server) ---------------------
-    srv := asynq.NewServer(redisOpt, asynq.Config{
-        Concurrency: 10, // 10 concurrent workers
-        Queues: map[string]int{
-            "email":    6, // higher priority
-            "default":  3,
-            "low":      1,
-        },
+// The queue NAME is the contract between producer and consumer; both
+// sides must spell it the same way. That is BullMQ's version of Asynq's
+// task type constant.
+export const worker = new Worker(
+  'email',
+  async (job) => {
+    // 1. The payload is already a JS object; BullMQ serialized it for us
+    const { userId, email, token } = job.data
+
+    // 2. Execute: call email provider API
+    console.log('sending verification email', userId, email)
+    await resend.emails.send({
+      from: 'noreply@myapp.com',
+      to: [email],
+      subject: 'Verify your email',
+      html: buildEmailTemplate(token),
     })
 
-    mux := asynq.NewServeMux()
-    mux.HandleFunc(tasks.TypeSendVerificationEmail,
-        handlers.EmailHandler{}.HandleSendVerificationEmail)
+    // 3. Returning normally ACKs the job (task done). THROWING is what
+    //    triggers a retry, so never swallow an error in here: a caught
+    //    exception looks exactly like success to the queue.
+  },
+  { connection, concurrency: 10 },
+)
 
-    srv.Run(mux)
-}
-Go
+worker.on('failed', (job, err) => {
+  console.error(`job ${job?.id} failed (attempt ${job?.attemptsMade})`, err)
+})
 ```
 
-### Go: Recurring Task with Asynq Scheduler
+```ts title="worker.ts / TypeScript 5+ + BullMQ"
+import { Worker, UnrecoverableError, type Job } from 'bullmq'
 
-```go
+// One exported type, imported by BOTH the producer and this worker. It is
+// the cheapest fix for the single most common task-queue bug: a producer
+// that starts sending a renamed field while the worker still reads the
+// old one. Here that mismatch is a compile error, not a 3am page.
+export interface EmailJob {
+  userId: string
+  email: string
+  token: string
+}
+
+export const worker = new Worker<EmailJob>(
+  'email',
+  async (job: Job<EmailJob>) => {
+    const { userId, email, token } = job.data
+
+    if (typeof email !== 'string') {
+      // Non-retryable: no amount of retrying fixes a malformed payload.
+      // UnrecoverableError is BullMQ's asynq.SkipRetry.
+      throw new UnrecoverableError('malformed payload: email missing')
+    }
+
+    console.log('sending verification email', userId, email)
+    await resend.emails.send({
+      from: 'noreply@myapp.com',
+      to: [email],
+      subject: 'Verify your email',
+      html: buildEmailTemplate(token),
+    })
+    // Returning normally ACKs; throwing anything else triggers a retry.
+  },
+  { connection, concurrency: 10 },
+)
+```
+
+```java title="EmailTaskHandler.java / Java 17+ + Spring Data Redis Streams"
+// Java has no single dominant task queue, so this is the mechanism itself:
+// a Redis Stream with a consumer group, which is exactly what Asynq builds
+// on. Section 6 of this chapter describes the XADD/XREADGROUP/XACK cycle
+// you are about to see in code.
+public record EmailPayload(String userId, String email, String token) {}
+
+@Component
+public class EmailTaskHandler
+        implements StreamListener<String, MapRecord<String, String, String>> {
+
+    static final String STREAM = "tasks:email";
+    static final String GROUP = "email-workers";
+    static final String DLQ = "tasks:email:dead";
+
+    private final StringRedisTemplate redis;
+    private final ObjectMapper json;
+    private final EmailService emailSvc; // injected dependency
+
+    EmailTaskHandler(StringRedisTemplate redis, ObjectMapper json, EmailService emailSvc) {
+        this.redis = redis;
+        this.json = json;
+        this.emailSvc = emailSvc;
+    }
+
+    @Override
+    public void onMessage(MapRecord<String, String, String> record) {
+        EmailPayload p;
+
+        // 1. Deserialize JSON -> Java record
+        try {
+            p = json.readValue(record.getValue().get("payload"), EmailPayload.class);
+        } catch (JsonProcessingException e) {
+            // Non-retryable: this payload will never parse. ACK it so it
+            // stops being redelivered, and park it in the dead letter stream.
+            redis.opsForStream().add(DLQ, record.getValue());
+            redis.opsForStream().acknowledge(STREAM, GROUP, record.getId());
+            return;
+        }
+
+        // 2. Execute: call email provider API
+        try {
+            log.info("sending verification email user_id={} email={}", p.userId(), p.email());
+            emailSvc.sendVerification(p.email(), p.token());
+        } catch (RuntimeException e) {
+            // Retryable: deliberately do NOT acknowledge. The message stays
+            // in the group's pending list and another worker reclaims it
+            // via XAUTOCLAIM once the idle timeout passes.
+            log.warn("send failed; leaving unacked for redelivery", e);
+            return;
+        }
+
+        // 3. XACK -> the task is done and leaves the pending list
+        redis.opsForStream().acknowledge(STREAM, GROUP, record.getId());
+    }
+}
+```
+
+### The producer: enqueue from your API handler
+
+This half runs inside the **HTTP request**, and the only thing that matters about it is that it returns in microseconds. Every version below hands a JSON payload to Redis and immediately moves on to sending the response.
+
+Go Python JavaScript TypeScript Java
+
+enqueue and return 201 without waiting for the email
+
+```go title="main.go / Go + Asynq, producer half"
+redisOpt := asynq.RedisClientOpt{Addr: "localhost:6379"}
+
+client := asynq.NewClient(redisOpt)
+defer client.Close()
+
+task, _ := tasks.NewSendVerificationEmailTask(
+    "usr_01J2K", "alice@example.com", "eyJhbGci...",
+)
+
+// Enqueue, returns immediately
+info, _ := client.Enqueue(task)
+// info.ID, info.Queue, info.State can be used for monitoring
+```
+
+```python title="signup.py / Python + Celery + FastAPI"
+# signup.py, Producer side (inside your API handler)
+from fastapi import FastAPI
+from tasks import send_verification_email
+
+app = FastAPI()
+
+@app.post("/signup")
+async def signup(body: SignupRequest):
+    # 1. Validate, hash password, save user to DB
+    user = await create_user(body)
+    token = generate_verification_token(user.id)
+
+    # 2. Enqueue, returns instantly, does NOT wait for email
+    send_verification_email.delay(
+        user_id=user.id,
+        email=user.email,
+        token=token
+    )
+
+    # 3. Return 201 immediately
+    return {"message": "Account created. Check your email."}, 201
+```
+
+```js title="signup.js / Node 20+ + BullMQ + Express"
+// signup.js, Producer side (inside your API handler)
+import { Queue } from 'bullmq'
+
+// Same queue name the worker listens on
+const emailQueue = new Queue('email', { connection: { host: 'localhost', port: 6379 } })
+
+app.post('/signup', async (req, res) => {
+  // 1. Validate, hash password, save user to DB
+  const user = await createUser(req.body)
+  const token = generateVerificationToken(user.id)
+
+  // 2. Enqueue, returns instantly, does NOT wait for email
+  await emailQueue.add(
+    'send_verification',
+    { userId: user.id, email: user.email, token },
+    { attempts: 5, backoff: { type: 'exponential', delay: 60_000 } },
+  )
+
+  // 3. Return 201 immediately
+  res.status(201).json({ message: 'Account created. Check your email.' })
+})
+```
+
+```ts title="signup.ts / TypeScript 5+ + BullMQ + Express"
+import { Queue } from 'bullmq'
+import type { Request, Response } from 'express'
+import type { EmailJob } from './worker'
+
+// The SAME EmailJob the worker imports. `add` now refuses a payload the
+// worker cannot read, which is the entire point of importing it here.
+const emailQueue = new Queue<EmailJob>('email', {
+  connection: { host: 'localhost', port: 6379 },
+})
+
+export async function signup(req: Request, res: Response): Promise<void> {
+  // 1. Validate, hash password, save user to DB
+  const user = await createUser(req.body)
+  const token = generateVerificationToken(user.id)
+
+  // 2. Enqueue, returns instantly, does NOT wait for email
+  await emailQueue.add(
+    'send_verification',
+    { userId: user.id, email: user.email, token },
+    {
+      attempts: 5,
+      backoff: { type: 'exponential', delay: 60_000 }, // 60s, 120s, 240s...
+      removeOnComplete: 1_000, // keep the last 1k, not every job forever
+    },
+  )
+
+  // 3. Return 201 immediately
+  res.status(201).json({ message: 'Account created. Check your email.' })
+}
+```
+
+```java title="SignupController.java / Java 17+ + Spring Data Redis Streams"
+@Service
+class EmailTaskProducer {
+    private final StringRedisTemplate redis;
+    private final ObjectMapper json;
+
+    EmailTaskProducer(StringRedisTemplate redis, ObjectMapper json) {
+        this.redis = redis;
+        this.json = json;
+    }
+
+    String enqueue(EmailPayload payload) throws JsonProcessingException {
+        // XADD tasks:email * payload <json>, returns immediately
+        RecordId id = redis.opsForStream().add(StreamRecords.newRecord()
+            .in(EmailTaskHandler.STREAM)
+            .ofMap(Map.of("payload", json.writeValueAsString(payload))));
+        return id.getValue(); // the task id, usable for monitoring
+    }
+}
+
+@RestController
+class SignupController {
+
+    @PostMapping("/signup")
+    @ResponseStatus(HttpStatus.CREATED) // 3. Return 201 immediately
+    Map<String, String> signup(@RequestBody SignupRequest body) throws JsonProcessingException {
+        // 1. Validate, hash password, save user to DB
+        User user = createUser(body);
+        String token = generateVerificationToken(user.id());
+
+        // 2. Enqueue, returns instantly, does NOT wait for email
+        producer.enqueue(new EmailPayload(user.id(), user.email(), token));
+
+        return Map.of("message", "Account created. Check your email.");
+    }
+}
+```
+
+### Running the worker: concurrency and priority queues
+
+The worker is a **separate process** from your API, and that separation is the point: you scale it independently, restart it independently, and a slow email never occupies a web thread. Two knobs matter, how many tasks run at once, and which queue gets drained first when work piles up.
+
+Go Python JavaScript TypeScript Java
+
+the long-running process that drains the queue
+
+```go title="main.go / Go + Asynq, worker half"
+srv := asynq.NewServer(redisOpt, asynq.Config{
+    Concurrency: 10, // 10 concurrent workers
+    Queues: map[string]int{
+        "email":    6, // higher priority
+        "default":  3,
+        "low":      1,
+    },
+})
+
+mux := asynq.NewServeMux()
+mux.HandleFunc(tasks.TypeSendVerificationEmail,
+    handlers.EmailHandler{}.HandleSendVerificationEmail)
+
+srv.Run(mux) // blocks; this process IS the worker
+```
+
+```python title="worker / Python + Celery CLI"
+# Celery's worker is a command, not code you write. The same tasks.py is
+# imported by both your API (to enqueue) and this process (to execute).
+#
+#   celery -A tasks worker \
+#       --concurrency=10 \
+#       --queues=email,default,low \
+#       --loglevel=info
+#
+# --concurrency defaults to the CPU count, which is the wrong default for
+# IO-bound work like sending email. See chapter 20.
+
+# Priority is expressed by ROUTING tasks to named queues:
+app.conf.task_routes = {
+    "tasks.send_verification_email": {"queue": "email"},
+    "tasks.generate_monthly_report": {"queue": "low"},
+}
+
+# Then run one worker per priority class, and give the important queue
+# more processes rather than trusting a single worker to interleave fairly:
+#   celery -A tasks worker --queues=email   --concurrency=6
+#   celery -A tasks worker --queues=default --concurrency=3
+#   celery -A tasks worker --queues=low     --concurrency=1
+```
+
+```js title="worker.js / Node 20+ + BullMQ, entry point"
+// This file is its own process: `node worker.js`, never imported by the API.
+import { Worker } from 'bullmq'
+
+const connection = { host: 'localhost', port: 6379 }
+
+// concurrency is how many jobs this ONE process runs at a time. Node is
+// single-threaded, so this is only a win for IO-bound work; for CPU-bound
+// tasks use several processes (or a Sandboxed Processor). See chapter 20.
+new Worker('email', emailProcessor, { connection, concurrency: 10 })
+new Worker('default', defaultProcessor, { connection, concurrency: 3 })
+new Worker('low', lowProcessor, { connection, concurrency: 1 })
+
+// Graceful shutdown: stop accepting new jobs, let in-flight ones finish.
+// Without this, a deploy kills jobs mid-send and they are redelivered,
+// which is exactly why handlers must be idempotent. See chapter 16.
+process.on('SIGTERM', async () => {
+  await Promise.all([emailWorker.close(), defaultWorker.close(), lowWorker.close()])
+  process.exit(0)
+})
+```
+
+```ts title="worker.ts / TypeScript 5+ + BullMQ, entry point"
+import { Worker } from 'bullmq'
+import type { EmailJob } from './types'
+
+const connection = { host: 'localhost', port: 6379 }
+
+// BullMQ has no cross-queue priority setting: a Worker drains exactly one
+// queue. Priority is therefore a RESOURCE decision, you give the queue
+// that matters more concurrency, and run it in more replicas.
+const workers = [
+  new Worker<EmailJob>('email', emailProcessor, { connection, concurrency: 10 }),
+  new Worker('default', defaultProcessor, { connection, concurrency: 3 }),
+  new Worker('low', lowProcessor, { connection, concurrency: 1 }),
+]
+
+process.on('SIGTERM', async () => {
+  // close() waits for in-flight jobs; a hard kill would let them be
+  // redelivered, which only a genuinely idempotent handler survives.
+  await Promise.all(workers.map((w) => w.close()))
+  process.exit(0)
+})
+```
+
+```java title="WorkerConfig.java / Java 17+ + Spring Data Redis Streams"
+@Configuration
+public class WorkerConfig {
+
+    @Bean
+    StreamMessageListenerContainer<String, MapRecord<String, String, String>> emailWorker(
+            RedisConnectionFactory cf, EmailTaskHandler handler) {
+
+        var options = StreamMessageListenerContainer
+            .StreamMessageListenerContainerOptions.builder()
+            .pollTimeout(Duration.ofSeconds(2))
+            // The thread pool IS the concurrency knob: 10 tasks at a time.
+            .executor(Executors.newFixedThreadPool(10))
+            .build();
+
+        var container = StreamMessageListenerContainer.create(cf, options);
+
+        // Reading as a CONSUMER GROUP is what makes this a work queue
+        // rather than a broadcast: each message goes to exactly ONE
+        // consumer, and anything unacked can be reclaimed by another.
+        container.receive(
+            Consumer.from(EmailTaskHandler.GROUP, "worker-" + UUID.randomUUID()),
+            StreamOffset.create(EmailTaskHandler.STREAM, ReadOffset.lastConsumed()),
+            handler);
+
+        container.start();
+        return container;
+    }
+}
+
+// Priority: one container per queue, sized by importance, exactly as the
+// Go version weights its queues 6 / 3 / 1.
+//
+// Higher-level options exist if you would rather not hold the stream
+// yourself: JobRunr (annotation-driven, SQL/Mongo-backed), Spring Batch
+// for chunked bulk jobs, or Spring Cloud AWS for @SqsListener.
+```
+
+### Recurring (cron-style) tasks
+
+Some work is not triggered by a user at all: a weekly report, a nightly cleanup. Every queue ships a **scheduler**, a small separate process that enqueues tasks on a cron expression. It does not run them; it only produces them, and your ordinary workers pick them up.
+
+<Callout type="info" title="Run exactly one scheduler">
+Workers scale horizontally; schedulers do not. Run two scheduler replicas and every recurring task is enqueued twice. Keep it at one replica, or use a scheduler that takes a lock (Asynq's `PeriodicTaskManager`, Celery Beat with a shared store, BullMQ's repeatable jobs, which are deduplicated by Redis itself).
+</Callout>
+
+Go Python JavaScript TypeScript Java
+
+weekly report every Sunday at midnight; cleanup on the 1st of each month
+
+```go title="scheduler/main.go / Go + Asynq Scheduler"
 // scheduler/main.go, Cron-style recurring tasks
 package main
 
@@ -687,12 +1030,9 @@ func main() {
         log.Fatal(err)
     }
 }
-Go
 ```
 
-### Python: Celery Beat (Recurring Tasks)
-
-```text
+```python title="celery_config.py / Python + Celery Beat"
 # celery_config.py, Celery Beat schedule
 from celery.schedules import crontab
 
@@ -708,7 +1048,90 @@ CELERYBEAT_SCHEDULE = {
         'schedule': crontab(hour=3, minute=0, day_of_month='1'),
     },
 }
-Python / Celery Beat
+
+# Beat is its own process, separate from the workers:
+#   celery -A tasks beat --loglevel=info
+```
+
+```js title="scheduler.js / Node 20+ + BullMQ repeatable jobs"
+// BullMQ has no separate scheduler process: a repeatable job is just a
+// job with a cron pattern, and Redis deduplicates it by repeat key. That
+// makes running this file on every replica harmless.
+import { Queue } from 'bullmq'
+
+const reports = new Queue('reports', { connection })
+
+// Send weekly report every Sunday at midnight
+await reports.add('weekly', null, {
+  repeat: { pattern: '0 0 * * 0', tz: 'UTC' },
+  jobId: 'report:weekly', // stable id, re-adding it does not duplicate
+})
+
+// Cleanup orphan sessions every 1st of the month
+await reports.add('sessionCleanup', null, {
+  repeat: { pattern: '0 3 1 * *', tz: 'UTC' },
+  jobId: 'sessions:cleanup',
+})
+
+// Always set `tz`. A schedule that silently follows the server's local
+// time will shift by an hour twice a year, and the bug surfaces months
+// later as "the Sunday report went out on Saturday night".
+```
+
+```ts title="scheduler.ts / TypeScript 5+ + BullMQ repeatable jobs"
+import { Queue } from 'bullmq'
+
+interface Schedule {
+  name: string
+  pattern: string
+  jobId: string
+}
+
+// Listing the schedules as DATA rather than as a sequence of calls is what
+// makes them reviewable: one array to read in a PR, and one loop that
+// cannot forget the tz or the stable jobId on the entry someone adds next.
+const SCHEDULES: Schedule[] = [
+  { name: 'weekly', pattern: '0 0 * * 0', jobId: 'report:weekly' },
+  { name: 'sessionCleanup', pattern: '0 3 1 * *', jobId: 'sessions:cleanup' },
+]
+
+const reports = new Queue('reports', { connection })
+
+for (const { name, pattern, jobId } of SCHEDULES) {
+  await reports.add(name, null, { repeat: { pattern, tz: 'UTC' }, jobId })
+}
+```
+
+```java title="SchedulerConfig.java / Java 17+ + Spring @Scheduled"
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+
+    private final EmailTaskProducer producer;
+
+    SchedulerConfig(EmailTaskProducer producer) {
+        this.producer = producer;
+    }
+
+    // Send weekly report every Sunday at midnight.
+    // Note the six fields: Spring's cron starts with SECONDS, so the
+    // five-field Unix expression "0 0 * * 0" becomes "0 0 0 * * SUN".
+    @Scheduled(cron = "0 0 0 * * SUN", zone = "UTC")
+    void enqueueWeeklyReport() {
+        // The scheduler only ENQUEUES; an ordinary worker runs it.
+        producer.enqueue("report:weekly", null);
+    }
+
+    // Cleanup orphan sessions every 1st of the month
+    @Scheduled(cron = "0 0 3 1 * *", zone = "UTC")
+    void enqueueSessionCleanup() {
+        producer.enqueue("sessions:cleanup", null);
+    }
+}
+
+// @Scheduled fires on EVERY instance, so with two replicas every task is
+// enqueued twice. In a multi-replica deployment take a lock first, with
+// ShedLock (@SchedulerLock) or Quartz in clustered mode.
 ```
 
 12
@@ -743,7 +1166,45 @@ If the queue grows faster than workers consume, you have backpressure. Solutions
 
 Assign a unique key to each task when it is created (usually a UUID or a hash of the input). Before doing any work, the handler checks if that key has already been successfully processed. If yes, it returns early without re-doing the work.
 
-```python
+Go Python JavaScript TypeScript Java
+
+claim the key first; only the winner does the work
+
+```go title="email_handler.go / Go + go-redis + Asynq"
+// Go, Idempotency key pattern with Redis
+func (h *EmailHandler) HandleSendVerificationEmail(
+    ctx context.Context, t *asynq.Task,
+) error {
+    var p tasks.EmailPayload
+    if err := json.Unmarshal(t.Payload(), &p); err != nil {
+        return fmt.Errorf("json.Unmarshal: %w: %w", err, asynq.SkipRetry)
+    }
+
+    // Build idempotency key from task inputs
+    key := fmt.Sprintf("idem:verify_email:%s:%s", p.UserID, p.Token)
+
+    // SetNX = SET only if Not eXists, with a 1-hour expiry.
+    // acquired is true only for the FIRST execution.
+    acquired, err := h.rdb.SetNX(ctx, key, "done", time.Hour).Result()
+    if err != nil {
+        // Redis is unreachable, so we cannot tell a duplicate from a
+        // first run. Retry rather than risk a second email.
+        return fmt.Errorf("idempotency check: %w", err)
+    }
+    if !acquired {
+        return nil // Already processed, ACK cleanly (idempotent return)
+    }
+
+    // First time, actually send the email
+    if err := h.emailSvc.SendVerification(ctx, p.Email, p.Token); err != nil {
+        h.rdb.Del(ctx, key) // release the key so the next retry can try again
+        return fmt.Errorf("emailSvc.SendVerification: %w", err)
+    }
+    return nil
+}
+```
+
+```python title="tasks.py / Python + redis-py + Celery"
 # Python, Idempotency key pattern with Redis
 import redis
 import hashlib
@@ -769,7 +1230,92 @@ def send_verification_email(self, user_id: str, email: str, token: str):
         # Delete the key so next retry can attempt again
         r.delete(key)
         raise self.retry(exc=exc, countdown=60 * 2 ** self.request.retries)
-Python
+```
+
+```js title="worker.js / Node 20+ + node-redis + BullMQ"
+// Node, Idempotency key pattern with Redis
+new Worker('email', async (job) => {
+  const { userId, email, token } = job.data
+
+  // Build idempotency key from task inputs
+  const key = `idem:verify_email:${userId}:${token}`
+
+  // NX = set only if Not eXists; EX = expire after 1 hour.
+  // set() returns 'OK' on the FIRST execution, and null if already done.
+  const acquired = await redis.set(key, 'done', { NX: true, EX: 3600 })
+  if (acquired === null) {
+    return { status: 'already_sent' } // skip silently (idempotent return)
+  }
+
+  // First time, actually send the email
+  try {
+    await sendEmailViaProvider(email, token)
+  } catch (err) {
+    await redis.del(key) // delete the key so the next retry can attempt again
+    throw err // throwing is what schedules the retry
+  }
+}, { connection })
+```
+
+```ts title="worker.ts / TypeScript 5+ + node-redis + BullMQ"
+// Worth naming the gap in this shape before you rely on it: if the process
+// dies AFTER the SET NX but BEFORE the send lands, the key is held and the
+// retry skips the email entirely. The one-hour TTL is what bounds the
+// damage. The stronger fix is the one chapter 07 uses for payments, store
+// the RESULT under the key instead of a bare "done" marker, so a duplicate
+// can return the original outcome rather than guessing.
+async function handler(job: Job<EmailJob>): Promise<{ status: string }> {
+  const { userId, email, token } = job.data
+  const key = `idem:verify_email:${userId}:${token}`
+
+  const acquired: string | null = await redis.set(key, 'pending', { NX: true, EX: 3600 })
+  if (acquired === null) {
+    return { status: 'already_sent' } // skip silently (idempotent return)
+  }
+
+  try {
+    const messageId = await sendEmailViaProvider(email, token)
+    // Overwrite the claim with the real result, still under the same TTL.
+    await redis.set(key, JSON.stringify({ messageId }), { EX: 3600 })
+    return { status: 'sent' }
+  } catch (err) {
+    await redis.del(key) // let the next retry attempt again
+    throw err
+  }
+}
+```
+
+```java title="EmailTaskHandler.java / Java 17+ + Spring Data Redis"
+// Java, Idempotency key pattern with Redis
+@Override
+public void onMessage(MapRecord<String, String, String> record) {
+    EmailPayload p = parse(record); // as in the consumer example above
+
+    // Build idempotency key from task inputs
+    String key = "idem:verify_email:%s:%s".formatted(p.userId(), p.token());
+
+    // setIfAbsent IS SET NX, and the Duration is the EX. It returns TRUE
+    // only for the FIRST execution, FALSE if an earlier attempt got there.
+    Boolean acquired = redis.opsForValue()
+        .setIfAbsent(key, "done", Duration.ofHours(1));
+
+    if (!Boolean.TRUE.equals(acquired)) {
+        // Already processed, ACK cleanly (idempotent return). Note the
+        // Boolean.TRUE.equals: `acquired` is a nullable Boolean, and
+        // unboxing a null here would throw instead of skipping.
+        redis.opsForStream().acknowledge(STREAM, GROUP, record.getId());
+        return;
+    }
+
+    // First time, actually send the email
+    try {
+        emailSvc.sendVerification(p.email(), p.token());
+        redis.opsForStream().acknowledge(STREAM, GROUP, record.getId());
+    } catch (RuntimeException e) {
+        redis.delete(key); // release the key so the redelivery can try again
+        log.warn("send failed; leaving unacked for redelivery", e);
+    }
+}
 ```
 
 ### Pattern 2: Database Transaction + Upsert
@@ -789,14 +1335,17 @@ VALUES ($1, true, NOW())
 ON CONFLICT (user_id) DO UPDATE
   SET email_verified = EXCLUDED.email_verified,
       updated_at = EXCLUDED.updated_at;
-SQL
 ```
 
 ### Pattern 3: Full Transaction Rollback (for complex tasks)
 
 For multi-step tasks (like account deletion) that touch many tables, wrap the entire task in a database transaction. If any step fails, the transaction rolls back completely, leaving the database in a clean state for the next retry attempt.
 
-```go
+Go Python JavaScript TypeScript Java
+
+every write commits together, or none of them do
+
+```go title="account_handler.go / Go + Asynq"
 // Go, Idempotent multi-step task with full transaction rollback
 func (h *AccountHandler) HandleDeleteAccount(ctx context.Context, t *asynq.Task) error {
     var p DeleteAccountPayload
@@ -824,14 +1373,128 @@ func (h *AccountHandler) HandleDeleteAccount(ctx context.Context, t *asynq.Task)
         return nil // all steps succeeded -> commit -> ACK
     })
 }
-Go
+```
+
+```python title="tasks.py / Python + SQLAlchemy + Celery"
+# Python, Idempotent multi-step task with full transaction rollback
+@app.task(bind=True, max_retries=5)
+def delete_account(self, user_id: str):
+    # Check if already deleted (idempotency guard)
+    if not db.user_exists(user_id):
+        return  # already deleted on a previous attempt, ACK cleanly
+
+    try:
+        # session.begin() COMMITs on a clean exit and ROLLBACKs on any
+        # exception, so the whole multi-step delete is one unit.
+        with Session(engine) as session, session.begin():
+            delete_user_projects(session, user_id)
+            delete_user_sessions(session, user_id)
+            delete_user_assets(session, user_id)
+            delete_user_account(session, user_id)
+    except SQLAlchemyError as exc:
+        # Nothing was written, so the retry starts from a clean database
+        raise self.retry(exc=exc, countdown=60 * 2 ** self.request.retries)
+```
+
+```js title="worker.js / Node 20+ + node-postgres + BullMQ"
+// Node, Idempotent multi-step task with full transaction rollback
+new Worker('account', async (job) => {
+  const { userId } = job.data
+
+  // Check if already deleted (idempotency guard)
+  if (!(await db.userExists(userId))) {
+    return // already deleted on a previous attempt, ACK cleanly
+  }
+
+  // Wrap all DB writes in a single transaction, on ONE connection
+  const tx = await pool.connect()
+  try {
+    await tx.query('BEGIN')
+    await deleteUserProjects(tx, userId)
+    await deleteUserSessions(tx, userId)
+    await deleteUserAssets(tx, userId)
+    await deleteUserAccount(tx, userId)
+    await tx.query('COMMIT') // all steps succeeded -> ACK
+  } catch (err) {
+    await tx.query('ROLLBACK') // full rollback; task retried from scratch
+    throw err
+  } finally {
+    tx.release()
+  }
+}, { connection })
+```
+
+```ts title="worker.ts / TypeScript 5+ + node-postgres + BullMQ"
+// The type on this array is doing real work: every step takes a `tx`, so
+// a function that does NOT take one cannot be added to the list. That
+// matters more than it looks, because a rollback only undoes DATABASE
+// writes. Slip an email send or an S3 delete in here and the retry does
+// it a second time with nothing to roll back.
+const steps: Array<(tx: PoolClient, userId: string) => Promise<void>> = [
+  deleteUserProjects,
+  deleteUserSessions,
+  deleteUserAssets,
+  deleteUserAccount,
+]
+
+async function handleDeleteAccount(job: Job<{ userId: string }>): Promise<void> {
+  const { userId } = job.data
+
+  // Check if already deleted (idempotency guard)
+  if (!(await db.userExists(userId))) {
+    return // already deleted on a previous attempt, ACK cleanly
+  }
+
+  // withTransaction (chapter 08) commits on return, rolls back on throw
+  await withTransaction(pool, async (tx) => {
+    for (const step of steps) {
+      await step(tx, userId) // any throw -> full rollback -> retry from scratch
+    }
+  })
+}
+```
+
+```java title="AccountTaskHandler.java / Java 17+ + Spring"
+// Java, Idempotent multi-step task with full transaction rollback
+@Service
+public class AccountTaskHandler {
+
+    // @Transactional wraps the WHOLE method: every write below commits
+    // together, or a thrown exception rolls all of them back and the
+    // redelivered task starts against a clean database.
+    @Transactional
+    public void handleDeleteAccount(DeleteAccountPayload p) {
+        // Check if already deleted (idempotency guard)
+        if (!db.userExists(p.userId())) {
+            return; // already deleted on a previous attempt, ACK cleanly
+        }
+
+        db.deleteUserProjects(p.userId());
+        db.deleteUserSessions(p.userId());
+        db.deleteUserAssets(p.userId());
+        db.deleteUserAccount(p.userId());
+        // returning commits; any RuntimeException triggers a full rollback
+    }
+}
+
+// Both chapter 08 traps are genuinely dangerous here, not academic:
+//  1. The proxy. Calling handleDeleteAccount() from another method of
+//     THIS class runs it with NO transaction at all, so a failure halfway
+//     down leaves an account that is half deleted and cannot be retried.
+//  2. Checked exceptions do not roll back by default, which commits the
+//     partial delete. Be explicit:
+//     @Transactional(rollbackFor = Exception.class)
 ```
 
 ### Pattern 4: Exactly-Once via SQS FIFO Deduplication
 
 SQS FIFO queues accept a `MessageDeduplicationId`. Any message with the same ID sent within a 5-minute window is silently dropped. This is broker-level idempotency, the handler never even sees the duplicate.
 
-```text
+Go Python JavaScript TypeScript Java
+
+the broker drops the duplicate; your handler never sees it
+
+```go title="producer.go / Go + AWS SDK v2"
 // Go, SQS FIFO with content-based deduplication
 client.SendMessage(ctx, &sqs.SendMessageInput{
     QueueUrl:               aws.String("https://sqs.us-east-1.amazonaws.com/123/orders.fifo"),
@@ -840,7 +1503,69 @@ client.SendMessage(ctx, &sqs.SendMessageInput{
     MessageDeduplicationId: aws.String(orderID),           // unique per business event
 })
 // Sending the same orderID twice within 5 min -> second is silently dropped by SQS
-Go / AWS SQS FIFO
+```
+
+```python title="producer.py / Python + boto3"
+# Python, SQS FIFO with deduplication
+import boto3
+
+sqs = boto3.client("sqs", region_name="us-east-1")
+
+sqs.send_message(
+    QueueUrl="https://sqs.us-east-1.amazonaws.com/123/orders.fifo",
+    MessageBody=payload,
+    MessageGroupId="order-processing",   # ordering group
+    MessageDeduplicationId=order_id,     # unique per business event
+)
+# Sending the same order_id twice within 5 min -> second is silently dropped
+```
+
+```js title="producer.js / Node 20+ + @aws-sdk/client-sqs"
+// Node, SQS FIFO with deduplication
+import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs'
+
+const sqs = new SQSClient({ region: 'us-east-1' })
+
+await sqs.send(new SendMessageCommand({
+  QueueUrl: 'https://sqs.us-east-1.amazonaws.com/123/orders.fifo',
+  MessageBody: payload,
+  MessageGroupId: 'order-processing', // ordering group
+  MessageDeduplicationId: orderId,    // unique per business event
+}))
+// Sending the same orderId twice within 5 min -> second is silently dropped
+```
+
+```ts title="producer.ts / TypeScript 5+ + @aws-sdk/client-sqs"
+import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs'
+
+const sqs = new SQSClient({ region: 'us-east-1' })
+
+// The dedup id has to come from the BUSINESS event, never from the
+// attempt: a randomUUID() per send makes every retry look like a new
+// message and deduplicates nothing. Typing it as the order id and not as
+// a bare `string` is a cheap way to keep that honest.
+export async function enqueueOrder(orderId: OrderId, payload: string): Promise<void> {
+  await sqs.send(new SendMessageCommand({
+    QueueUrl: process.env.ORDERS_QUEUE_URL,
+    MessageBody: payload,
+    MessageGroupId: 'order-processing', // ordering group
+    MessageDeduplicationId: orderId,    // unique per business event
+  }))
+}
+// Sending the same orderId twice within 5 min -> second is silently dropped
+```
+
+```java title="Producer.java / Java 17+ + AWS SDK v2"
+// Java, SQS FIFO with deduplication
+SqsClient sqs = SqsClient.builder().region(Region.US_EAST_1).build();
+
+sqs.sendMessage(SendMessageRequest.builder()
+    .queueUrl("https://sqs.us-east-1.amazonaws.com/123/orders.fifo")
+    .messageBody(payload)
+    .messageGroupId("order-processing") // ordering group
+    .messageDeduplicationId(orderId)    // unique per business event
+    .build());
+// Sending the same orderId twice within 5 min -> second is silently dropped
 ```
 
 Rule of thumb
@@ -863,9 +1588,77 @@ Sliding Window
 
 Count requests in the last N seconds using a sliding time window. More accurate than token bucket for strict rate compliance. Redis implementation: sorted sets with timestamps as scores.
 
-### Token Bucket in Python (Redis-backed)
+### Token Bucket (Redis-backed)
 
-```python
+The Lua script below is identical in all five tabs, and that is the whole trick: Redis executes a script atomically, so the read-refill-write cycle cannot interleave with another worker's. Do the arithmetic in your own language instead, and you have rebuilt the lost-update race from chapter 08, at a hundred workers a second.
+
+Go Python JavaScript TypeScript Java
+
+one atomic script; five ways of calling it
+
+```go title="rate/token_bucket.go / Go + go-redis"
+// rate/token_bucket.go, Redis token bucket implementation
+package rate
+
+// Loaded once; go-redis sends EVALSHA and only falls back to the full
+// body if Redis has not seen the script before.
+var tokenBucketScript = redis.NewScript(`
+local key = KEYS[1]
+local capacity = tonumber(ARGV[1])
+local refill_rate = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
+
+local bucket = redis.call('HMGET', key, 'tokens', 'last_refill')
+local tokens = tonumber(bucket[1]) or capacity
+local last_refill = tonumber(bucket[2]) or now
+
+-- Refill tokens based on time elapsed
+local elapsed = now - last_refill
+tokens = math.min(capacity, tokens + elapsed * refill_rate)
+
+if tokens >= 1 then
+    tokens = tokens - 1
+    redis.call('HMSET', key, 'tokens', tokens, 'last_refill', now)
+    redis.call('EXPIRE', key, 3600)
+    return 1
+end
+return 0
+`)
+
+type TokenBucketLimiter struct {
+    rdb        *redis.Client
+    key        string  // e.g. "ratelimit:resend_emails"
+    capacity   int     // max burst (e.g. 100)
+    refillRate float64 // tokens per second (e.g. 10)
+}
+
+// Acquire reports whether a token was taken; false means rate limited.
+func (l *TokenBucketLimiter) Acquire(ctx context.Context) (bool, error) {
+    now := float64(time.Now().UnixMicro()) / 1e6
+    got, err := tokenBucketScript.Run(ctx, l.rdb,
+        []string{l.key}, l.capacity, l.refillRate, now).Int()
+    if err != nil {
+        return false, err
+    }
+    return got == 1, nil
+}
+
+// Usage inside an Asynq handler
+func (h *EmailHandler) HandleSendEmail(ctx context.Context, t *asynq.Task) error {
+    ok, err := h.limiter.Acquire(ctx)
+    if err != nil {
+        return err
+    }
+    if !ok {
+        // Rate limited. Any non-nil error re-queues the task with backoff,
+        // so this costs a retry slot but never drops the work.
+        return errors.New("rate limited, retrying")
+    }
+    return h.doSendEmail(ctx, t)
+}
+```
+
+```python title="rate_limiter.py / Python + redis-py + Celery"
 # rate_limiter.py, Redis token bucket implementation
 import time
 import redis
@@ -917,12 +1710,144 @@ def send_email_task(self, email, token):
         # Rate limited, retry after a short delay (not counted as failure)
         raise self.retry(countdown=1, max_retries=60)  # retry every 1s up to 60 times
     _do_send_email(email, token)
-Python
 ```
 
-### Sliding Window Rate Limiter in Go
+```js title="rateLimiter.js / Node 20+ + node-redis + BullMQ"
+// rateLimiter.js, Redis token bucket implementation
+const TOKEN_BUCKET_LUA = `
+local key = KEYS[1]
+local capacity = tonumber(ARGV[1])
+local refill_rate = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
 
-```go
+local bucket = redis.call('HMGET', key, 'tokens', 'last_refill')
+local tokens = tonumber(bucket[1]) or capacity
+local last_refill = tonumber(bucket[2]) or now
+
+-- Refill tokens based on time elapsed
+local elapsed = now - last_refill
+tokens = math.min(capacity, tokens + elapsed * refill_rate)
+
+if tokens >= 1 then
+    tokens = tokens - 1
+    redis.call('HMSET', key, 'tokens', tokens, 'last_refill', now)
+    redis.call('EXPIRE', key, 3600)
+    return 1
+end
+return 0
+`
+
+export class TokenBucketRateLimiter {
+  constructor(redis, key, capacity, refillRate) {
+    this.redis = redis
+    this.key = key                // e.g. "ratelimit:resend_emails"
+    this.capacity = capacity      // max burst (e.g. 100)
+    this.refillRate = refillRate  // tokens per second (e.g. 10)
+  }
+
+  // Returns true if a token was acquired, false if rate limited.
+  async acquire() {
+    const now = Date.now() / 1000
+    const result = await this.redis.eval(TOKEN_BUCKET_LUA, {
+      keys: [this.key],
+      arguments: [String(this.capacity), String(this.refillRate), String(now)],
+    })
+    return result === 1
+  }
+}
+
+// Usage inside a BullMQ worker
+const limiter = new TokenBucketRateLimiter(redis, 'ratelimit:resend', 100, 10)
+
+new Worker('email', async (job) => {
+  if (!(await limiter.acquire())) {
+    throw new Error('rate limited') // throwing re-queues with backoff
+  }
+  await doSendEmail(job.data)
+}, { connection })
+
+// BullMQ also ships a built-in limiter that PAUSES the worker instead of
+// failing jobs, which is usually the better shape, no retry budget burned:
+//   new Worker('email', fn, { connection, limiter: { max: 10, duration: 1000 } })
+// Its scope is the queue, though, so a second unrelated queue hitting the
+// same provider is not counted. A shared bucket like the one above is.
+```
+
+```ts title="rateLimiter.ts / TypeScript 5+ + node-redis"
+import type { RedisClientType } from 'redis'
+
+// Two details decide whether this holds up in production:
+//
+//  1. `now` comes from the WORKER's clock, and ten pods do not agree to
+//     the millisecond. If the refill has to be exact across machines,
+//     take the time from Redis (`TIME`) and pass that instead.
+//  2. It must stay ONE eval. Reading the bucket, computing the refill in
+//     TypeScript, and writing it back is the chapter 08 lost-update race
+//     wearing a different hat, and it leaks tokens under real load.
+export class TokenBucketRateLimiter {
+  constructor(
+    private readonly redis: RedisClientType,
+    private readonly key: string,        // e.g. "ratelimit:resend_emails"
+    private readonly capacity: number,   // max burst (e.g. 100)
+    private readonly refillRate: number, // tokens per second (e.g. 10)
+  ) {}
+
+  /** Returns true if a token was acquired, false if rate limited. */
+  async acquire(): Promise<boolean> {
+    const now = Date.now() / 1000
+    const result = (await this.redis.eval(TOKEN_BUCKET_LUA, {
+      keys: [this.key],
+      arguments: [String(this.capacity), String(this.refillRate), String(now)],
+    })) as number
+    return result === 1
+  }
+}
+```
+
+```java title="TokenBucketRateLimiter.java / Java 17+ + Spring Data Redis"
+@Component
+public class TokenBucketRateLimiter {
+
+    // Same Lua script, kept in src/main/resources/token_bucket.lua.
+    // Spring caches its SHA and calls EVALSHA, so the body is not resent.
+    private static final RedisScript<Long> SCRIPT = RedisScript.of(
+        new ClassPathResource("token_bucket.lua"), Long.class);
+
+    private final StringRedisTemplate redis;
+
+    TokenBucketRateLimiter(StringRedisTemplate redis) {
+        this.redis = redis;
+    }
+
+    /** Returns true if a token was acquired, false if rate limited. */
+    public boolean acquire(String key, int capacity, double refillRate) {
+        double now = System.currentTimeMillis() / 1000.0;
+        Long result = redis.execute(SCRIPT, List.of(key),
+            String.valueOf(capacity), String.valueOf(refillRate), String.valueOf(now));
+        return Long.valueOf(1L).equals(result);
+    }
+}
+
+// Usage inside the stream handler
+if (!limiter.acquire("ratelimit:resend", 100, 10)) {
+    // Rate limited: deliberately do NOT ack. The message stays pending
+    // and gets reclaimed later, which is this broker's version of a retry.
+    return;
+}
+doSendEmail(payload);
+
+// Resilience4j ships a RateLimiter too, but its scope is ONE JVM. That is
+// the wrong scope here: ten worker pods each allowing 100/s is 1000/s
+// arriving at the provider. A shared limit has to live in Redis.
+```
+
+### Sliding Window Rate Limiter
+
+Go Python JavaScript TypeScript Java
+
+a sorted set of timestamps; count what falls inside the window
+
+```go title="rate/sliding_window.go / Go + go-redis"
 // rate/sliding_window.go, Redis sorted-set sliding window
 package rate
 
@@ -968,7 +1893,148 @@ func (h *EmailHandler) HandleSendEmail(ctx context.Context, t *asynq.Task) error
     }
     return h.doSendEmail(ctx, t)
 }
-Go
+```
+
+```python title="sliding_window.py / Python + redis-py + Celery"
+# sliding_window.py, Redis sorted-set sliding window
+import time
+
+
+class SlidingWindowLimiter:
+    def __init__(self, redis_client, key: str, limit: int, window_seconds: float):
+        self.r = redis_client
+        self.key = key
+        self.limit = limit            # max requests
+        self.window = window_seconds  # time window
+
+    def allow(self) -> bool:
+        now_us = int(time.time() * 1_000_000)
+        window_start = now_us - int(self.window * 1_000_000)
+
+        pipe = self.r.pipeline()
+        # Remove entries older than the window
+        pipe.zremrangebyscore(self.key, 0, window_start)
+        # Count entries in current window
+        pipe.zcard(self.key)
+        # Add current request timestamp as a member
+        pipe.zadd(self.key, {str(now_us): now_us})
+        pipe.expire(self.key, int(self.window * 2))
+        _, count, _, _ = pipe.execute()
+
+        return count < self.limit
+
+
+# Usage inside a Celery task
+@app.task(bind=True, max_retries=60)
+def send_email_task(self, email, token):
+    if not limiter.allow():
+        raise self.retry(countdown=1)  # rate limited, not a failure
+    _do_send_email(email, token)
+```
+
+```js title="slidingWindow.js / Node 20+ + node-redis + BullMQ"
+// slidingWindow.js, Redis sorted-set sliding window
+export class SlidingWindowLimiter {
+  constructor(redis, key, limit, windowMs) {
+    this.redis = redis
+    this.key = key
+    this.limit = limit        // max requests
+    this.windowMs = windowMs  // time window
+  }
+
+  async allow() {
+    const now = Date.now() * 1000 // microseconds, used as the score
+    const windowStart = now - this.windowMs * 1000
+
+    const [, count] = await this.redis
+      .multi()
+      // Remove entries older than the window
+      .zRemRangeByScore(this.key, 0, windowStart)
+      // Count entries in current window
+      .zCard(this.key)
+      // Add current request timestamp as a member
+      .zAdd(this.key, { score: now, value: String(now) })
+      .expire(this.key, Math.ceil((this.windowMs * 2) / 1000))
+      .exec()
+
+    return count < this.limit
+  }
+}
+```
+
+```ts title="slidingWindow.ts / TypeScript 5+ + node-redis"
+// Two behaviours of this algorithm that are easy to miss, and both are in
+// the Go version above too:
+//
+//  1. The count is read BEFORE this request's own entry is added, so the
+//     effective ceiling is limit + 1 in flight. Either compare against
+//     `limit - 1`, or move the ZADD ahead of the ZCARD. Choose one on
+//     purpose, because drifting between the two across services is how a
+//     documented "100/s" quietly becomes 101/s at the provider.
+//  2. An entry is added even when the request is REJECTED. A caller that
+//     keeps hammering a limited endpoint therefore keeps its own window
+//     permanently full and never recovers. If that is not what you want,
+//     only ZADD on the allowed path.
+export class SlidingWindowLimiter {
+  constructor(
+    private readonly redis: RedisClientType,
+    private readonly key: string,
+    private readonly limit: number,    // max requests
+    private readonly windowMs: number, // time window
+  ) {}
+
+  async allow(): Promise<boolean> {
+    const now = Date.now() * 1000
+    const windowStart = now - this.windowMs * 1000
+
+    const results = await this.redis
+      .multi()
+      .zRemRangeByScore(this.key, 0, windowStart)
+      .zCard(this.key)
+      .expire(this.key, Math.ceil((this.windowMs * 2) / 1000))
+      .exec()
+
+    const count = results[1] as number
+    if (count >= this.limit) {
+      return false // rejected, and deliberately NOT recorded
+    }
+
+    await this.redis.zAdd(this.key, { score: now, value: String(now) })
+    return true
+  }
+}
+```
+
+```java title="SlidingWindowLimiter.java / Java 17+ + Spring Data Redis"
+@Component
+public class SlidingWindowLimiter {
+    private final StringRedisTemplate redis;
+
+    SlidingWindowLimiter(StringRedisTemplate redis) {
+        this.redis = redis;
+    }
+
+    public boolean allow(String key, int limit, Duration window) {
+        long nowMicros = Instant.now().toEpochMilli() * 1_000L;
+        long windowStart = nowMicros - window.toMillis() * 1_000L;
+
+        // Remove entries older than the window
+        redis.opsForZSet().removeRangeByScore(key, 0, windowStart);
+        // Count entries in current window
+        Long count = redis.opsForZSet().zCard(key);
+        // Add current request timestamp as a member
+        redis.opsForZSet().add(key, String.valueOf(nowMicros), nowMicros);
+        redis.expire(key, window.multipliedBy(2));
+
+        return count != null && count < limit;
+    }
+}
+
+// Written plainly like this it is four round trips AND four separate
+// moments: another worker can slip an entry in between the ZCARD and the
+// ZADD. Pipeline it with executePipelined, or move the whole sequence
+// into a Lua script the way the token bucket does. At low rates you will
+// never notice; at the rates that make you reach for a limiter, you will.
 ```
 
 <Callout type="info" title="Asynq Built-In Rate Limiting">
@@ -989,9 +2055,76 @@ Background tasks fail silently unless you've built observability into the system
 
 ### Step 1: Instrument Your Workers
 
-Every worker exposes a `/metrics` HTTP endpoint in Prometheus text format. The `prometheus_client` library (Python) or `prometheus/client_golang` (Go) handles this automatically.
+Every worker exposes a `/metrics` HTTP endpoint in Prometheus text format, and every ecosystem has a client that does the formatting for you: `prometheus_client` in Python, `prometheus/client_golang` in Go, `prom-client` in Node, and Micrometer (via Spring Boot Actuator) in Java. Four metrics carry almost all of the value, a **counter** of tasks by status, a **histogram** of durations, a **gauge** of queue depth, and a **counter** of retries.
 
-```python
+Go Python JavaScript TypeScript Java
+
+four metrics, and one wrapper that fills three of them
+
+```go title="metrics/metrics.go / Go + client_golang"
+// Go, Full metrics instrumentation for a worker process
+package metrics
+
+// -- Define metrics ---------------------------------------------
+var (
+    TaskTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+        Name: "worker_tasks_total",
+        Help: "Total tasks processed",
+    }, []string{"task_name", "status"}) // labels: status=success|failure
+
+    TaskDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+        Name:    "worker_task_duration_seconds",
+        Help:    "Task processing duration",
+        Buckets: []float64{.01, .05, .1, .5, 1, 5, 10, 30}, // bucket boundaries
+    }, []string{"task_name"})
+
+    QueueDepth = promauto.NewGaugeVec(prometheus.GaugeOpts{
+        Name: "worker_queue_depth",
+        Help: "Current tasks waiting in queue",
+    }, []string{"queue_name"})
+
+    RetryCount = promauto.NewCounterVec(prometheus.CounterOpts{
+        Name: "worker_task_retries_total",
+        Help: "Number of task retries",
+    }, []string{"task_name"})
+)
+
+// -- Middleware to wrap any handler with metrics -----------------
+// asynq.MiddlewareFunc is the same shape as the Python decorator: it
+// wraps the handler instead of being called from inside it, so no task
+// body has to remember to record anything.
+func Track(taskName string) asynq.MiddlewareFunc {
+    return func(next asynq.Handler) asynq.Handler {
+        return asynq.HandlerFunc(func(ctx context.Context, t *asynq.Task) error {
+            start := time.Now()
+            // deferred, so the duration is recorded on BOTH paths
+            defer func() {
+                TaskDuration.WithLabelValues(taskName).
+                    Observe(time.Since(start).Seconds())
+            }()
+
+            if n, _ := asynq.GetRetryCount(ctx); n > 0 {
+                RetryCount.WithLabelValues(taskName).Inc()
+            }
+
+            if err := next.ProcessTask(ctx, t); err != nil {
+                TaskTotal.WithLabelValues(taskName, "failure").Inc()
+                return err
+            }
+            TaskTotal.WithLabelValues(taskName, "success").Inc()
+            return nil
+        })
+    }
+}
+
+// Start /metrics server on port 9090 (Prometheus scrapes this)
+func Serve() {
+    http.Handle("/metrics", promhttp.Handler())
+    go http.ListenAndServe(":9090", nil)
+}
+```
+
+```python title="metrics.py / Python + prometheus_client + Celery"
 # Python, Full metrics instrumentation for a worker process
 from prometheus_client import (
     Counter, Histogram, Gauge, start_http_server
@@ -1051,7 +2184,159 @@ def send_verification_email(self, user_id, email, token):
     if self.request.retries > 0:
         RETRY_COUNT.labels(task_name="send_verification_email").inc()
     _do_send_email(email, token)
-Python
+```
+
+```js title="metrics.js / Node 20+ + prom-client + BullMQ"
+// Node, Full metrics instrumentation for a worker process
+import { Counter, Histogram, Gauge, register } from 'prom-client'
+import express from 'express'
+
+// -- Define metrics ---------------------------------------------
+export const TASK_TOTAL = new Counter({
+  name: 'worker_tasks_total',
+  help: 'Total tasks processed',
+  labelNames: ['task_name', 'status'], // status=success|failure
+})
+
+export const TASK_DURATION = new Histogram({
+  name: 'worker_task_duration_seconds',
+  help: 'Task processing duration',
+  labelNames: ['task_name'],
+  buckets: [0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30], // histogram bucket boundaries
+})
+
+export const QUEUE_DEPTH = new Gauge({
+  name: 'worker_queue_depth',
+  help: 'Current tasks waiting in queue',
+  labelNames: ['queue_name'],
+})
+
+export const RETRY_COUNT = new Counter({
+  name: 'worker_task_retries_total',
+  help: 'Number of task retries',
+  labelNames: ['task_name'],
+})
+
+// -- Wrapper to give any processor metrics ----------------------
+export function trackMetrics(taskName, processor) {
+  return async (job) => {
+    const end = TASK_DURATION.startTimer({ task_name: taskName })
+    if (job.attemptsMade > 0) {
+      RETRY_COUNT.inc({ task_name: taskName })
+    }
+    try {
+      const result = await processor(job)
+      TASK_TOTAL.inc({ task_name: taskName, status: 'success' })
+      return result
+    } catch (err) {
+      TASK_TOTAL.inc({ task_name: taskName, status: 'failure' })
+      throw err
+    } finally {
+      end() // records the duration on both the success and failure paths
+    }
+  }
+}
+
+// Start /metrics server on port 9090 (Prometheus scrapes this)
+const metricsApp = express()
+metricsApp.get('/metrics', async (_req, res) => {
+  res.set('Content-Type', register.contentType)
+  res.end(await register.metrics())
+})
+metricsApp.listen(9090)
+
+// -- Apply to task ----------------------------------------------
+new Worker('email', trackMetrics('send_verification_email', emailProcessor), { connection })
+
+// QUEUE_DEPTH is the one no wrapper can fill in: it describes the QUEUE,
+// not any single job, so it has to be polled on a timer.
+setInterval(async () => {
+  QUEUE_DEPTH.set({ queue_name: 'email' }, await emailQueue.getWaitingCount())
+}, 15_000)
+```
+
+```ts title="metrics.ts / TypeScript 5+ + prom-client + BullMQ"
+import type { Job } from 'bullmq'
+
+// The Prometheus rule worth burning in before you add a single label:
+// labels must be LOW cardinality. `task_name` has maybe twenty values,
+// which is fine. A user id or a job id creates a new time series per
+// user, and that is how people take their own Prometheus down. Pinning
+// the label type instead of accepting an open Record is a cheap guard.
+type TaskLabels = { task_name: string; status?: 'success' | 'failure' }
+
+// The generics keep the wrapper invisible at the call site: what goes in
+// is a processor, what comes out is the SAME processor type.
+export function trackMetrics<T, R>(
+  taskName: string,
+  processor: (job: Job<T>) => Promise<R>,
+): (job: Job<T>) => Promise<R> {
+  return async (job: Job<T>): Promise<R> => {
+    const labels: TaskLabels = { task_name: taskName }
+    const end = TASK_DURATION.startTimer(labels)
+
+    if (job.attemptsMade > 0) {
+      RETRY_COUNT.inc(labels)
+    }
+
+    try {
+      const result = await processor(job)
+      TASK_TOTAL.inc({ ...labels, status: 'success' })
+      return result
+    } catch (err) {
+      TASK_TOTAL.inc({ ...labels, status: 'failure' })
+      throw err
+    } finally {
+      end() // records the duration on both paths
+    }
+  }
+}
+```
+
+```java title="WorkerMetrics.java / Java 17+ + Micrometer + Actuator"
+// Java, Full metrics instrumentation for a worker process.
+// spring-boot-starter-actuator + micrometer-registry-prometheus give you
+// the /actuator/prometheus endpoint for free; you define the metrics.
+@Component
+public class WorkerMetrics {
+    private final MeterRegistry registry;
+
+    WorkerMetrics(MeterRegistry registry, EmailQueue queue) {
+        this.registry = registry;
+
+        // A Gauge is POLLED, not incremented: Micrometer calls this
+        // supplier at scrape time, which is the right shape for a value
+        // that describes the queue rather than any one task.
+        Gauge.builder("worker_queue_depth", queue::waitingCount)
+             .tag("queue_name", "email")
+             .register(registry);
+    }
+
+    /** Wraps any task body with the counter + histogram, like the decorator. */
+    public <T> T track(String taskName, Supplier<T> body) {
+        Timer.Sample sample = Timer.start(registry);
+        try {
+            T result = body.get();
+            registry.counter("worker_tasks_total",
+                "task_name", taskName, "status", "success").increment();
+            return result;
+        } catch (RuntimeException e) {
+            registry.counter("worker_tasks_total",
+                "task_name", taskName, "status", "failure").increment();
+            throw e;
+        } finally {
+            // stop() in the finally block, so a failed task is timed too
+            sample.stop(Timer.builder("worker_task_duration_seconds")
+                .tag("task_name", taskName)
+                .publishPercentileHistogram() // the histogram buckets
+                .register(registry));
+        }
+    }
+}
+
+// application.yml, expose the scrape endpoint on the metrics port:
+//   management.endpoints.web.exposure.include: prometheus
+//   management.server.port: 9090
 ```
 
 ### Step 2: Prometheus Configuration
@@ -1085,7 +2370,6 @@ scrape_configs:
   - job_name: "api_server"
     static_configs:
       - targets: ["api:8080"]
-YAML
 ```
 
 ### Step 3: Alert Rules
@@ -1125,7 +2409,6 @@ groups:
           severity: critical
         annotations:
           summary: "Worker {{ $labels.instance }} is down"
-YAML
 ```
 
 ### Step 4: Key Grafana Panels to Build
@@ -1208,7 +2491,7 @@ Imagine a payment workflow: charge card -> reserve inventory -> send confirmatio
 
 ### Task Queue vs Workflow Engine
 
-| Capability                     | Task Queue (Celery/Asynq)                    | Temporal                                      |
+| Capability                     | Task Queue (Celery/Asynq/BullMQ)             | Temporal                                      |
 | ------------------------------ | -------------------------------------------- | --------------------------------------------- |
 | **Individual task retries**    | Built-in                                     | Built-in                                      |
 | **Multi-step workflows**       | Manual, you chain tasks yourself             | Native, workflows are first-class             |
@@ -1246,11 +2529,15 @@ Event History
 
 Temporal persists every single event in a workflow's lifetime. This is how it achieves crash recovery, on restart it replays the history to restore state.
 
-### Example: Video Processing Workflow in Go
+### Example: Video Processing Workflow
 
-The same video upload chain task we saw in Section 9, now implemented with Temporal:
+The same video upload chain task we saw in Section 9, now implemented with Temporal. Temporal ships first-party SDKs for Go, Java, Python and TypeScript, and the shape below is deliberately the same in all of them: each step reads like an ordinary function call, and each one is recorded in the workflow history so a crash resumes at the first step that had not finished.
 
-```go
+Go Python JavaScript TypeScript Java
+
+five steps, two of them in parallel, resumable at any point
+
+```go title="workflows/video_processing.go / Go + Temporal SDK"
 // workflows/video_processing.go
 package workflows
 
@@ -1298,12 +2585,208 @@ func VideoProcessingWorkflow(ctx workflow.Context, videoID string) error {
     // Step 5: Notify user their video is ready
     return workflow.ExecuteActivity(ctx, activities.NotifyUserVideoReady, videoID).Get(ctx, nil)
 }
-Go / Temporal
 ```
 
-### Example: Human-in-the-Loop with Signals (Go)
+```python title="workflows/video_processing.py / Python + temporalio"
+# workflows/video_processing.py
+import asyncio
+from datetime import timedelta
 
-```go
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from activities import (
+        encode_video, generate_thumbnails, generate_transcription,
+        process_thumbnail_images, notify_user_video_ready,
+    )
+
+
+@workflow.defn
+class VideoProcessingWorkflow:
+    """Orchestrates the entire pipeline.
+
+    Temporal persists every step, crash at any point = resume here.
+    """
+
+    @workflow.run
+    async def run(self, video_id: str) -> None:
+        # Activity options, each step has its own retry policy
+        opts = dict(
+            start_to_close_timeout=timedelta(minutes=10),
+            retry_policy=RetryPolicy(
+                maximum_attempts=3,
+                initial_interval=timedelta(minutes=1),
+                backoff_coefficient=2.0,
+            ),
+        )
+
+        # Step 1: Encode video to multiple resolutions.
+        # If the worker crashes here, the workflow resumes from step 1.
+        encoded_path = await workflow.execute_activity(encode_video, video_id, **opts)
+
+        # Step 2 + 3: Thumbnail generation AND transcription in parallel.
+        # gather() is what makes them concurrent; awaiting each in turn
+        # would quietly serialise them and double the wall-clock time.
+        await asyncio.gather(
+            workflow.execute_activity(generate_thumbnails, encoded_path, **opts),
+            workflow.execute_activity(generate_transcription, encoded_path, **opts),
+        )
+
+        # Step 4: Process thumbnails (depends on step 2 completing)
+        await workflow.execute_activity(process_thumbnail_images, video_id, **opts)
+
+        # Step 5: Notify user their video is ready
+        await workflow.execute_activity(notify_user_video_ready, video_id, **opts)
+```
+
+```js title="workflows/videoProcessing.js / Node 20+ + @temporalio/workflow"
+// workflows/videoProcessing.js
+import { proxyActivities } from '@temporalio/workflow'
+
+// Activity options, each step has its own retry policy
+const {
+  encodeVideo,
+  generateThumbnails,
+  generateTranscription,
+  processThumbnailImages,
+  notifyUserVideoReady,
+} = proxyActivities({
+  startToCloseTimeout: '10 minutes',
+  retry: { maximumAttempts: 3, initialInterval: '1 minute', backoffCoefficient: 2 },
+})
+
+// videoProcessingWorkflow, orchestrates the entire pipeline.
+// Temporal persists every step, crash at any point = resume here.
+export async function videoProcessingWorkflow(videoId) {
+  // Step 1: Encode video to multiple resolutions.
+  // If the worker crashes here, the workflow resumes from step 1.
+  const encodedPath = await encodeVideo(videoId)
+
+  // Step 2 + 3: Thumbnail generation AND transcription in parallel
+  await Promise.all([
+    generateThumbnails(encodedPath),
+    generateTranscription(encodedPath),
+  ])
+
+  // Step 4: Process thumbnails (depends on step 2 completing)
+  await processThumbnailImages(videoId)
+
+  // Step 5: Notify user their video is ready
+  await notifyUserVideoReady(videoId)
+}
+
+// Temporal ships ONE SDK for Node, written in TypeScript. It runs from
+// plain JavaScript exactly as above; what you give up is the compile-time
+// check on activity names and arguments shown in the TypeScript tab.
+//
+// The hard rule in any language: workflow code must be deterministic. No
+// Date.now(), no Math.random(), no direct fetch. Replay has to produce
+// the same decisions, so anything non-deterministic belongs in an
+// activity (or in workflow.now() / workflow.random()).
+```
+
+```ts title="workflows/videoProcessing.ts / TypeScript 5+ + @temporalio/workflow"
+import { proxyActivities } from '@temporalio/workflow'
+import type * as activities from '../activities'
+
+// `typeof activities` is the TypeScript SDK's best trick: the signatures
+// come from the REAL implementations, so renaming an activity or changing
+// its arguments breaks the build rather than breaking a replay in
+// production, weeks later, on a workflow that started before the deploy.
+const {
+  encodeVideo,
+  generateThumbnails,
+  generateTranscription,
+  processThumbnailImages,
+  notifyUserVideoReady,
+} = proxyActivities<typeof activities>({
+  // Activity options, each step has its own retry policy
+  startToCloseTimeout: '10 minutes',
+  retry: { maximumAttempts: 3, initialInterval: '1 minute', backoffCoefficient: 2 },
+})
+
+// videoProcessingWorkflow, orchestrates the entire pipeline.
+// Temporal persists every step, crash at any point = resume here.
+export async function videoProcessingWorkflow(videoId: string): Promise<void> {
+  // Step 1: Encode video to multiple resolutions.
+  // If the worker crashes here, the workflow resumes from step 1.
+  const encodedPath: string = await encodeVideo(videoId)
+
+  // Step 2 + 3: Thumbnail generation AND transcription in parallel
+  await Promise.all([
+    generateThumbnails(encodedPath),
+    generateTranscription(encodedPath),
+  ])
+
+  // Step 4: Process thumbnails (depends on step 2 completing)
+  await processThumbnailImages(videoId)
+
+  // Step 5: Notify user their video is ready
+  await notifyUserVideoReady(videoId)
+}
+```
+
+```java title="VideoProcessingWorkflow.java / Java 17+ + Temporal SDK"
+// workflows/VideoProcessingWorkflow.java
+@WorkflowInterface
+public interface VideoProcessingWorkflow {
+    @WorkflowMethod
+    void process(String videoId);
+}
+
+public class VideoProcessingWorkflowImpl implements VideoProcessingWorkflow {
+
+    // Activity options, each step has its own retry policy
+    private static final ActivityOptions OPTIONS = ActivityOptions.newBuilder()
+        .setStartToCloseTimeout(Duration.ofMinutes(10))
+        .setRetryOptions(RetryOptions.newBuilder()
+            .setMaximumAttempts(3)
+            .setInitialInterval(Duration.ofMinutes(1))
+            .setBackoffCoefficient(2.0)
+            .build())
+        .build();
+
+    // The stub looks like an ordinary object and is not one: every call
+    // on it is recorded in the workflow history.
+    private final VideoActivities activities =
+        Workflow.newActivityStub(VideoActivities.class, OPTIONS);
+
+    @Override
+    public void process(String videoId) {
+        // Step 1: Encode video to multiple resolutions.
+        // If the worker crashes here, the workflow resumes from step 1.
+        String encodedPath = activities.encodeVideo(videoId);
+
+        // Step 2 + 3: Thumbnail generation AND transcription in parallel.
+        // Async.procedure STARTS the activity and returns immediately;
+        // calling activities.generateThumbnails() directly would block.
+        Promise<Void> thumbs =
+            Async.procedure(activities::generateThumbnails, encodedPath);
+        Promise<Void> transcript =
+            Async.procedure(activities::generateTranscription, encodedPath);
+
+        // Wait for both, if either fails, the workflow fails (after its retries)
+        Promise.allOf(thumbs, transcript).get();
+
+        // Step 4: Process thumbnails (depends on step 2 completing)
+        activities.processThumbnailImages(videoId);
+
+        // Step 5: Notify user their video is ready
+        activities.notifyUserVideoReady(videoId);
+    }
+}
+```
+
+### Example: Human-in-the-Loop with Signals
+
+A **signal** is an external event delivered into a running workflow. It is what lets a workflow sit and wait for a person, for a day or for a month, without holding a thread, a connection, or a row lock anywhere.
+
+Go Python JavaScript TypeScript Java
+
+wait 24 hours for a human, and compensate if nobody answers
+
+```go title="workflows/payment_approval.go / Go + Temporal SDK"
 // workflows/payment_approval.go, Wait for human signal
 func PaymentApprovalWorkflow(ctx workflow.Context, orderID string) error {
     // Register a signal channel, external events can wake this workflow
@@ -1338,11 +2821,173 @@ func ApprovePaymentHandler(c *gin.Context) {
     temporalClient.SignalWorkflow(c, orderID, "", "approval-signal", true)
     c.JSON(200, gin.H{"status": "approved"})
 }
-Go / Temporal
+```
+
+```python title="workflows/payment_approval.py / Python + temporalio"
+# workflows/payment_approval.py, Wait for human signal
+@workflow.defn
+class PaymentApprovalWorkflow:
+    def __init__(self) -> None:
+        self._approved: bool | None = None
+
+    # A signal is just a method: external events can wake this workflow
+    @workflow.signal
+    def approve(self, approved: bool) -> None:
+        self._approved = approved
+
+    @workflow.run
+    async def run(self, order_id: str) -> None:
+        # Step 1: Process payment details
+        await workflow.execute_activity(prepare_payment, order_id, **opts)
+
+        # Step 2: Wait up to 24 hours for human approval.
+        # Temporal pauses here, no CPU/memory consumed while waiting.
+        try:
+            await workflow.wait_condition(
+                lambda: self._approved is not None,
+                timeout=timedelta(hours=24),
+            )
+        except asyncio.TimeoutError:
+            self._approved = False  # timeout, auto-reject
+
+        if not self._approved:
+            # Saga: compensate previous steps
+            await workflow.execute_activity(refund_payment, order_id, **opts)
+            return
+
+        await workflow.execute_activity(finalize_payment, order_id, **opts)
+
+
+# To send the approval signal from your API handler:
+handle = client.get_workflow_handle(order_id)
+await handle.signal(PaymentApprovalWorkflow.approve, True)
+```
+
+```js title="workflows/paymentApproval.js / Node 20+ + @temporalio/workflow"
+// workflows/paymentApproval.js, Wait for human signal
+import { condition, defineSignal, setHandler } from '@temporalio/workflow'
+
+// Register a signal, external events can wake this workflow
+export const approvalSignal = defineSignal('approval-signal')
+
+export async function paymentApprovalWorkflow(orderId) {
+  let approved
+
+  setHandler(approvalSignal, (value) => {
+    approved = value
+  })
+
+  // Step 1: Process payment details
+  await preparePayment(orderId)
+
+  // Step 2: Wait up to 24 hours for human approval.
+  // Temporal pauses here, no CPU/memory consumed while waiting.
+  const signalled = await condition(() => approved !== undefined, '24 hours')
+  if (!signalled) {
+    approved = false // timeout, auto-reject
+  }
+
+  if (!approved) {
+    // Saga: compensate previous steps
+    await refundPayment(orderId)
+    return
+  }
+  await finalizePayment(orderId)
+}
+
+// To send the approval signal from your API handler:
+//   const handle = client.workflow.getHandle(orderId)
+//   await handle.signal(approvalSignal, true)
+```
+
+```ts title="workflows/paymentApproval.ts / TypeScript 5+ + @temporalio/workflow"
+import { condition, defineSignal, setHandler } from '@temporalio/workflow'
+
+// defineSignal's type parameter is the signal's ARGUMENT list, and it is
+// shared by the workflow and the API handler that sends it. Sending a
+// string where the workflow expects a boolean is then a compile error
+// rather than a workflow that wakes up holding the wrong value.
+export const approvalSignal = defineSignal<[boolean]>('approval-signal')
+
+export async function paymentApprovalWorkflow(orderId: string): Promise<void> {
+  // `undefined` is a third state here and it matters: it distinguishes
+  // "nobody has answered yet" from "somebody rejected it", which is
+  // exactly the distinction the timeout branch below turns into a refund.
+  let approved: boolean | undefined
+
+  setHandler(approvalSignal, (value: boolean) => {
+    approved = value
+  })
+
+  // Step 1: Process payment details
+  await preparePayment(orderId)
+
+  // Step 2: Wait up to 24 hours for human approval.
+  // Temporal pauses here, no CPU/memory consumed while waiting.
+  const signalled = await condition(() => approved !== undefined, '24 hours')
+  if (!signalled) {
+    approved = false // timeout, auto-reject
+  }
+
+  if (!approved) {
+    // Saga: compensate previous steps
+    await refundPayment(orderId)
+    return
+  }
+  await finalizePayment(orderId)
+}
+```
+
+```java title="PaymentApprovalWorkflow.java / Java 17+ + Temporal SDK"
+// workflows/PaymentApprovalWorkflow.java, Wait for human signal
+@WorkflowInterface
+public interface PaymentApprovalWorkflow {
+    @WorkflowMethod
+    void run(String orderId);
+
+    // Register a signal, external events can wake this workflow
+    @SignalMethod
+    void approve(boolean approved);
+}
+
+public class PaymentApprovalWorkflowImpl implements PaymentApprovalWorkflow {
+    // Boolean, not boolean: null is the "nobody has answered yet" state.
+    private Boolean approved = null;
+
+    @Override
+    public void approve(boolean value) {
+        this.approved = value;
+    }
+
+    @Override
+    public void run(String orderId) {
+        // Step 1: Process payment details
+        activities.preparePayment(orderId);
+
+        // Step 2: Wait up to 24 hours for human approval.
+        // Temporal pauses here, no CPU/memory consumed while waiting.
+        boolean signalled = Workflow.await(Duration.ofHours(24), () -> approved != null);
+        if (!signalled) {
+            approved = false; // timeout, auto-reject
+        }
+
+        if (!approved) {
+            // Saga: compensate previous steps
+            activities.refundPayment(orderId);
+            return;
+        }
+        activities.finalizePayment(orderId);
+    }
+}
+
+// To send the approval signal from your API handler:
+//   PaymentApprovalWorkflow wf =
+//       client.newWorkflowStub(PaymentApprovalWorkflow.class, orderId);
+//   wf.approve(true); // returns as soon as Temporal accepts the signal
 ```
 
 <Callout type="info" title="When to use Temporal vs a regular task queue">
-Use a regular task queue (Celery/Asynq/BullMQ) for **simple, independent tasks**: emails, notifications, image processing. Reach for Temporal when you have **multi-step business workflows** with compensation logic, long waiting periods, human approvals, or when you need full execution history for compliance/debugging. Temporal has higher operational overhead (you run a Temporal server cluster), so don't use it unless you need it.
+Use a regular task queue (Celery / Asynq / BullMQ / Redis Streams) for **simple, independent tasks**: emails, notifications, image processing. Reach for Temporal when you have **multi-step business workflows** with compensation logic, long waiting periods, human approvals, or when you need full execution history for compliance/debugging. Temporal has higher operational overhead (you run a Temporal server cluster), so don't use it unless you need it.
 </Callout>
 
-Backend from First Principles / Chapter 10 / Task Queues. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 10 / Task Queues. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+ (Spring Boot).


### PR DESCRIPTION
I have left Chapter 4 and 5 for now since I saw a PR for someone adding Javascript language, I will add Typescript and Java after that one is merged

Every language tabbed code block in chapters 06 through 10 now offers five languages, in the order Go, Python, JavaScript, TypeScript, Java. JavaScript and TypeScript use Express/BullMQ/node-redis/node-postgres
Java uses Spring Boot with JdbcClient, Spring Data Redis and Micrometer.

Chapter 06 (Controllers, Services & Middlewares)
- Added the three languages to all 8 Go/Python groups handler binding, the validate and transform step, the service and repository layers, middleware shape, CORS + auth, reading identity from context, and request ids.
- Java middleware is a servlet Filter, and the request context is request attributes plus MDC, which keeps the chapter's point intact.

Chapter 07 (API Design)
- Add the three languages to all 5 Go/Python groups and the PATCHED concurrency guard, idempotency keys, the list endpoint, full resource wiring, and the error envelope.
- The complete worked task API at the end stays Go only.

Chapter 08 (Databases)
- Add the three languages to both SQL/Go/Python groups: parameterized queries and transactions. Both call out the language-specific trap (a template literal in JavaScript, @Transactional's proxy and checked exceptions in Java).

Chapter 09 (Caching)
- The four Code Examples sections were single language. Retitled them to drop "in Go" / "in Python" and turn each into one five-tab block, cache aside + write-through, rate limiting, wrapping a function in a cache, and session management.

Chapter 10 (Task Queues & Background Jobs)
- Split the parallel Python Celery + Redis and Go Asynq + Redis deep-dives into four concept based sections, each a five-tab block the consumer, the producer, running the worker, and recurring tasks. 
- JS/TS use BullMQ
-  Java uses Redis Streams consumer groups, which pays off the chapter's own Redis Streams section.
- Added the three languages to the idempotency patterns (keys, full transaction rollback, SQS FIFO dedup), both rate limiters, worker instrumentation, and both Temporal workflows.
- Droped the stray language names the HTML migration left inside code fences, where they rendered as a last line of code (a bare JSON, SQL, YAML and Go / AWS SDK v2).

Supporting changes
- List the new languages in each chapter's summary, callouts and footer, and fill in chapter 10's placeholder summary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded backend development chapters with JavaScript, TypeScript, and Java examples alongside existing Go and Python content.
  - Added multi-language examples for REST API design, databases, caching, task queues, middleware, transactions, authentication, and observability.
  - Updated code selectors, chapter summaries, headings, contextual notes, and runtime/version references to reflect broader language coverage.
  - Improved code-block titles and removed outdated standalone labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->